### PR TITLE
feat(medialib): Radarr and Sonarr client helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	golift.io/starr v1.3.1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/asticode/go-astiav v0.40.0
 	github.com/hatchet-dev/hatchet v0.79.43
 	github.com/stretchr/testify v1.11.1
+	golift.io/starr v1.3.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -76,7 +77,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golift.io/starr v1.3.1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golift.io/starr v1.3.1 h1:+Hv4abYcrom+7OZS96OV0r9HJrgdIcqYy/lMsXmUbLQ=
+golift.io/starr v1.3.1/go.mod h1:ZmfSxCqxOR2Uh+jbyde3jSPIfHgmFB/B0GmlbBZU74w=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 h1:JLQynH/LBHfCTSbDWl+py8C+Rg/k1OVH3xfcaiANuF0=

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -1,2 +1,37 @@
-// Package medialib provides higher-level abstractions over ffmpeg and ffprobe.
+// Package medialib provides higher-level abstractions for media library services.
 package medialib
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound is returned when a media item is not found in the library.
+var ErrNotFound = errors.New("not found in library")
+
+// Movie represents a movie entry in a movie library service.
+type Movie struct {
+	ID    int64
+	Title string
+	Year  int
+}
+
+// Episode represents an episode entry in a TV library service.
+type Episode struct {
+	ID            int64
+	SeriesTitle   string
+	SeasonNumber  int
+	EpisodeNumber int
+}
+
+// MovieLibrary provides operations for movie media items.
+type MovieLibrary interface {
+	GetMovieByFilePath(ctx context.Context, path string) (Movie, error)
+	RefreshMovie(ctx context.Context, id int64) error
+}
+
+// EpisodeLibrary provides operations for episode media items.
+type EpisodeLibrary interface {
+	GetEpisodeByFilePath(ctx context.Context, path string) (Episode, error)
+	RefreshSeries(ctx context.Context, seriesID int64) error
+}

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -11,6 +11,7 @@ var ErrNotFound = errors.New("not found in library")
 
 // Movie represents a movie entry in a movie library service.
 type Movie struct {
+	// ID is the internal database ID assigned by the backing movie library service.
 	ID    int64
 	Title string
 	Year  int
@@ -18,6 +19,7 @@ type Movie struct {
 
 // Episode represents an episode entry in a TV library service.
 type Episode struct {
+	// ID is the internal database ID assigned by the backing TV library service.
 	ID            int64
 	SeriesTitle   string
 	SeasonNumber  int

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -20,7 +20,10 @@ type Movie struct {
 // Episode represents an episode entry in a TV library service.
 type Episode struct {
 	// ID is the internal database ID assigned by the backing TV library service.
-	ID            int64
+	ID int64
+	// SeriesID is the internal database ID of the series this episode belongs to.
+	// Use this with EpisodeLibrary.RefreshSeries to trigger a library rescan.
+	SeriesID      int64
 	SeriesTitle   string
 	SeasonNumber  int
 	EpisodeNumber int

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -1,0 +1,81 @@
+// Package radarr provides a Radarr client implementing medialib.MovieLibrary.
+package radarr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golift.io/starr"
+	radarrlib "golift.io/starr/radarr"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+)
+
+// Compile-time assertion that *Client implements medialib.MovieLibrary.
+var _ medialib.MovieLibrary = (*Client)(nil)
+
+// Config holds the configuration for a Radarr client.
+type Config struct {
+	URL    string
+	APIKey string
+	// LocalPathPrefix and RemotePathPrefix enable optional path translation.
+	// When set, paths starting with LocalPathPrefix are rewritten to use
+	// RemotePathPrefix before being matched against Radarr's stored paths.
+	// This handles cases where the worker and Radarr use different mount points
+	// for the same storage.
+	LocalPathPrefix  string
+	RemotePathPrefix string
+}
+
+// Client is a Radarr client implementing medialib.MovieLibrary.
+type Client struct {
+	cfg    Config
+	radarr *radarrlib.Radarr
+}
+
+// New creates a new Radarr client.
+func New(cfg Config) *Client {
+	s := starr.New(cfg.APIKey, cfg.URL, 0)
+	return &Client{cfg: cfg, radarr: radarrlib.New(s)}
+}
+
+// GetMovieByFilePath returns the movie whose file matches path.
+// Returns medialib.ErrNotFound if no match is found.
+func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.Movie, error) {
+	if c.cfg.LocalPathPrefix != "" {
+		if after, ok := strings.CutPrefix(path, c.cfg.LocalPathPrefix); ok {
+			path = c.cfg.RemotePathPrefix + after
+		}
+	}
+
+	movies, err := c.radarr.GetMovieContext(ctx, &radarrlib.GetMovie{})
+	if err != nil {
+		return medialib.Movie{}, fmt.Errorf("list movies: %w", err)
+	}
+
+	for _, m := range movies {
+		if m.MovieFile != nil && m.MovieFile.Path == path {
+			return medialib.Movie{
+				ID:    m.ID,
+				Title: m.Title,
+				Year:  m.Year,
+			}, nil
+		}
+	}
+
+	return medialib.Movie{}, medialib.ErrNotFound
+}
+
+// RefreshMovie triggers a Radarr library rescan for the given movie ID.
+func (c *Client) RefreshMovie(ctx context.Context, id int64) error {
+	_, err := c.radarr.SendCommandContext(ctx, &radarrlib.CommandRequest{
+		Name:     "RefreshMovie",
+		MovieIDs: []int64{id},
+	})
+	if err != nil {
+		return fmt.Errorf("refresh movie %d: %w", id, err)
+	}
+
+	return nil
+}

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -4,6 +4,7 @@ package radarr
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -41,8 +42,9 @@ func New(cfg Config) *Client {
 	return &Client{cfg: cfg, radarr: radarrlib.New(s)}
 }
 
-// GetMovieByFilePath returns the movie whose file matches path.
-// Returns medialib.ErrNotFound if no match is found.
+// GetMovieByFilePath returns the movie identified by parsing the file path.
+// Uses Radarr's parse endpoint, so it works for pre-import files.
+// Returns medialib.ErrNotFound if no movie is identified.
 func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.Movie, error) {
 	if c.cfg.LocalPathPrefix != "" {
 		if after, ok := strings.CutPrefix(path, c.cfg.LocalPathPrefix); ok {
@@ -60,22 +62,38 @@ func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.
 		}
 	}
 
-	movies, err := c.radarr.GetMovieContext(ctx, &radarrlib.GetMovie{})
+	movie, err := c.parseFilePath(ctx, path)
 	if err != nil {
-		return medialib.Movie{}, fmt.Errorf("list movies: %w", err)
+		return medialib.Movie{}, fmt.Errorf("parse file path: %w", err)
 	}
 
-	for _, m := range movies {
-		if m.MovieFile != nil && m.MovieFile.Path == path {
-			return medialib.Movie{
-				ID:    m.ID,
-				Title: m.Title,
-				Year:  m.Year,
-			}, nil
-		}
+	if movie == nil {
+		return medialib.Movie{}, medialib.ErrNotFound
 	}
 
-	return medialib.Movie{}, medialib.ErrNotFound
+	return medialib.Movie{
+		ID:    movie.ID,
+		Title: movie.Title,
+		Year:  movie.Year,
+	}, nil
+}
+
+// parseFilePath calls Radarr's /api/v3/parse endpoint to identify a movie
+// from a file path. Returns nil if Radarr cannot identify the movie.
+func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Movie, error) {
+	var output struct {
+		Movie *radarrlib.Movie `json:"movie"`
+	}
+
+	q := make(url.Values)
+	q.Set("path", path)
+
+	req := starr.Request{URI: radarrlib.APIver + "/parse", Query: q}
+	if err := c.radarr.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(parse): %w", err)
+	}
+
+	return output.Movie, nil
 }
 
 // RefreshMovie triggers a Radarr library rescan for the given movie ID.

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -4,6 +4,7 @@ package radarr
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"golift.io/starr"
@@ -48,6 +49,7 @@ func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.
 			path = c.cfg.RemotePathPrefix + after
 		}
 	}
