### PR TITLE
feat(watcher): implement directory scan worker with Hatchet cron dispatch

### DIFF
--- a/cmd/watcher/config.go
+++ b/cmd/watcher/config.go
@@ -13,9 +13,15 @@ type WatchEntry struct {
 	Workflow string `yaml:"workflow"`
 }
 
+const defaultCronSchedule = "*/5 * * * * *"
+
 // Config is the top-level watcher configuration loaded from the YAML config file.
 type Config struct {
-	Watches []WatchEntry `yaml:"watches"`
+	// CronSchedule is the Hatchet cron expression controlling how often the watcher
+	// scans directories (default: every 5 seconds). Supports Hatchet's 6-field format
+	// with a leading seconds field, e.g. "*/5 * * * * *".
+	CronSchedule string       `yaml:"cron_schedule"`
+	Watches      []WatchEntry `yaml:"watches"`
 }
 
 // loadConfig reads and parses the watcher YAML config file at path.
@@ -25,7 +31,7 @@ func loadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("cannot read config file %q: %w", path, err)
 	}
 
-	var cfg Config
+	cfg := Config{CronSchedule: defaultCronSchedule}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("cannot parse config file %q: %w", path, err)
 	}

--- a/cmd/watcher/config_test.go
+++ b/cmd/watcher/config_test.go
@@ -31,10 +31,30 @@ watches:
     workflow: ShowWorkflow
 `,
 			expected: Config{
+				CronSchedule: defaultCronSchedule,
 				Watches: []WatchEntry{
 					{Path: "/watch/movies", Workflow: "MovieWorkflow"},
 					{Path: "/watch/shows", Workflow: "ShowWorkflow"},
 				},
+			},
+		},
+		{
+			name: "custom cron_schedule is parsed",
+			content: `
+cron_schedule: "*/10 * * * * *"
+watches: []
+`,
+			expected: Config{
+				CronSchedule: "*/10 * * * * *",
+				Watches:      []WatchEntry{},
+			},
+		},
+		{
+			name:    "cron_schedule defaults to every 5 seconds when omitted",
+			content: "watches: []",
+			expected: Config{
+				CronSchedule: defaultCronSchedule,
+				Watches:      []WatchEntry{},
 			},
 		},
 		{

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -33,17 +33,35 @@ func run(ctx context.Context, configPath string) error {
 
 	log.Printf("loaded %d watch mapping(s) from %s", len(cfg.Watches), configPath)
 
+	if err := validateWatchDirs(cfg); err != nil {
+		return fmt.Errorf("invalid watch configuration: %w", err)
+	}
+
 	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
 		return fmt.Errorf("HATCHET_CLIENT_TOKEN is not set")
 	}
 
-	if _, err = hatchet.NewClient(); err != nil {
+	client, err := hatchet.NewClient()
+	if err != nil {
 		return fmt.Errorf("connect to Hatchet: %w", err)
 	}
 
 	log.Println("connected to Hatchet")
 
-	// TODO(#7): start fsnotify directory watching
-	<-ctx.Done()
+	scanWorkflow := NewScanWorkflow(client, cfg)
+
+	worker, err := client.NewWorker("mediaprocessor-watcher",
+		hatchet.WithWorkflows(scanWorkflow),
+	)
+	if err != nil {
+		return fmt.Errorf("create watcher worker: %w", err)
+	}
+
+	log.Printf("starting directory scan worker (schedule: %s)", cfg.CronSchedule)
+
+	if err := worker.StartBlocking(ctx); err != nil {
+		return fmt.Errorf("watcher stopped: %w", err)
+	}
+
 	return nil
 }

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -50,13 +50,20 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTas
 }
 
 // validateWatchDirs returns an error listing every configured watch directory that does
-// not exist, so the operator sees all problems at once rather than fixing them one at a time.
+// not exist or is not a directory, so the operator sees all problems at once rather than
+// fixing them one at a time.
 func validateWatchDirs(cfg *Config) error {
 	errs := make([]error, 0, len(cfg.Watches))
 
 	for _, w := range cfg.Watches {
-		if _, err := os.Stat(w.Path); err != nil {
+		info, err := os.Stat(w.Path)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("watch directory %q: %w", w.Path, err))
+			continue
+		}
+
+		if !info.IsDir() {
+			errs = append(errs, fmt.Errorf("watch path %q is not a directory", w.Path))
 		}
 	}
 
@@ -66,12 +73,21 @@ func validateWatchDirs(cfg *Config) error {
 // scan walks every configured watch directory recursively and calls dispatch for each
 // file found. Files in subdirectories inherit the mapping of their watch root. All
 // per-file errors (access errors and dispatch errors) are collected and returned as an
-// aggregate so a single failure does not abort the scan.
+// aggregate so a single failure does not abort the scan. The walk respects ctx
+// cancellation and returns immediately on shutdown.
 func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 	var errs []error
 
 	for _, w := range cfg.Watches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+
 			if err != nil {
 				errs = append(errs, fmt.Errorf("scan error at %q: %w", path, err))
 				return nil
@@ -93,6 +109,10 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 
 			return nil
 		}); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+
 			errs = append(errs, fmt.Errorf("walk directory %q: %w", w.Path, err))
 		}
 	}

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -22,7 +23,7 @@ type dispatchFunc func(ctx context.Context, workflowName, filePath string) error
 // Overlapping scans are dropped (CANCEL_NEWEST, max 1 concurrent run) so a slow
 // scan does not pile up behind a cron backlog.
 func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTask {
-	var maxRuns int32 = 1
+	maxRuns := int32(1)
 	strategy := types.CancelNewest
 
 	return client.NewStandaloneTask(
@@ -49,14 +50,18 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTas
 	)
 }
 
-// validateWatchDirs returns an error if any configured watch directory does not exist.
+// validateWatchDirs returns an error listing every configured watch directory that does
+// not exist, so the operator sees all problems at once rather than fixing them one at a time.
 func validateWatchDirs(cfg *Config) error {
+	var errs []error
+
 	for _, w := range cfg.Watches {
 		if _, err := os.Stat(w.Path); err != nil {
-			return fmt.Errorf("watch directory %q: %w", w.Path, err)
+			errs = append(errs, fmt.Errorf("watch directory %q: %w", w.Path, err))
 		}
 	}
-	return nil
+
+	return errors.Join(errs...)
 }
 
 // scan walks every configured watch directory recursively and calls dispatch for each
@@ -69,16 +74,20 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 				log.Printf("warning: scan error at %q: %v", path, err)
 				return nil
 			}
+
 			if d.IsDir() {
 				return nil
 			}
+
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return fmt.Errorf("resolve absolute path for %q: %w", path, err)
 			}
+
 			if dispatchErr := dispatch(ctx, w.Workflow, absPath); dispatchErr != nil {
 				log.Printf("warning: dispatch workflow %q for %q: %v", w.Workflow, absPath, dispatchErr)
 			}
+
 			return nil
 		}); err != nil {
 			return fmt.Errorf("walk directory %q: %w", w.Path, err)

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -97,5 +97,9 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 		}
 	}
 
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("directory scan completed with errors: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/hatchet-dev/hatchet/pkg/client/types"
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+// dispatchFunc submits a workflow run for the given absolute file path.
+type dispatchFunc func(ctx context.Context, workflowName, filePath string) error
+
+// NewScanWorkflow returns a Hatchet standalone task that scans all configured watch
+// directories on the configured cron schedule and spawns a child workflow run for
+// every file found, using the absolute file path as the idempotency key.
+//
+// Overlapping scans are dropped (CANCEL_NEWEST, max 1 concurrent run) so a slow
+// scan does not pile up behind a cron backlog.
+func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTask {
+	var maxRuns int32 = 1
+	strategy := types.CancelNewest
+
+	return client.NewStandaloneTask(
+		"directory-scan",
+		func(ctx hatchet.Context, _ struct{}) (struct{}, error) {
+			dispatch := func(dispatchCtx context.Context, workflowName, filePath string) error {
+				_, err := client.RunNoWait(
+					dispatchCtx,
+					workflowName,
+					map[string]string{"file_path": filePath},
+					hatchet.WithRunKey(filePath),
+				)
+				return err
+			}
+			return struct{}{}, scan(ctx, cfg, dispatch)
+		},
+		hatchet.WithWorkflowCron(cfg.CronSchedule),
+		hatchet.WithWorkflowConcurrency(types.Concurrency{
+			// Constant expression groups all scan runs under a single concurrency slot.
+			Expression:    `"scan"`,
+			MaxRuns:       &maxRuns,
+			LimitStrategy: &strategy,
+		}),
+	)
+}
+
+// validateWatchDirs returns an error if any configured watch directory does not exist.
+func validateWatchDirs(cfg *Config) error {
+	for _, w := range cfg.Watches {
+		if _, err := os.Stat(w.Path); err != nil {
+			return fmt.Errorf("watch directory %q: %w", w.Path, err)
+		}
+	}
+	return nil
+}
+
+// scan walks every configured watch directory recursively and calls dispatch for each
+// file found. Files in subdirectories inherit the mapping of their watch root. Dispatch
+// errors are logged as warnings so a single failed submission does not abort the scan.
+func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
+	for _, w := range cfg.Watches {
+		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				log.Printf("warning: scan error at %q: %v", path, err)
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return fmt.Errorf("resolve absolute path for %q: %w", path, err)
+			}
+			if dispatchErr := dispatch(ctx, w.Workflow, absPath); dispatchErr != nil {
+				log.Printf("warning: dispatch workflow %q for %q: %v", w.Workflow, absPath, dispatchErr)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("walk directory %q: %w", w.Path, err)
+		}
+	}
+	return nil
+}

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -53,7 +52,7 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTas
 // validateWatchDirs returns an error listing every configured watch directory that does
 // not exist, so the operator sees all problems at once rather than fixing them one at a time.
 func validateWatchDirs(cfg *Config) error {
-	var errs []error
+	errs := make([]error, 0, len(cfg.Watches))
 
 	for _, w := range cfg.Watches {
 		if _, err := os.Stat(w.Path); err != nil {
@@ -65,13 +64,16 @@ func validateWatchDirs(cfg *Config) error {
 }
 
 // scan walks every configured watch directory recursively and calls dispatch for each
-// file found. Files in subdirectories inherit the mapping of their watch root. Dispatch
-// errors are logged as warnings so a single failed submission does not abort the scan.
+// file found. Files in subdirectories inherit the mapping of their watch root. All
+// per-file errors (access errors and dispatch errors) are collected and returned as an
+// aggregate so a single failure does not abort the scan.
 func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
+	var errs []error
+
 	for _, w := range cfg.Watches {
 		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
-				log.Printf("warning: scan error at %q: %v", path, err)
+				errs = append(errs, fmt.Errorf("scan error at %q: %w", path, err))
 				return nil
 			}
 
@@ -81,17 +83,19 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 
 			absPath, err := filepath.Abs(path)
 			if err != nil {
-				return fmt.Errorf("resolve absolute path for %q: %w", path, err)
+				errs = append(errs, fmt.Errorf("resolve absolute path for %q: %w", path, err))
+				return nil
 			}
 
 			if dispatchErr := dispatch(ctx, w.Workflow, absPath); dispatchErr != nil {
-				log.Printf("warning: dispatch workflow %q for %q: %v", w.Workflow, absPath, dispatchErr)
+				errs = append(errs, fmt.Errorf("dispatch workflow %q for %q: %w", w.Workflow, absPath, dispatchErr))
 			}
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("walk directory %q: %w", w.Path, err)
+			errs = append(errs, fmt.Errorf("walk directory %q: %w", w.Path, err))
 		}
 	}
-	return nil
+
+	return errors.Join(errs...)
 }

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -124,9 +124,9 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 	assert.Equal(t, filePath, dispatched[0])
 }
 
-// TestScan_DispatchErrorIsWarningNotFatal verifies that a dispatch error does not abort
-// the scan — all files in the directory are still processed.
-func TestScan_DispatchErrorIsWarningNotFatal(t *testing.T) {
+// TestScan_DispatchErrorsAreAggregated verifies that dispatch errors do not abort the
+// scan — all files are still processed — and the aggregate error is returned.
+func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -145,7 +145,7 @@ func TestScan_DispatchErrorIsWarningNotFatal(t *testing.T) {
 		return errors.New("simulated dispatch failure")
 	}
 
-	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.Error(t, scan(t.Context(), cfg, dispatch))
 	assert.Equal(t, 2, count)
 }
 

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -58,6 +58,19 @@ func TestValidateWatchDirs(t *testing.T) {
 			cfg:     &Config{},
 			errFunc: require.NoError,
 		},
+		{
+			name: "path that exists but is a file returns error",
+			cfg: func() *Config {
+				f, err := os.CreateTemp(t.TempDir(), "notadir")
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+				return &Config{Watches: []WatchEntry{{Path: f.Name(), Workflow: "W"}}}
+			}(),
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				assert.Contains(t, err.Error(), "not a directory")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -147,6 +160,28 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 
 	require.Error(t, scan(t.Context(), cfg, dispatch))
 	assert.Equal(t, 2, count)
+}
+
+// TestScan_ContextCancellationStopsWalk verifies that cancelling the context causes scan
+// to stop walking and return the context error rather than an aggregate scan error.
+func TestScan_ContextCancellationStopsWalk(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.mkv"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Path: dir, Workflow: "W"},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately before scan starts
+
+	err := scan(ctx, cfg, func(_ context.Context, _, _ string) error { return nil })
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 // TestScan_MultipleWatchEntries verifies that files in separate watch directories are

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -40,6 +40,20 @@ func TestValidateWatchDirs(t *testing.T) {
 			errFunc: require.Error,
 		},
 		{
+			name: "all errors reported when multiple dirs are missing",
+			cfg: &Config{
+				Watches: []WatchEntry{
+					{Path: "/nonexistent/alpha", Workflow: "W"},
+					{Path: "/nonexistent/beta", Workflow: "W"},
+				},
+			},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				assert.Contains(t, err.Error(), "/nonexistent/alpha")
+				assert.Contains(t, err.Error(), "/nonexistent/beta")
+			},
+		},
+		{
 			name:    "empty watch list passes",
 			cfg:     &Config{},
 			errFunc: require.NoError,

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateWatchDirs verifies that validateWatchDirs returns a descriptive error
+// when a configured watch directory does not exist, and succeeds when all dirs are present.
+func TestValidateWatchDirs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		errFunc require.ErrorAssertionFunc
+	}{
+		{
+			name: "existing directory passes",
+			cfg: &Config{
+				Watches: []WatchEntry{
+					{Path: t.TempDir(), Workflow: "W"},
+				},
+			},
+			errFunc: require.NoError,
+		},
+		{
+			name: "missing directory returns error",
+			cfg: &Config{
+				Watches: []WatchEntry{
+					{Path: "/nonexistent/path/abc123", Workflow: "W"},
+				},
+			},
+			errFunc: require.Error,
+		},
+		{
+			name:    "empty watch list passes",
+			cfg:     &Config{},
+			errFunc: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.errFunc(t, validateWatchDirs(tt.cfg))
+		})
+	}
+}
+
+// TestScan_FileInWatchedDir verifies that a file present in a configured watch directory
+// is dispatched with the correct workflow name and absolute file path.
+func TestScan_FileInWatchedDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "movie.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Path: dir, Workflow: "MovieWorkflow"},
+		},
+	}
+
+	type call struct{ workflow, path string }
+	var calls []call
+	dispatch := func(_ context.Context, workflow, path string) error {
+		calls = append(calls, call{workflow, path})
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.Len(t, calls, 1)
+	assert.Equal(t, "MovieWorkflow", calls[0].workflow)
+	assert.Equal(t, filePath, calls[0].path)
+}
+
+// TestScan_SubdirectoryFilesUseParentMapping verifies that files within subdirectories
+// of a configured watch path are dispatched using the parent watch entry's workflow.
+func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "show-title")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	filePath := filepath.Join(subdir, "episode.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Path: dir, Workflow: "ShowWorkflow"},
+		},
+	}
+
+	var dispatched []string
+	dispatch := func(_ context.Context, _, path string) error {
+		dispatched = append(dispatched, path)
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.Len(t, dispatched, 1)
+	assert.Equal(t, filePath, dispatched[0])
+}
+
+// TestScan_DispatchErrorIsWarningNotFatal verifies that a dispatch error does not abort
+// the scan — all files in the directory are still processed.
+func TestScan_DispatchErrorIsWarningNotFatal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.mkv"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Path: dir, Workflow: "W"},
+		},
+	}
+
+	var count int
+	dispatch := func(_ context.Context, _, _ string) error {
+		count++
+		return errors.New("simulated dispatch failure")
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	assert.Equal(t, 2, count)
+}
+
+// TestScan_MultipleWatchEntries verifies that files in separate watch directories are
+// each dispatched with their respective configured workflow names.
+func TestScan_MultipleWatchEntries(t *testing.T) {
+	t.Parallel()
+
+	movieDir := t.TempDir()
+	showDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(movieDir, "movie.mkv"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "show.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Path: movieDir, Workflow: "MovieWorkflow"},
+			{Path: showDir, Workflow: "ShowWorkflow"},
+		},
+	}
+
+	dispatched := make(map[string]string) // path → workflow
+	dispatch := func(_ context.Context, workflow, path string) error {
+		dispatched[path] = workflow
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	assert.Equal(t, "MovieWorkflow", dispatched[filepath.Join(movieDir, "movie.mkv")])
+	assert.Equal(t, "ShowWorkflow", dispatched[filepath.Join(showDir, "show.mkv")])
+}


### PR DESCRIPTION
## Summary

- Implements the `cmd/watcher` binary's core functionality: a Hatchet-managed cron workflow that recursively scans configured watch directories and spawns child workflow runs for each file found
- Replaces fsnotify (inotify-based, incompatible with NFS mounts) with a polling approach managed by Hatchet's cron scheduler (6-field cron, seconds granularity)
- Uses `hatchet.WithRunKey(absFilePath)` inside a Hatchet task context for proper server-side idempotency per file path
- Adds configurable `cron_schedule` field to YAML config (default: `*/5 * * * * *`)

## Test plan

- [x] `make test` passes for `cmd/watcher` (all new tests green)
- [x] `make build` produces valid `bin/watcher` binary
- [x] `make lint` reports no issues
- [ ] Integration: start watcher with a valid config and NFS-mounted volume; confirm workflow runs appear in Hatchet UI when files are dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #7