### PR TITLE
chore(deps): migrate ffmpeg/ffprobe from subprocess to go-astiav Cgo bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ lint-fix: ## Run golangci-lint and perform fixes.
 
 ##@ Build
 
+# Note: CGO is required. FFmpeg 8 development headers must be available via pkg-config.
+# Run 'nix develop' to enter the dev shell with all required dependencies.
+
 $(BIN_DIR)/watcher: $(GO_SOURCE_FILES)
 	@mkdir -p "$(BIN_DIR)"
 	go build -o "$@" ./cmd/watcher

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,6 +8,7 @@
 | Workflow orchestration | [Hatchet](https://hatchet.run) |
 | Database | PostgreSQL |
 | Filesystem watching | `fsnotify` |
+| Media processing | `github.com/asticode/go-astiav` (FFmpeg 8 Cgo bindings) |
 | Static analysis | `golangci-lint` |
 | Dev environment | Nix (flake.nix) |
 
@@ -37,18 +38,18 @@ Responsibilities:
 
 ### `pkg/ffmpeg`
 
-Wraps invocation of the `ffmpeg` command-line tool.
+Wraps `libavcodec`, `libavformat`, and related libraries via `github.com/asticode/go-astiav` for in-process media transcoding.
 
-- Accepts an arbitrary argument list and an optional working directory
-- Returns combined stdout/stderr output and exit code
-- Does not interpret output — callers are responsible for parsing
+- Exposes a builder API: `NewTranscode(in, out).VideoCodec(...).AudioCodec(...).Container(...).HardwareAccel(...).Build().Run(ctx)`
+- Hardware encoder availability is determined in-process via `astiav.FindEncoderByName` — no subprocess probe
+- No external binary required; CGO must be enabled and FFmpeg 8 shared libraries must be present at runtime
 
 ### `pkg/ffprobe`
 
-Wraps invocation of the `ffprobe` command-line tool for media file inspection.
+Wraps `libavformat` and `libavcodec` via `github.com/asticode/go-astiav` for in-process media file inspection.
 
-- Accepts a file path and returns structured metadata (codec, duration, streams, etc.)
-- Output is parsed from ffprobe's JSON mode
+- Accepts a file path and context; returns structured `MediaInfo` (container format, duration, overall bitrate, streams)
+- No external binary required; context cancellation is honoured via `astiav.IOInterrupter`
 
 ### `pkg/medialib`
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,11 @@
             pkgs.gnumake
             pkgs.docker
             pkgs.docker-compose
+            pkgs.pkg-config
+            pkgs.ffmpeg
+          ];
+          buildInputs = [
+            pkgs.ffmpeg.dev
           ];
           shellHook = ''
             if [ -f .env.hatchet ]; then

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/asticode/go-astiav v0.40.0 // indirect
+	github.com/asticode/go-astikit v0.42.0 // indirect
 	github.com/cockroachdb/errors v1.12.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/asticode/go-astiav v0.40.0 h1:7El8FyONtjPOmcmqR+zjjihG7ysum5RtTVIhIMrLFQM=
+github.com/asticode/go-astiav v0.40.0/go.mod h1:GI0pHw6K2/pl/o8upCtT49P/q4KCwhv/8nGLlCsZLdA=
+github.com/asticode/go-astikit v0.42.0 h1:pnir/2KLUSr0527Tv908iAH6EGYYrYta132vvjXsH5w=
+github.com/asticode/go-astikit v0.42.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=


### PR DESCRIPTION
## Summary

- Updates SPEC.md tech stack table and `pkg/ffmpeg`/`pkg/ffprobe` contracts to describe the in-process Cgo approach (no subprocess invocation)
- Adds `github.com/asticode/go-astiav v0.40.0` (FFmpeg 8 Cgo bindings) to `go.mod`
- Updates `flake.nix` devShell with `pkg-config`, `pkgs.ffmpeg` (runtime libs), and `pkgs.ffmpeg.dev` (headers) so `make build` works inside `nix develop`
- Adds a CGO requirement note to `Makefile`
- Updates issue #3 and #4 bodies to reference `go-astiav` instead of the subprocess libraries; removes binary-in-PATH acceptance criteria; posts explanatory comments

## Test plan

- [x] `make build` passes inside `nix develop` (CGO + FFmpeg 8 headers verified)
- [x] `make test` passes
- [x] `make lint` reports 0 issues
- [x] `go-astiav v0.40.0` present in `go.mod`; `ffmpeg-8.0.1` resolved by nix

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)