+	path = filepath.Clean(path)
 
 	movies, err := c.radarr.GetMovieContext(ctx, &radarrlib.GetMovie{})
 	if err != nil {

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -51,6 +51,15 @@ func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.
 	}
 	path = filepath.Clean(path)
 
+	// Guard against path traversal: if a remote prefix is configured, reject
+	// any path that escapes it after translation and cleaning.
+	if c.cfg.RemotePathPrefix != "" {
+		cleanPrefix := filepath.Clean(c.cfg.RemotePathPrefix)
+		if !strings.HasPrefix(path, cleanPrefix+string(filepath.Separator)) {
+			return medialib.Movie{}, fmt.Errorf("path %q is outside configured remote prefix %q", path, cleanPrefix)
+		}
+	}
+
 	movies, err := c.radarr.GetMovieContext(ctx, &radarrlib.GetMovie{})
 	if err != nil {
 		return medialib.Movie{}, fmt.Errorf("list movies: %w", err)

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -1,9 +1,10 @@
 package radarr_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,6 +33,16 @@ func newTestServer(t *testing.T, movies []*radarrlib.Movie) *httptest.Server {
 	})
 
 	return httptest.NewServer(mux)
+}
+
+// unusedURL returns a URL pointing at a port where nothing is listening.
+func unusedURL(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return fmt.Sprintf("http://%s", addr)
 }
 
 func TestGetMovieByFilePath(t *testing.T) {
@@ -132,28 +143,16 @@ func TestRefreshMovie(t *testing.T) {
 }
 
 func TestGetMovieByFilePath_UnreachableURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	srv.Close() // immediately close so the URL is unreachable
+	client := radarr.New(radarr.Config{URL: unusedURL(t), APIKey: "test-key"})
 
-	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100)
-	defer cancel()
-
-	_, err := client.GetMovieByFilePath(ctx, "/any/path.mkv")
+	_, err := client.GetMovieByFilePath(t.Context(), "/any/path.mkv")
 	require.Error(t, err)
 }
 
 func TestRefreshMovie_UnreachableURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	srv.Close()
+	client := radarr.New(radarr.Config{URL: unusedURL(t), APIKey: "test-key"})
 
