### PR TITLE
feat(webhook): failure notification client with configurable payload

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,2 +1,102 @@
-// Package webhook provides HTTP handler utilities for inbound webhook events.
+// Package webhook provides an HTTP client for posting failure notifications
+// to a configured webhook endpoint.
 package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const defaultTimeout = 10 * time.Second
+
+// FailureEvent describes a workflow step failure.
+type FailureEvent struct {
+	Workflow string
+	FilePath string
+	Step     string
+	Err      error
+}
+
+// PayloadFunc builds the HTTP request body for a given failure event.
+// Implementations can return any JSON structure — for example, Discord's
+// {"content": "..."} format.
+type PayloadFunc func(event FailureEvent) ([]byte, error)
+
+// Client sends failure notifications to a webhook endpoint.
+type Client struct {
+	URL          string
+	Timeout      time.Duration // zero → defaultTimeout (10s)
+	BuildPayload PayloadFunc   // nil → DefaultPayload
+}
+
+// defaultPayload is the built-in payload shape described in the issue spec.
+type defaultPayloadShape struct {
+	Workflow string `json:"workflow"`
+	FilePath string `json:"file_path"`
+	Step     string `json:"step"`
+	Error    string `json:"error"`
+}
+
+// DefaultPayload marshals the event into the standard JSON shape:
+//
+//	{"workflow":"...","file_path":"...","step":"...","error":"..."}
+func DefaultPayload(e FailureEvent) ([]byte, error) {
+	errMsg := ""
+	if e.Err != nil {
+		errMsg = e.Err.Error()
+	}
+	return json.Marshal(defaultPayloadShape{
+		Workflow: e.Workflow,
+		FilePath: e.FilePath,
+		Step:     e.Step,
+		Error:    errMsg,
+	})
+}
+
+// NotifyFailure sends an HTTP POST to c.URL with the failure event payload.
+// If c.URL is empty the call is a no-op and nil is returned.
+// If the endpoint returns a non-2xx status code, a non-nil error is returned
+// containing the status code.
+func (c *Client) NotifyFailure(ctx context.Context, event FailureEvent) error {
+	if c.URL == "" {
+		return nil
+	}
+
+	buildPayload := c.BuildPayload
+	if buildPayload == nil {
+		buildPayload = DefaultPayload
+	}
+
+	body, err := buildPayload(event)
+	if err != nil {
+		return fmt.Errorf("webhook: build payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	timeout := c.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+	httpClient := &http.Client{Timeout: timeout}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook: send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook: unexpected status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -129,14 +128,9 @@ func TestNotifyFailure_CancelledContext(t *testing.T) {
 // TestNotifyFailure_UnreachableEndpoint verifies that an unreachable endpoint
 // returns a non-nil error.
 func TestNotifyFailure_UnreachableEndpoint(t *testing.T) {
-	// Bind a listener, get its address, then close it so nothing is listening.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	require.NoError(t, ln.Close())
-
-	client := &webhook.Client{URL: "http://" + addr}
-	err = client.NotifyFailure(t.Context(), testEvent)
+	// Port 1 is reserved and connections to it are reliably refused.
+	client := &webhook.Client{URL: "http://127.0.0.1:1"}
+	err := client.NotifyFailure(t.Context(), testEvent)
 	require.Error(t, err)
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,180 @@
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/webhook"
+)
+
+var testEvent = webhook.FailureEvent{
+	Workflow: "MovieWorkflow",
+	FilePath: "/watch/movies/example.mkv",
+	Step:     "transcode",
+	Err:      errors.New("exit status 1"),
+}
+
+// TestNotifyFailure_DefaultPayloadContents verifies the POST body contains all
+// required fields when using the default payload builder.
+func TestNotifyFailure_DefaultPayloadContents(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &webhook.Client{URL: srv.URL}
+	err := client.NotifyFailure(t.Context(), testEvent)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	assert.Equal(t, "MovieWorkflow", payload["workflow"])
+	assert.Equal(t, "/watch/movies/example.mkv", payload["file_path"])
+	assert.Equal(t, "transcode", payload["step"])
+	assert.Equal(t, "exit status 1", payload["error"])
+}
+
+// TestNotifyFailure_StatusCodes verifies return values for 2xx and non-2xx responses.
+func TestNotifyFailure_StatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		errFunc    require.ErrorAssertionFunc
+		errMsg     string
+	}{
+		{
+			name:       "2xx returns nil",
+			statusCode: http.StatusOK,
+			errFunc:    require.NoError,
+		},
+		{
+			name:       "2xx created returns nil",
+			statusCode: http.StatusCreated,
+			errFunc:    require.NoError,
+		},
+		{
+			name:       "non-2xx returns error with status code",
+			statusCode: http.StatusInternalServerError,
+			errFunc:    require.Error,
+			errMsg:     "500",
+		},
+		{
+			name:       "4xx returns error with status code",
+			statusCode: http.StatusBadRequest,
+			errFunc:    require.Error,
+			errMsg:     "400",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer srv.Close()
+
+			client := &webhook.Client{URL: srv.URL}
+			err := client.NotifyFailure(t.Context(), testEvent)
+			if tc.errFunc == nil {
+				tc.errFunc = require.NoError
+			}
+			tc.errFunc(t, err)
+			if tc.errMsg != "" {
+				assert.ErrorContains(t, err, tc.errMsg)
+			}
+		})
+	}
+}
+
+// TestNotifyFailure_EmptyURL verifies that an empty URL is a no-op.
+func TestNotifyFailure_EmptyURL(t *testing.T) {
+	client := &webhook.Client{URL: ""}
+	err := client.NotifyFailure(t.Context(), testEvent)
+	require.NoError(t, err)
+}
+
+// TestNotifyFailure_CancelledContext verifies that a cancelled context causes
+// the call to return promptly with a context error.
+func TestNotifyFailure_CancelledContext(t *testing.T) {
+	// Server that blocks so we can test cancellation.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before calling
+
+	client := &webhook.Client{URL: srv.URL}
+	err := client.NotifyFailure(ctx, testEvent)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestNotifyFailure_UnreachableEndpoint verifies that an unreachable endpoint
+// returns a non-nil error.
+func TestNotifyFailure_UnreachableEndpoint(t *testing.T) {
+	// Bind a listener, get its address, then close it so nothing is listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	client := &webhook.Client{URL: "http://" + addr}
+	err = client.NotifyFailure(t.Context(), testEvent)
+	require.Error(t, err)
+}
+
+// TestNotifyFailure_CustomPayloadFunc verifies that a custom PayloadFunc is used
+// instead of the default, enabling arbitrary endpoint formats such as Discord.
+func TestNotifyFailure_CustomPayloadFunc(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	customPayload := []byte(`{"content":"custom discord message"}`)
+	client := &webhook.Client{
+		URL: srv.URL,
+		BuildPayload: func(e webhook.FailureEvent) ([]byte, error) {
+			return customPayload, nil
+		},
+	}
+
+	err := client.NotifyFailure(t.Context(), testEvent)
+	require.NoError(t, err)
+	assert.Equal(t, customPayload, gotBody)
+}
+
+// TestDefaultPayload verifies the standalone DefaultPayload function produces
+// the expected JSON structure.
+func TestDefaultPayload(t *testing.T) {
+	data, err := webhook.DefaultPayload(testEvent)
+	require.NoError(t, err)
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.Equal(t, "MovieWorkflow", payload["workflow"])
+	assert.Equal(t, "/watch/movies/example.mkv", payload["file_path"])
+	assert.Equal(t, "transcode", payload["step"])
+	assert.Equal(t, "exit status 1", payload["error"])
+}


### PR DESCRIPTION
## Summary

- Implements `pkg/webhook.Client` with `NotifyFailure(ctx, event)` that POSTs a structured JSON failure payload to a configured URL
- Adds `PayloadFunc` callback field for fully configurable payload building — enables Discord webhooks and any other format
- `DefaultPayload` provides the standard `{"workflow","file_path","step","error"}` shape
- Empty URL is a no-op; non-2xx and network errors are returned
- Uses `net/http` with a 10s default timeout

Fixes #6

## Test plan

- [x] `TestNotifyFailure_DefaultPayloadContents` — POST body contains all required fields
- [x] `TestNotifyFailure_StatusCodes` — 2xx → nil, non-2xx → error with status code
- [x] `TestNotifyFailure_EmptyURL` — no-op, returns nil
- [x] `TestNotifyFailure_CancelledContext` — returns context.Canceled promptly
- [x] `TestNotifyFailure_UnreachableEndpoint` — returns non-nil error
- [x] `TestNotifyFailure_CustomPayloadFunc` — custom func body is used verbatim
- [x] `TestDefaultPayload` — verifies standalone DefaultPayload output

🤖 Generated with [Claude Code](https://claude.com/claude-code)