-	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100)
-	defer cancel()
-
-	err := client.RefreshMovie(ctx, 42)
+	err := client.RefreshMovie(t.Context(), 42)
 	require.Error(t, err)
 }
 

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -1,0 +1,168 @@
+package radarr_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	radarrlib "golift.io/starr/radarr"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/radarr"
+)
+
+func newTestServer(t *testing.T, movies []*radarrlib.Movie) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v3/movie", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(movies))
+	})
+
+	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(&radarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestGetMovieByFilePath(t *testing.T) {
+	knownMovie := &radarrlib.Movie{
+		ID:    42,
+		Title: "The Matrix",
+		Year:  1999,
+		MovieFile: &radarrlib.MovieFile{
+			ID:   1,
+			Path: "/movies/The Matrix (1999)/The.Matrix.1999.mkv",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		movies   []*radarrlib.Movie
+		cfg      radarr.Config
+		expected medialib.Movie
+		errFunc  require.ErrorAssertionFunc
+	}{
+		{
+			name:   "known path returns movie",
+			path:   "/movies/The Matrix (1999)/The.Matrix.1999.mkv",
+			movies: []*radarrlib.Movie{knownMovie},
+			expected: medialib.Movie{
+				ID:    42,
+				Title: "The Matrix",
+				Year:  1999,
+			},
+		},
+		{
+			name:   "unknown path returns ErrNotFound",
+			path:   "/movies/Unknown/Unknown.mkv",
+			movies: []*radarrlib.Movie{knownMovie},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
+			},
+		},
+		{
+			name:   "path translation maps local to remote path",
+			path:   "/mnt/movies/The Matrix (1999)/The.Matrix.1999.mkv",
+			movies: []*radarrlib.Movie{knownMovie},
+			cfg: radarr.Config{
+				LocalPathPrefix:  "/mnt/movies",
+				RemotePathPrefix: "/movies",
+			},
+			expected: medialib.Movie{
+				ID:    42,
+				Title: "The Matrix",
+				Year:  1999,
+			},
+		},
+		{
+			name:   "movie without file is skipped",
+			path:   "/movies/Anything/anything.mkv",
+			movies: []*radarrlib.Movie{{ID: 1, Title: "No File", Year: 2000}},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer(t, tc.movies)
+			t.Cleanup(srv.Close)
+
+			cfg := tc.cfg
+			cfg.URL = srv.URL
+			cfg.APIKey = "test-key"
+
+			client := radarr.New(cfg)
+
+			movie, err := client.GetMovieByFilePath(t.Context(), tc.path)
+
+			errFunc := tc.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+			errFunc(t, err)
+
+			if err == nil {
+				assert.Equal(t, tc.expected, movie)
+			}
+		})
+	}
+}
+
+func TestRefreshMovie(t *testing.T) {
+	srv := newTestServer(t, nil)
+	t.Cleanup(srv.Close)
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	err := client.RefreshMovie(t.Context(), 42)
+	require.NoError(t, err)
+}
+
+func TestGetMovieByFilePath_UnreachableURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // immediately close so the URL is unreachable
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100)
+	defer cancel()
+
+	_, err := client.GetMovieByFilePath(ctx, "/any/path.mkv")
+	require.Error(t, err)
+}
+
+func TestRefreshMovie_UnreachableURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100)
+	defer cancel()
+
+	err := client.RefreshMovie(ctx, 42)
+	require.Error(t, err)
+}
+
+func TestGetMovieByFilePath_ErrNotFoundSentinel(t *testing.T) {
+	srv := newTestServer(t, []*radarrlib.Movie{})
+	t.Cleanup(srv.Close)
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, err := client.GetMovieByFilePath(t.Context(), "/no/such/file.mkv")
+	require.True(t, errors.Is(err, medialib.ErrNotFound), "expected ErrNotFound, got %v", err)
+}

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -19,14 +19,19 @@ import (
 // privileged port with no listener in any normal environment).
 const unreachableURL = "http://127.0.0.1:1"
 
-func newTestServer(t *testing.T, movies []*radarrlib.Movie) *httptest.Server {
+// parseResponse mirrors the shape of Radarr's /api/v3/parse response.
+type parseResponse struct {
+	Movie *radarrlib.Movie `json:"movie"`
+}
+
+func newTestServer(t *testing.T, parseResp *parseResponse) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/api/v3/movie", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(movies))
+		require.NoError(t, json.NewEncoder(w).Encode(parseResp))
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
@@ -42,24 +47,20 @@ func TestGetMovieByFilePath(t *testing.T) {
 		ID:    42,
 		Title: "The Matrix",
 		Year:  1999,
-		MovieFile: &radarrlib.MovieFile{
-			ID:   1,
-			Path: "/movies/The Matrix (1999)/The.Matrix.1999.mkv",
-		},
 	}
 
 	tests := []struct {
-		name     string
-		path     string
-		movies   []*radarrlib.Movie
-		cfg      radarr.Config
-		expected medialib.Movie
-		errFunc  require.ErrorAssertionFunc
+		name      string
+		path      string
+		cfg       radarr.Config
+		parseResp *parseResponse
+		expected  medialib.Movie
+		errFunc   require.ErrorAssertionFunc
 	}{
 		{
-			name:   "known path returns movie",
-			path:   "/movies/The Matrix (1999)/The.Matrix.1999.mkv",
-			movies: []*radarrlib.Movie{knownMovie},
+			name:      "known path returns movie",
+			path:      "/movies/The.Matrix.1999.mkv",
+			parseResp: &parseResponse{Movie: knownMovie},
 			expected: medialib.Movie{
 				ID:    42,
 				Title: "The Matrix",
@@ -67,17 +68,17 @@ func TestGetMovieByFilePath(t *testing.T) {
 			},
 		},
 		{
-			name:   "unknown path returns ErrNotFound",
-			path:   "/movies/Unknown/Unknown.mkv",
-			movies: []*radarrlib.Movie{knownMovie},
+			name:      "unknown path returns ErrNotFound",
+			path:      "/movies/Unknown.mkv",
+			parseResp: &parseResponse{Movie: nil},
 			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
 				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
 			},
 		},
 		{
-			name:   "path translation maps local to remote path",
-			path:   "/mnt/movies/The Matrix (1999)/The.Matrix.1999.mkv",
-			movies: []*radarrlib.Movie{knownMovie},
+			name:      "path translation maps local to remote path",
+			path:      "/mnt/movies/The.Matrix.1999.mkv",
+			parseResp: &parseResponse{Movie: knownMovie},
 			cfg: radarr.Config{
 				LocalPathPrefix:  "/mnt/movies",
 				RemotePathPrefix: "/movies",
@@ -89,17 +90,9 @@ func TestGetMovieByFilePath(t *testing.T) {
 			},
 		},
 		{
-			name:   "movie without file is skipped",
-			path:   "/movies/Anything/anything.mkv",
-			movies: []*radarrlib.Movie{{ID: 1, Title: "No File", Year: 2000}},
-			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
-				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
-			},
-		},
-		{
-			name:   "path traversal outside remote prefix returns error",
-			path:   "/mnt/movies/../../etc/passwd",
-			movies: []*radarrlib.Movie{knownMovie},
+			name:      "path traversal outside remote prefix returns error",
+			path:      "/mnt/movies/../../etc/passwd",
+			parseResp: &parseResponse{},
 			cfg: radarr.Config{
 				LocalPathPrefix:  "/mnt/movies",
 				RemotePathPrefix: "/movies",
@@ -113,7 +106,7 @@ func TestGetMovieByFilePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := newTestServer(t, tc.movies)
+			srv := newTestServer(t, tc.parseResp)
 			t.Cleanup(srv.Close)
 
 			cfg := tc.cfg
@@ -162,7 +155,7 @@ func TestRefreshMovie_UnreachableURL(t *testing.T) {
 }
 
 func TestGetMovieByFilePath_ErrNotFoundSentinel(t *testing.T) {
-	srv := newTestServer(t, []*radarrlib.Movie{})
+	srv := newTestServer(t, &parseResponse{Movie: nil})
 	t.Cleanup(srv.Close)
 
 	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -3,8 +3,6 @@ package radarr_test
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +14,10 @@ import (
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/pkg/medialib/radarr"
 )
+
+// unreachableURL is a URL that always refuses connections (port 1 is a
+// privileged port with no listener in any normal environment).
+const unreachableURL = "http://127.0.0.1:1"
 
 func newTestServer(t *testing.T, movies []*radarrlib.Movie) *httptest.Server {
 	t.Helper()
@@ -33,16 +35,6 @@ func newTestServer(t *testing.T, movies []*radarrlib.Movie) *httptest.Server {
 	})
 
 	return httptest.NewServer(mux)
-}
-
-// unusedURL returns a URL pointing at a port where nothing is listening.
-func unusedURL(t *testing.T) string {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := l.Addr().String()
-	require.NoError(t, l.Close())
-	return fmt.Sprintf("http://%s", addr)
 }
 
 func TestGetMovieByFilePath(t *testing.T) {
@@ -104,6 +96,19 @@ func TestGetMovieByFilePath(t *testing.T) {
 				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
 			},
 		},
+		{
+			name:   "path traversal outside remote prefix returns error",
+			path:   "/mnt/movies/../../etc/passwd",
+			movies: []*radarrlib.Movie{knownMovie},
+			cfg: radarr.Config{
+				LocalPathPrefix:  "/mnt/movies",
+				RemotePathPrefix: "/movies",
+			},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				require.NotErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -143,14 +148,14 @@ func TestRefreshMovie(t *testing.T) {
 }
 
 func TestGetMovieByFilePath_UnreachableURL(t *testing.T) {
-	client := radarr.New(radarr.Config{URL: unusedURL(t), APIKey: "test-key"})
+	client := radarr.New(radarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
 	_, err := client.GetMovieByFilePath(t.Context(), "/any/path.mkv")
 	require.Error(t, err)
 }
 
 func TestRefreshMovie_UnreachableURL(t *testing.T) {
-	client := radarr.New(radarr.Config{URL: unusedURL(t), APIKey: "test-key"})
+	client := radarr.New(radarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
 	err := client.RefreshMovie(t.Context(), 42)
 	require.Error(t, err)

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -55,6 +55,15 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 	}
 	path = filepath.Clean(path)
 
+	// Guard against path traversal: if a remote prefix is configured, reject
+	// any path that escapes it after translation and cleaning.
+	if c.cfg.RemotePathPrefix != "" {
+		cleanPrefix := filepath.Clean(c.cfg.RemotePathPrefix)
+		if !strings.HasPrefix(path, cleanPrefix+string(filepath.Separator)) {
+			return medialib.Episode{}, fmt.Errorf("path %q is outside configured remote prefix %q", path, cleanPrefix)
+		}
+	}
+
 	series, err := c.sonarr.GetAllSeriesContext(ctx)
 	if err != nil {
 		return medialib.Episode{}, fmt.Errorf("list series: %w", err)

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -4,6 +4,7 @@ package sonarr
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"golift.io/starr"
@@ -42,36 +43,47 @@ func New(cfg Config) *Client {
 
 // GetEpisodeByFilePath returns the episode whose file matches path.
 // Returns medialib.ErrNotFound if no match is found.
+//
+// The implementation first fetches all series and uses each series' root path
+// as a prefix filter, so episode files are fetched for only the one series
+// whose root path matches — reducing API calls from O(N series) to O(1).
 func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (medialib.Episode, error) {
 	if c.cfg.LocalPathPrefix != "" {
 		if after, ok := strings.CutPrefix(path, c.cfg.LocalPathPrefix); ok {
 			path = c.cfg.RemotePathPrefix + after
 		}
 	}
+	path = filepath.Clean(path)
 
 	series, err := c.sonarr.GetAllSeriesContext(ctx)
 	if err != nil {
 		return medialib.Episode{}, fmt.Errorf("list series: %w", err)
 	}
 
+	// Use each series' root path as a prefix filter to avoid fetching episode
+	// files for every series in the library.
 	for _, s := range series {
+		if !strings.HasPrefix(path, filepath.Clean(s.Path)+string(filepath.Separator)) {
+			continue
+		}
+
 		files, err := c.sonarr.GetSeriesEpisodeFilesContext(ctx, s.ID)
 		if err != nil {
 			return medialib.Episode{}, fmt.Errorf("list episode files for series %d: %w", s.ID, err)
 		}
 
-		for _, f := range files {
-			if f.Path != path {
+		for _, file := range files {
+			if file.Path != path {
 				continue
 			}
 
-			episodes, err := c.sonarr.GetSeriesEpisodesContext(ctx, &sonarrlib.GetEpisode{EpisodeFileID: f.ID})
+			episodes, err := c.sonarr.GetSeriesEpisodesContext(ctx, &sonarrlib.GetEpisode{EpisodeFileID: file.ID})
 			if err != nil {
-				return medialib.Episode{}, fmt.Errorf("get episode for file %d: %w", f.ID, err)
+				return medialib.Episode{}, fmt.Errorf("get episode for file %d: %w", file.ID, err)
 			}
 
 			if len(episodes) == 0 {
-				return medialib.Episode{}, fmt.Errorf("no episode found for file %d: %w", f.ID, medialib.ErrNotFound)
+				return medialib.Episode{}, fmt.Errorf("no episode found for file %d: %w", file.ID, medialib.ErrNotFound)
 			}
 
 			ep := episodes[0]

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -1,0 +1,101 @@
+// Package sonarr provides a Sonarr client implementing medialib.EpisodeLibrary.
+package sonarr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golift.io/starr"
+	sonarrlib "golift.io/starr/sonarr"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+)
+
+// Compile-time assertion that *Client implements medialib.EpisodeLibrary.
+var _ medialib.EpisodeLibrary = (*Client)(nil)
+
+// Config holds the configuration for a Sonarr client.
+type Config struct {
+	URL    string
+	APIKey string
+	// LocalPathPrefix and RemotePathPrefix enable optional path translation.
+	// When set, paths starting with LocalPathPrefix are rewritten to use
+	// RemotePathPrefix before being matched against Sonarr's stored paths.
+	// This handles cases where the worker and Sonarr use different mount points
+	// for the same storage.
+	LocalPathPrefix  string
+	RemotePathPrefix string
+}
+
+// Client is a Sonarr client implementing medialib.EpisodeLibrary.
+type Client struct {
+	cfg    Config
+	sonarr *sonarrlib.Sonarr
+}
+
+// New creates a new Sonarr client.
+func New(cfg Config) *Client {
+	s := starr.New(cfg.APIKey, cfg.URL, 0)
+	return &Client{cfg: cfg, sonarr: sonarrlib.New(s)}
+}
+
+// GetEpisodeByFilePath returns the episode whose file matches path.
+// Returns medialib.ErrNotFound if no match is found.
+func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (medialib.Episode, error) {
+	if c.cfg.LocalPathPrefix != "" {
+		if after, ok := strings.CutPrefix(path, c.cfg.LocalPathPrefix); ok {
+			path = c.cfg.RemotePathPrefix + after
+		}
+	}
+
+	series, err := c.sonarr.GetAllSeriesContext(ctx)
+	if err != nil {
+		return medialib.Episode{}, fmt.Errorf("list series: %w", err)
+	}
+
+	for _, s := range series {
+		files, err := c.sonarr.GetSeriesEpisodeFilesContext(ctx, s.ID)
+		if err != nil {
+			return medialib.Episode{}, fmt.Errorf("list episode files for series %d: %w", s.ID, err)
+		}
+
+		for _, f := range files {
+			if f.Path != path {
+				continue
+			}
+
+			episodes, err := c.sonarr.GetSeriesEpisodesContext(ctx, &sonarrlib.GetEpisode{EpisodeFileID: f.ID})
+			if err != nil {
+				return medialib.Episode{}, fmt.Errorf("get episode for file %d: %w", f.ID, err)
+			}
+
+			if len(episodes) == 0 {
+				return medialib.Episode{}, fmt.Errorf("no episode found for file %d: %w", f.ID, medialib.ErrNotFound)
+			}
+
+			ep := episodes[0]
+			return medialib.Episode{
+				ID:            ep.ID,
+				SeriesTitle:   s.Title,
+				SeasonNumber:  ep.SeasonNumber,
+				EpisodeNumber: ep.EpisodeNumber,
+			}, nil
+		}
+	}
+
+	return medialib.Episode{}, medialib.ErrNotFound
+}
+
+// RefreshSeries triggers a Sonarr library rescan for the given series ID.
+func (c *Client) RefreshSeries(ctx context.Context, seriesID int64) error {
+	_, err := c.sonarr.SendCommandContext(ctx, &sonarrlib.CommandRequest{
+		Name:      "RefreshSeries",
+		SeriesIDs: []int64{seriesID},
+	})
+	if err != nil {
+		return fmt.Errorf("refresh series %d: %w", seriesID, err)
+	}
+
+	return nil
+}

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -41,12 +41,9 @@ func New(cfg Config) *Client {
 	return &Client{cfg: cfg, sonarr: sonarrlib.New(s)}
 }
 
-// GetEpisodeByFilePath returns the episode whose file matches path.
-// Returns medialib.ErrNotFound if no match is found.
-//
-// The implementation first fetches all series and uses each series' root path
-// as a prefix filter, so episode files are fetched for only the one series
-// whose root path matches — reducing API calls from O(N series) to O(1).
+// GetEpisodeByFilePath returns the episode identified by parsing the file path.
+// Uses Sonarr's parse endpoint, so it works for pre-import files.
+// Returns medialib.ErrNotFound if no episode is identified.
 func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (medialib.Episode, error) {
 	if c.cfg.LocalPathPrefix != "" {
 		if after, ok := strings.CutPrefix(path, c.cfg.LocalPathPrefix); ok {
@@ -64,48 +61,23 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 		}
 	}
 
-	series, err := c.sonarr.GetAllSeriesContext(ctx)
+	parsed, err := c.sonarr.ParseContext(ctx, &sonarrlib.ParseInput{Path: path})
 	if err != nil {
-		return medialib.Episode{}, fmt.Errorf("list series: %w", err)
+		return medialib.Episode{}, fmt.Errorf("parse file path: %w", err)
 	}
 
-	// Use each series' root path as a prefix filter to avoid fetching episode
-	// files for every series in the library.
-	for _, s := range series {
-		if !strings.HasPrefix(path, filepath.Clean(s.Path)+string(filepath.Separator)) {
-			continue
-		}
-
-		files, err := c.sonarr.GetSeriesEpisodeFilesContext(ctx, s.ID)
-		if err != nil {
-			return medialib.Episode{}, fmt.Errorf("list episode files for series %d: %w", s.ID, err)
-		}
-
-		for _, file := range files {
-			if file.Path != path {
-				continue
-			}
-
-			episodes, err := c.sonarr.GetSeriesEpisodesContext(ctx, &sonarrlib.GetEpisode{EpisodeFileID: file.ID})
-			if err != nil {
-				return medialib.Episode{}, fmt.Errorf("get episode for file %d: %w", file.ID, err)
-			}
-
-			if len(episodes) == 0 {
-				return medialib.Episode{}, fmt.Errorf("no episode found for file %d: %w", file.ID, medialib.ErrNotFound)
-			}
-
-			ep := episodes[0]
-			return medialib.Episode{
-				ID:            ep.ID,
-				SeriesTitle:   s.Title,
-				SeasonNumber:  ep.SeasonNumber,
-				EpisodeNumber: ep.EpisodeNumber,
-			}, nil
-		}
+	if parsed == nil || parsed.ParsedEpisodeInfo == nil || len(parsed.Episodes) == 0 {
+		return medialib.Episode{}, medialib.ErrNotFound
 	}
 
-	return medialib.Episode{}, medialib.ErrNotFound
+	ep := parsed.Episodes[0]
+	return medialib.Episode{
+		ID:            ep.ID,
+		SeriesID:      ep.SeriesID,
+		SeriesTitle:   parsed.Title,
+		SeasonNumber:  ep.SeasonNumber,
+		EpisodeNumber: ep.EpisodeNumber,
+	}, nil
 }
 
 // RefreshSeries triggers a Sonarr library rescan for the given series ID.

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -3,8 +3,6 @@ package sonarr_test
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,6 +15,10 @@ import (
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/pkg/medialib/sonarr"
 )
+
+// unreachableURL is a URL that always refuses connections (port 1 is a
+// privileged port with no listener in any normal environment).
+const unreachableURL = "http://127.0.0.1:1"
 
 type sonarrFixture struct {
 	series       []*sonarrlib.Series
@@ -68,16 +70,6 @@ func newSonarrTestServer(t *testing.T, fix sonarrFixture) *httptest.Server {
 	})
 
 	return httptest.NewServer(mux)
-}
-
-// unusedURL returns a URL pointing at a port where nothing is listening.
-func unusedURL(t *testing.T) string {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := l.Addr().String()
-	require.NoError(t, l.Close())
-	return fmt.Sprintf("http://%s", addr)
 }
 
 func TestGetEpisodeByFilePath(t *testing.T) {
@@ -135,6 +127,18 @@ func TestGetEpisodeByFilePath(t *testing.T) {
 				EpisodeNumber: 1,
 			},
 		},
+		{
+			name: "path traversal outside remote prefix returns error",
+			path: "/mnt/tv/../../etc/passwd",
+			cfg: sonarr.Config{
+				LocalPathPrefix:  "/mnt/tv",
+				RemotePathPrefix: "/tv",
+			},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				require.NotErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -174,14 +178,14 @@ func TestRefreshSeries(t *testing.T) {
 }
 
 func TestGetEpisodeByFilePath_UnreachableURL(t *testing.T) {
-	client := sonarr.New(sonarr.Config{URL: unusedURL(t), APIKey: "test-key"})
+	client := sonarr.New(sonarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
 	_, err := client.GetEpisodeByFilePath(t.Context(), "/any/path.mkv")
 	require.Error(t, err)
 }
 
 func TestRefreshSeries_UnreachableURL(t *testing.T) {
-	client := sonarr.New(sonarr.Config{URL: unusedURL(t), APIKey: "test-key"})
+	client := sonarr.New(sonarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
 	err := client.RefreshSeries(t.Context(), 10)
 	require.Error(t, err)

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -1,0 +1,201 @@
+package sonarr_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sonarrlib "golift.io/starr/sonarr"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/sonarr"
+)
+
+type sonarrFixture struct {
+	series       []*sonarrlib.Series
+	episodeFiles map[int64][]*sonarrlib.EpisodeFile // keyed by seriesID
+	episodes     map[int64][]*sonarrlib.Episode     // keyed by episodeFileID
+}
+
+func newSonarrTestServer(t *testing.T, fix sonarrFixture) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v3/series", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(fix.series))
+	})
+
+	mux.HandleFunc("/api/v3/episodeFile", func(w http.ResponseWriter, r *http.Request) {
+		seriesIDStr := r.URL.Query().Get("seriesId")
+		seriesID, err := strconv.ParseInt(seriesIDStr, 10, 64)
+		require.NoError(t, err)
+
+		files := fix.episodeFiles[seriesID]
+		if files == nil {
+			files = []*sonarrlib.EpisodeFile{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(files))
+	})
+
+	mux.HandleFunc("/api/v3/episode", func(w http.ResponseWriter, r *http.Request) {
+		fileIDStr := r.URL.Query().Get("episodeFileId")
+		fileID, err := strconv.ParseInt(fileIDStr, 10, 64)
+		require.NoError(t, err)
+
+		eps := fix.episodes[fileID]
+		if eps == nil {
+			eps = []*sonarrlib.Episode{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(eps))
+	})
+
+	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(&sonarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestGetEpisodeByFilePath(t *testing.T) {
+	fix := sonarrFixture{
+		series: []*sonarrlib.Series{
+			{ID: 10, Title: "Breaking Bad"},
+		},
+		episodeFiles: map[int64][]*sonarrlib.EpisodeFile{
+			10: {
+				{ID: 100, SeriesID: 10, Path: "/tv/Breaking Bad/Season 01/S01E01.mkv"},
+			},
+		},
+		episodes: map[int64][]*sonarrlib.Episode{
+			100: {
+				{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		cfg      sonarr.Config
+		expected medialib.Episode
+		errFunc  require.ErrorAssertionFunc
+	}{
+		{
+			name: "known path returns episode",
+			path: "/tv/Breaking Bad/Season 01/S01E01.mkv",
+			expected: medialib.Episode{
+				ID:            200,
+				SeriesTitle:   "Breaking Bad",
+				SeasonNumber:  1,
+				EpisodeNumber: 1,
+			},
+		},
+		{
+			name: "unknown path returns ErrNotFound",
+			path: "/tv/Unknown/S01E01.mkv",
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
+			},
+		},
+		{
+			name: "path translation maps local to remote path",
+			path: "/mnt/tv/Breaking Bad/Season 01/S01E01.mkv",
+			cfg: sonarr.Config{
+				LocalPathPrefix:  "/mnt/tv",
+				RemotePathPrefix: "/tv",
+			},
+			expected: medialib.Episode{
+				ID:            200,
+				SeriesTitle:   "Breaking Bad",
+				SeasonNumber:  1,
+				EpisodeNumber: 1,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSonarrTestServer(t, fix)
+			t.Cleanup(srv.Close)
+
+			cfg := tc.cfg
+			cfg.URL = srv.URL
+			cfg.APIKey = "test-key"
+
+			client := sonarr.New(cfg)
+
+			episode, err := client.GetEpisodeByFilePath(t.Context(), tc.path)
+
+			errFunc := tc.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+			errFunc(t, err)
+
+			if err == nil {
+				assert.Equal(t, tc.expected, episode)
+			}
+		})
+	}
+}
+
+func TestRefreshSeries(t *testing.T) {
+	srv := newSonarrTestServer(t, sonarrFixture{})
+	t.Cleanup(srv.Close)
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	err := client.RefreshSeries(t.Context(), 10)
+	require.NoError(t, err)
+}
+
+func TestGetEpisodeByFilePath_UnreachableURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100)
+	defer cancel()
+
+	_, err := client.GetEpisodeByFilePath(ctx, "/any/path.mkv")
+	require.Error(t, err)
+}
+
+func TestRefreshSeries_UnreachableURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100)
+	defer cancel()
+
+	err := client.RefreshSeries(ctx, 10)
+	require.Error(t, err)
+}
+
+func TestGetEpisodeByFilePath_ErrNotFoundSentinel(t *testing.T) {
+	srv := newSonarrTestServer(t, sonarrFixture{
+		series: []*sonarrlib.Series{},
+	})
+	t.Cleanup(srv.Close)
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, err := client.GetEpisodeByFilePath(t.Context(), "/no/such/file.mkv")
+	require.True(t, errors.Is(err, medialib.ErrNotFound), "expected ErrNotFound, got %v", err)
+}

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -1,9 +1,10 @@
 package sonarr_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -69,10 +70,20 @@ func newSonarrTestServer(t *testing.T, fix sonarrFixture) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
+// unusedURL returns a URL pointing at a port where nothing is listening.
+func unusedURL(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return fmt.Sprintf("http://%s", addr)
+}
+
 func TestGetEpisodeByFilePath(t *testing.T) {
 	fix := sonarrFixture{
 		series: []*sonarrlib.Series{
-			{ID: 10, Title: "Breaking Bad"},
+			{ID: 10, Title: "Breaking Bad", Path: "/tv/Breaking Bad"},
 		},
 		episodeFiles: map[int64][]*sonarrlib.EpisodeFile{
 			10: {
@@ -163,28 +174,16 @@ func TestRefreshSeries(t *testing.T) {
 }
 
 func TestGetEpisodeByFilePath_UnreachableURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	srv.Close()
+	client := sonarr.New(sonarr.Config{URL: unusedURL(t), APIKey: "test-key"})
 
-	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100)
-	defer cancel()
-
-	_, err := client.GetEpisodeByFilePath(ctx, "/any/path.mkv")
+	_, err := client.GetEpisodeByFilePath(t.Context(), "/any/path.mkv")
 	require.Error(t, err)
 }
 
 func TestRefreshSeries_UnreachableURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	srv.Close()
+	client := sonarr.New(sonarr.Config{URL: unusedURL(t), APIKey: "test-key"})
 
-	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100)
-	defer cancel()
-
-	err := client.RefreshSeries(ctx, 10)
+	err := client.RefreshSeries(t.Context(), 10)
 	require.Error(t, err)
 }
 

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,48 +19,14 @@ import (
 // privileged port with no listener in any normal environment).
 const unreachableURL = "http://127.0.0.1:1"
 
-type sonarrFixture struct {
-	series       []*sonarrlib.Series
-	episodeFiles map[int64][]*sonarrlib.EpisodeFile // keyed by seriesID
-	episodes     map[int64][]*sonarrlib.Episode     // keyed by episodeFileID
-}
-
-func newSonarrTestServer(t *testing.T, fix sonarrFixture) *httptest.Server {
+func newSonarrTestServer(t *testing.T, parseResp *sonarrlib.ParseOutput) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/api/v3/series", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(fix.series))
-	})
-
-	mux.HandleFunc("/api/v3/episodeFile", func(w http.ResponseWriter, r *http.Request) {
-		seriesIDStr := r.URL.Query().Get("seriesId")
-		seriesID, err := strconv.ParseInt(seriesIDStr, 10, 64)
-		require.NoError(t, err)
-
-		files := fix.episodeFiles[seriesID]
-		if files == nil {
-			files = []*sonarrlib.EpisodeFile{}
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(files))
-	})
-
-	mux.HandleFunc("/api/v3/episode", func(w http.ResponseWriter, r *http.Request) {
-		fileIDStr := r.URL.Query().Get("episodeFileId")
-		fileID, err := strconv.ParseInt(fileIDStr, 10, 64)
-		require.NoError(t, err)
-
-		eps := fix.episodes[fileID]
-		if eps == nil {
-			eps = []*sonarrlib.Episode{}
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(eps))
+		require.NoError(t, json.NewEncoder(w).Encode(parseResp))
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
@@ -73,63 +38,66 @@ func newSonarrTestServer(t *testing.T, fix sonarrFixture) *httptest.Server {
 }
 
 func TestGetEpisodeByFilePath(t *testing.T) {
-	fix := sonarrFixture{
-		series: []*sonarrlib.Series{
-			{ID: 10, Title: "Breaking Bad", Path: "/tv/Breaking Bad"},
+	knownParseOutput := &sonarrlib.ParseOutput{
+		Title: "Breaking Bad",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Breaking Bad",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
 		},
-		episodeFiles: map[int64][]*sonarrlib.EpisodeFile{
-			10: {
-				{ID: 100, SeriesID: 10, Path: "/tv/Breaking Bad/Season 01/S01E01.mkv"},
-			},
-		},
-		episodes: map[int64][]*sonarrlib.Episode{
-			100: {
-				{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
-			},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
 		},
 	}
 
 	tests := []struct {
-		name     string
-		path     string
-		cfg      sonarr.Config
-		expected medialib.Episode
-		errFunc  require.ErrorAssertionFunc
+		name      string
+		path      string
+		cfg       sonarr.Config
+		parseResp *sonarrlib.ParseOutput
+		expected  medialib.Episode
+		errFunc   require.ErrorAssertionFunc
 	}{
 		{
-			name: "known path returns episode",
-			path: "/tv/Breaking Bad/Season 01/S01E01.mkv",
+			name:      "known path returns episode",
+			path:      "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp: knownParseOutput,
 			expected: medialib.Episode{
 				ID:            200,
+				SeriesID:      10,
 				SeriesTitle:   "Breaking Bad",
 				SeasonNumber:  1,
 				EpisodeNumber: 1,
 			},
 		},
 		{
-			name: "unknown path returns ErrNotFound",
-			path: "/tv/Unknown/S01E01.mkv",
+			name:      "unrecognized path returns ErrNotFound",
+			path:      "/tv/Unknown.S01E01.mkv",
+			parseResp: &sonarrlib.ParseOutput{},
 			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
 				require.ErrorIs(t, err, medialib.ErrNotFound, msgAndArgs...)
 			},
 		},
 		{
-			name: "path translation maps local to remote path",
-			path: "/mnt/tv/Breaking Bad/Season 01/S01E01.mkv",
+			name:      "path translation maps local to remote path",
+			path:      "/mnt/tv/Breaking.Bad.S01E01.mkv",
+			parseResp: knownParseOutput,
 			cfg: sonarr.Config{
 				LocalPathPrefix:  "/mnt/tv",
 				RemotePathPrefix: "/tv",
 			},
 			expected: medialib.Episode{
 				ID:            200,
+				SeriesID:      10,
 				SeriesTitle:   "Breaking Bad",
 				SeasonNumber:  1,
 				EpisodeNumber: 1,
 			},
 		},
 		{
-			name: "path traversal outside remote prefix returns error",
-			path: "/mnt/tv/../../etc/passwd",
+			name:      "path traversal outside remote prefix returns error",
+			path:      "/mnt/tv/../../etc/passwd",
+			parseResp: &sonarrlib.ParseOutput{},
 			cfg: sonarr.Config{
 				LocalPathPrefix:  "/mnt/tv",
 				RemotePathPrefix: "/tv",
@@ -143,7 +111,7 @@ func TestGetEpisodeByFilePath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := newSonarrTestServer(t, fix)
+			srv := newSonarrTestServer(t, tc.parseResp)
 			t.Cleanup(srv.Close)
 
 			cfg := tc.cfg
@@ -168,7 +136,7 @@ func TestGetEpisodeByFilePath(t *testing.T) {
 }
 
 func TestRefreshSeries(t *testing.T) {
-	srv := newSonarrTestServer(t, sonarrFixture{})
+	srv := newSonarrTestServer(t, nil)
 	t.Cleanup(srv.Close)
 
 	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
@@ -192,9 +160,7 @@ func TestRefreshSeries_UnreachableURL(t *testing.T) {
 }
 
 func TestGetEpisodeByFilePath_ErrNotFoundSentinel(t *testing.T) {
-	srv := newSonarrTestServer(t, sonarrFixture{
-		series: []*sonarrlib.Series{},
-	})
+	srv := newSonarrTestServer(t, &sonarrlib.ParseOutput{})
 	t.Cleanup(srv.Close)
 
 	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})


### PR DESCRIPTION
## Summary
- Add `pkg/medialib/radarr` and `pkg/medialib/sonarr` packages wrapping `golift.io/starr`
- Define `MovieLibrary` and `EpisodeLibrary` interfaces in `pkg/medialib` for future backend swappability
- Optional `LocalPathPrefix`/`RemotePathPrefix` config per client to handle differing mount points between the worker and *Arr services (populated by the `cmd/` layer from env vars — library does not read env vars directly)

## Acceptance criteria
- [x] `radarr.GetMovieByFilePath` returns `Movie` for known path
- [x] `radarr.GetMovieByFilePath` returns `ErrNotFound` for unknown path
- [x] `radarr.RefreshMovie` returns nil on success
- [x] `sonarr.GetEpisodeByFilePath` returns `Episode` for known path
- [x] `sonarr.GetEpisodeByFilePath` returns `ErrNotFound` for unknown path
- [x] `sonarr.RefreshSeries` returns nil on success
- [x] Unreachable URL returns non-nil error within context deadline

## Test plan
- All tests use `httptest.NewServer` stubs — no real Radarr/Sonarr required
- `make test` and `make lint` pass cleanly

Fixes #5