### PR TITLE
feat(workflow): show/episode processing workflow

### DIFF
--- a/workflows/movie/movie.go
+++ b/workflows/movie/movie.go
@@ -2,10 +2,7 @@
 package movie
 
 import (
-	"errors"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
@@ -85,7 +82,7 @@ func NewMovieWorkflow(
 			return struct{}{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		return struct{}{}, shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir)
+		return struct{}{}, shared.RunTranscode(ctx, input.FilePath, probe.VideoCodec, probe.Format, cfg.OutputDir)
 	}, hatchet.WithParents(probeTask, lookupTask), skipIfInvalid)
 
 	// notify-radarr: trigger a Radarr library rescan for the movie.
@@ -108,32 +105,7 @@ func NewMovieWorkflow(
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
-		stepErrors := ctx.StepRunErrors()
-		if len(stepErrors) == 0 {
-			return struct{}{}, nil
-		}
-
-		steps := make([]string, 0, len(stepErrors))
-		for stepName := range stepErrors {
-			steps = append(steps, stepName)
-		}
-		sort.Strings(steps)
-
-		errs := make([]error, 0, len(stepErrors))
-		for _, stepName := range steps {
-			errs = append(errs, fmt.Errorf("%s: %s", stepName, stepErrors[stepName]))
-		}
-
-		if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
-			Workflow: movieWorkflowName,
-			FilePath: input.FilePath,
-			Step:     strings.Join(steps, ", "),
-			Err:      errors.Join(errs...),
-		}); err != nil {
-			return struct{}{}, fmt.Errorf("notify failure: %w", err)
-		}
-
-		return struct{}{}, nil
+		return struct{}{}, shared.NotifyWorkflowFailure(ctx, movieWorkflowName, input.FilePath, webhookClient)
 	})
 
 	return wf

--- a/workflows/movie/movie.go
+++ b/workflows/movie/movie.go
@@ -105,7 +105,7 @@ func NewMovieWorkflow(
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
-		return struct{}{}, shared.NotifyWorkflowFailure(ctx, movieWorkflowName, input.FilePath, webhookClient)
+		return struct{}{}, shared.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), movieWorkflowName, input.FilePath, webhookClient)
 	})
 
 	return wf

--- a/workflows/shared/cleanup.go
+++ b/workflows/shared/cleanup.go
@@ -1,4 +1,4 @@
-package movie
+package shared
 
 import (
 	"errors"
@@ -6,8 +6,8 @@ import (
 	"os"
 )
 
-// runCleanup deletes the original source file after successful processing.
-func runCleanup(filePath string) error {
+// RunCleanup deletes the original source file after successful processing.
+func RunCleanup(filePath string) error {
 	if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("delete source file: %w", err)
 	}

--- a/workflows/shared/cleanup_test.go
+++ b/workflows/shared/cleanup_test.go
@@ -1,4 +1,4 @@
-package movie
+package shared
 
 import (
 	"os"
@@ -40,7 +40,7 @@ func TestRunCleanup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := tt.setupPath(t)
 
-			err := runCleanup(path)
+			err := RunCleanup(path)
 
 			tt.errFunc(t, err)
 			if tt.fileDeleted {

--- a/workflows/shared/onfailure.go
+++ b/workflows/shared/onfailure.go
@@ -1,0 +1,45 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+
+	"github.com/solidDoWant/media-processor/pkg/webhook"
+)
+
+// NotifyWorkflowFailure sends an aggregated failure notification to webhookClient.
+// It is intended to be called from a workflow's OnFailure handler.
+// workflowName is included in the webhook payload; filePath is the file being processed.
+// Returns nil (no-op) when there are no step errors.
+func NotifyWorkflowFailure(ctx hatchet.Context, workflowName, filePath string, webhookClient *webhook.Client) error {
+	stepErrors := ctx.StepRunErrors()
+	if len(stepErrors) == 0 {
+		return nil
+	}
+
+	steps := make([]string, 0, len(stepErrors))
+	for stepName := range stepErrors {
+		steps = append(steps, stepName)
+	}
+	sort.Strings(steps)
+
+	errs := make([]error, 0, len(stepErrors))
+	for _, stepName := range steps {
+		errs = append(errs, fmt.Errorf("%s: %s", stepName, stepErrors[stepName]))
+	}
+
+	if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
+		Workflow: workflowName,
+		FilePath: filePath,
+		Step:     strings.Join(steps, ", "),
+		Err:      errors.Join(errs...),
+	}); err != nil {
+		return fmt.Errorf("notify failure: %w", err)
+	}
+
+	return nil
+}

--- a/workflows/shared/onfailure.go
+++ b/workflows/shared/onfailure.go
@@ -1,22 +1,20 @@
 package shared
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
-	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
-
 	"github.com/solidDoWant/media-processor/pkg/webhook"
 )
 
 // NotifyWorkflowFailure sends an aggregated failure notification to webhookClient.
-// It is intended to be called from a workflow's OnFailure handler.
+// stepErrors is the map returned by ctx.StepRunErrors() in an OnFailure handler.
 // workflowName is included in the webhook payload; filePath is the file being processed.
-// Returns nil (no-op) when there are no step errors.
-func NotifyWorkflowFailure(ctx hatchet.Context, workflowName, filePath string, webhookClient *webhook.Client) error {
-	stepErrors := ctx.StepRunErrors()
+// Returns nil (no-op) when stepErrors is empty.
+func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, workflowName, filePath string, webhookClient *webhook.Client) error {
 	if len(stepErrors) == 0 {
 		return nil
 	}

--- a/workflows/shared/onfailure_test.go
+++ b/workflows/shared/onfailure_test.go
@@ -1,0 +1,96 @@
+package shared
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/webhook"
+)
+
+func TestNotifyWorkflowFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		stepErrors map[string]string
+		wantCalled bool
+		wantStep   string
+		wantErrMsg string
+		errFunc    require.ErrorAssertionFunc
+	}{
+		{
+			name:       "empty step errors is a no-op",
+			stepErrors: map[string]string{},
+			wantCalled: false,
+			errFunc:    require.NoError,
+		},
+		{
+			name:       "nil step errors is a no-op",
+			stepErrors: nil,
+			wantCalled: false,
+			errFunc:    require.NoError,
+		},
+		{
+			name:       "single step error sends correct payload",
+			stepErrors: map[string]string{"transcode": "ffmpeg exited with code 1"},
+			wantCalled: true,
+			wantStep:   "transcode",
+			wantErrMsg: "transcode: ffmpeg exited with code 1",
+			errFunc:    require.NoError,
+		},
+		{
+			name: "multiple step errors are sorted and joined deterministically",
+			stepErrors: map[string]string{
+				"lookup":    "not found",
+				"transcode": "disk full",
+				"cleanup":   "permission denied",
+			},
+			wantCalled: true,
+			wantStep:   "cleanup, lookup, transcode",
+			wantErrMsg: "cleanup: permission denied\nlookup: not found\ntranscode: disk full",
+			errFunc:    require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			var gotPayload map[string]string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload))
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			client := &webhook.Client{URL: srv.URL}
+			err := NotifyWorkflowFailure(t.Context(), tt.stepErrors, "TestWorkflow", "/media/file.mkv", client)
+
+			tt.errFunc(t, err)
+			assert.Equal(t, tt.wantCalled, called, "webhook server call expectation")
+
+			if tt.wantCalled {
+				assert.Equal(t, tt.wantStep, gotPayload["step"])
+				assert.Equal(t, tt.wantErrMsg, gotPayload["error"])
+				assert.Equal(t, "TestWorkflow", gotPayload["workflow"])
+				assert.Equal(t, "/media/file.mkv", gotPayload["file_path"])
+			}
+		})
+	}
+}
+
+func TestNotifyWorkflowFailure_WebhookErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &webhook.Client{URL: srv.URL}
+	err := NotifyWorkflowFailure(t.Context(), map[string]string{"lookup": "not found"}, "TestWorkflow", "/media/file.mkv", client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notify failure")
+}

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -1,4 +1,5 @@
-package movie
+// Package shared provides workflow step implementations shared across workflow types.
+package shared
 
 import (
 	"context"
@@ -9,8 +10,8 @@ import (
 	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
 
-// probeOutput is the output of the probe step.
-type probeOutput struct {
+// ProbeOutput is the output of the probe step.
+type ProbeOutput struct {
 	// IsValidMedia is false when the file is not a recognisable media file with a
 	// video stream. All downstream steps are skipped when this is false.
 	IsValidMedia bool `json:"is_valid_media"`
@@ -22,28 +23,28 @@ type probeOutput struct {
 	Format string `json:"format"`
 }
 
-// runProbe reads codec and container info for filePath. If the file is not a
+// RunProbe reads codec and container info for filePath. If the file is not a
 // recognised media file or has no video stream, it deletes the file and returns
 // IsValidMedia=false (without error), causing all downstream steps to be skipped.
-func runProbe(ctx context.Context, filePath string) (probeOutput, error) {
+func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 	info, err := ffprobe.Probe(ctx, filePath)
 	if err != nil {
 		// Context errors are operational — propagate them so the step fails and
 		// OnFailure fires, instead of silently deleting the file.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return probeOutput{}, err
+			return ProbeOutput{}, err
 		}
 
 		if removeErr := os.Remove(filePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			return probeOutput{}, fmt.Errorf("remove unrecognised file: %w", removeErr)
+			return ProbeOutput{}, fmt.Errorf("remove unrecognised file: %w", removeErr)
 		}
 
-		return probeOutput{IsValidMedia: false}, nil
+		return ProbeOutput{IsValidMedia: false}, nil
 	}
 
 	for _, s := range info.Streams {
 		if s.CodecType == ffprobe.CodecTypeVideo {
-			return probeOutput{
+			return ProbeOutput{
 				IsValidMedia: true,
 				VideoCodec:   s.CodecName,
 				Format:       info.Format,
@@ -51,10 +52,10 @@ func runProbe(ctx context.Context, filePath string) (probeOutput, error) {
 		}
 	}
 
-	// No video stream found — not a movie file.
+	// No video stream found.
 	if removeErr := os.Remove(filePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return probeOutput{}, fmt.Errorf("remove file with no video streams: %w", removeErr)
+		return ProbeOutput{}, fmt.Errorf("remove file with no video streams: %w", removeErr)
 	}
 
-	return probeOutput{IsValidMedia: false}, nil
+	return ProbeOutput{IsValidMedia: false}, nil
 }

--- a/workflows/shared/probe_test.go
+++ b/workflows/shared/probe_test.go
@@ -1,4 +1,4 @@
-package movie
+package shared
 
 import (
 	"context"
@@ -14,14 +14,14 @@ func TestRunProbe(t *testing.T) {
 	tests := []struct {
 		name        string
 		setupPath   func(t *testing.T) string
-		expected    probeOutput
+		expected    ProbeOutput
 		errFunc     require.ErrorAssertionFunc
 		fileDeleted bool
 	}{
 		{
 			name:      "valid H.264 MP4 returns codec and format",
 			setupPath: copyTestVideo,
-			expected: probeOutput{
+			expected: ProbeOutput{
 				IsValidMedia: true,
 				VideoCodec:   "h264",
 				Format:       "mov,mp4,m4a,3gp,3g2,mj2",
@@ -36,7 +36,7 @@ func TestRunProbe(t *testing.T) {
 				require.NoError(t, os.WriteFile(p, []byte("hello"), 0o600))
 				return p
 			},
-			expected:    probeOutput{IsValidMedia: false},
+			expected:    ProbeOutput{IsValidMedia: false},
 			errFunc:     require.NoError,
 			fileDeleted: true,
 		},
@@ -45,7 +45,7 @@ func TestRunProbe(t *testing.T) {
 			setupPath: func(t *testing.T) string {
 				return filepath.Join(t.TempDir(), "does-not-exist.mp4")
 			},
-			expected:    probeOutput{IsValidMedia: false},
+			expected:    ProbeOutput{IsValidMedia: false},
 			errFunc:     require.NoError,
 			fileDeleted: false, // nothing to delete
 		},
@@ -55,7 +55,7 @@ func TestRunProbe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := tt.setupPath(t)
 
-			got, err := runProbe(t.Context(), path)
+			got, err := RunProbe(t.Context(), path)
 
 			tt.errFunc(t, err)
 			assert.Equal(t, tt.expected, got)
@@ -76,7 +76,7 @@ func TestRunProbe_CancelledContextPropagatesError(t *testing.T) {
 
 	path := copyTestVideo(t)
 
-	_, err := runProbe(ctx, path)
+	_, err := RunProbe(ctx, path)
 	require.ErrorIs(t, err, context.Canceled, "cancelled context should propagate as error, not delete the file")
 
 	_, statErr := os.Stat(path)

--- a/workflows/shared/testhelpers_test.go
+++ b/workflows/shared/testhelpers_test.go
@@ -1,0 +1,24 @@
+package shared
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testVideoPath points to the small H.264/MP4 clip shared with the ffprobe package.
+const testVideoPath = "../../pkg/ffprobe/testdata/video.mp4"
+
+// copyTestVideo copies the shared test video to a temp file and returns its path.
+// The file is NOT registered for cleanup so tests can verify deletion behaviour.
+func copyTestVideo(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(testVideoPath)
+	require.NoError(t, err)
+
+	dst := filepath.Join(t.TempDir(), "video.mp4")
+	require.NoError(t, os.WriteFile(dst, src, 0o600))
+	return dst
+}

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -29,8 +29,10 @@ func SelectVideoCodec(videoCodecName, format string) ffmpeg.Codec {
 // The output always carries a .mkv extension to match the forced MKV container.
 // Writing directly to the output directory avoids a cross-filesystem copy and
 // guarantees the rename is atomic on Linux (same directory).
-func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string) error {
-	videoCodec := SelectVideoCodec(probe.VideoCodec, probe.Format)
+// videoCodecName and format are the codec name and container format from ffprobe
+// (e.g. "h264", "matroska,webm").
+func RunTranscode(ctx context.Context, filePath, videoCodecName, format, outputDir string) error {
+	videoCodec := SelectVideoCodec(videoCodecName, format)
 
 	inputBase := filepath.Base(filePath)
 	mkvBase := strings.TrimSuffix(inputBase, filepath.Ext(inputBase)) + ".mkv"

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -1,4 +1,4 @@
-package movie
+package shared
 
 import (
 	"context"
@@ -12,9 +12,9 @@ import (
 	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
 
-// selectVideoCodec returns CodecCopy when the video is already H.264 or H.265 in an
+// SelectVideoCodec returns CodecCopy when the video is already H.264 or H.265 in an
 // MKV container, and CodecH265 otherwise.
-func selectVideoCodec(videoCodecName, format string) ffmpeg.Codec {
+func SelectVideoCodec(videoCodecName, format string) ffmpeg.Codec {
 	if strings.Contains(format, string(ffmpeg.ContainerMKV)) {
 		if videoCodecName == ffprobe.CodecNameH264 || videoCodecName == ffprobe.CodecNameH265 {
 			return ffmpeg.CodecCopy
@@ -24,20 +24,20 @@ func selectVideoCodec(videoCodecName, format string) ffmpeg.Codec {
 	return ffmpeg.CodecH265
 }
 
-// runTranscode transcodes input.FilePath into outputDir, writing to a temp file named
+// RunTranscode transcodes filePath into outputDir, writing to a temp file named
 // "._<stem>.mkv.tmp" and atomically renaming it to "<stem>.mkv" on success.
 // The output always carries a .mkv extension to match the forced MKV container.
 // Writing directly to the output directory avoids a cross-filesystem copy and
 // guarantees the rename is atomic on Linux (same directory).
-func runTranscode(ctx context.Context, input MovieInput, probe probeOutput, outputDir string) error {
-	videoCodec := selectVideoCodec(probe.VideoCodec, probe.Format)
+func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string) error {
+	videoCodec := SelectVideoCodec(probe.VideoCodec, probe.Format)
 
-	inputBase := filepath.Base(input.FilePath)
+	inputBase := filepath.Base(filePath)
 	mkvBase := strings.TrimSuffix(inputBase, filepath.Ext(inputBase)) + ".mkv"
 	tempPath := filepath.Join(outputDir, "._"+mkvBase+".tmp")
 	finalPath := filepath.Join(outputDir, mkvBase)
 
-	if err := ffmpeg.NewTranscode(input.FilePath, tempPath).
+	if err := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
 		Build().

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -168,7 +168,7 @@ func TestRunTranscode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
 
-			err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir)
+			err := RunTranscode(t.Context(), inputPath, tt.probe.VideoCodec, tt.probe.Format, outputDir)
 
 			tt.errFunc(t, err)
 			if tt.check != nil {

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -1,4 +1,4 @@
-package movie
+package shared
 
 import (
 	"os"
@@ -61,14 +61,14 @@ func TestSelectVideoCodec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := selectVideoCodec(tt.videoCodecName, tt.format)
+			got := SelectVideoCodec(tt.videoCodecName, tt.format)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
 func TestRunTranscode(t *testing.T) {
-	h264Probe := probeOutput{
+	h264Probe := ProbeOutput{
 		IsValidMedia: true,
 		VideoCodec:   "h264",
 		Format:       "mov,mp4,m4a,3gp,3g2,mj2",
@@ -77,7 +77,7 @@ func TestRunTranscode(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T) (inputPath, outputDir string)
-		probe   probeOutput
+		probe   ProbeOutput
 		errFunc require.ErrorAssertionFunc
 		check   func(t *testing.T, outputDir, inputPath string)
 	}{
@@ -102,7 +102,6 @@ func TestRunTranscode(t *testing.T) {
 			setup: func(t *testing.T) (string, string) {
 				inputPath := copyTestVideo(t)
 				outputDir := t.TempDir()
-				// Simulate a stale temp file from a previous failed run.
 				stale := filepath.Join(outputDir, "._"+mkvOutputName(inputPath)+".tmp")
 				require.NoError(t, os.WriteFile(stale, []byte("stale partial data"), 0o600))
 				return inputPath, outputDir
@@ -123,7 +122,6 @@ func TestRunTranscode(t *testing.T) {
 			setup: func(t *testing.T) (string, string) {
 				inputPath := copyTestVideo(t)
 				outputDir := t.TempDir()
-				// Simulate a file already processed in a previous run.
 				oldContent := []byte("old output")
 				require.NoError(t, os.WriteFile(filepath.Join(outputDir, mkvOutputName(inputPath)), oldContent, 0o600))
 				return inputPath, outputDir
@@ -143,7 +141,7 @@ func TestRunTranscode(t *testing.T) {
 				require.NoError(t, os.WriteFile(p, []byte("not a video"), 0o600))
 				return p, t.TempDir()
 			},
-			probe:   probeOutput{IsValidMedia: false},
+			probe:   ProbeOutput{IsValidMedia: false},
 			errFunc: require.Error,
 			check: func(t *testing.T, outputDir, inputPath string) {
 				_, statErr := os.Stat(filepath.Join(outputDir, "._"+mkvOutputName(inputPath)+".tmp"))
@@ -169,9 +167,8 @@ func TestRunTranscode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
-			input := MovieInput{FilePath: inputPath}
 
-			err := runTranscode(t.Context(), input, tt.probe, outputDir)
+			err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir)
 
 			tt.errFunc(t, err)
 			if tt.check != nil {

--- a/workflows/show/integration_test.go
+++ b/workflows/show/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,8 +19,9 @@ import (
 )
 
 // startShowWorker creates a Hatchet worker with the given ShowWorkflow and starts it.
-// The worker is automatically stopped via t.Cleanup. The call blocks briefly to allow
-// the worker to register its workflows with Hatchet before dispatching runs.
+// The worker is automatically stopped via t.Cleanup. The call blocks until the worker
+// appears as ACTIVE in the Hatchet server (with a 30s timeout) so tests never race
+// against a fixed sleep.
 func startShowWorker(t *testing.T, client *hatchet.Client, wf *hatchet.Workflow) {
 	t.Helper()
 	worker, err := client.NewWorker("test-show-worker", hatchet.WithWorkflows(wf))
@@ -29,8 +31,19 @@ func startShowWorker(t *testing.T, client *hatchet.Client, wf *hatchet.Workflow)
 	require.NoError(t, err, "start worker")
 	t.Cleanup(func() { _ = cleanup() })
 
-	// Allow time for the worker to register its workflow definitions with the Hatchet server.
-	time.Sleep(3 * time.Second)
+	// Poll until the worker is registered and ACTIVE on the Hatchet server.
+	require.Eventually(t, func() bool {
+		list, listErr := client.Workers().List(t.Context())
+		if listErr != nil || list == nil || list.Rows == nil {
+			return false
+		}
+		for _, w := range *list.Rows {
+			if w.Name == "test-show-worker" && w.Status != nil && *w.Status == rest.ACTIVE {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond, "show worker failed to register within 30s")
 }
 
 func TestShowWorkflow_ValidVideoIsTranscodedAndSourceDeleted(t *testing.T) {
@@ -113,7 +126,8 @@ func TestShowWorkflow_NonVideoFileIsDeletedByProbeAndDownstreamStepsSkipped(t *t
 	assert.True(t, os.IsNotExist(statErr), "non-video file should be deleted by probe step")
 
 	// Nothing should have been written to the output directory.
-	entries, _ := os.ReadDir(outputDir)
+	entries, err := os.ReadDir(outputDir)
+	require.NoError(t, err)
 	assert.Empty(t, entries, "output directory should be empty when file is not a valid video")
 
 	// Sonarr should not have been called.

--- a/workflows/show/integration_test.go
+++ b/workflows/show/integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package show
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/webhook"
+)
+
+// startShowWorker creates a Hatchet worker with the given ShowWorkflow and starts it.
+// The worker is automatically stopped via t.Cleanup. The call blocks briefly to allow
+// the worker to register its workflows with Hatchet before dispatching runs.
+func startShowWorker(t *testing.T, client *hatchet.Client, wf *hatchet.Workflow) {
+	t.Helper()
+	worker, err := client.NewWorker("test-show-worker", hatchet.WithWorkflows(wf))
+	require.NoError(t, err, "create Hatchet worker")
+
+	cleanup, err := worker.Start()
+	require.NoError(t, err, "start worker")
+	t.Cleanup(func() { _ = cleanup() })
+
+	// Allow time for the worker to register its workflow definitions with the Hatchet server.
+	time.Sleep(3 * time.Second)
+}
+
+func TestShowWorkflow_ValidVideoIsTranscodedAndSourceDeleted(t *testing.T) {
+	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
+		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")
+	}
+
+	client, err := hatchet.NewClient()
+	require.NoError(t, err)
+
+	inputPath := copyTestVideo(t)
+	outputDir := t.TempDir()
+
+	sonarrStub := &stubEpisodeLibrary{episode: medialib.Episode{ID: 1, SeriesID: 42, SeriesTitle: "Test Show"}}
+	wf := NewShowWorkflow(client, ShowWorkflowConfig{OutputDir: outputDir}, sonarrStub, &webhook.Client{})
+	startShowWorker(t, client, wf)
+
+	ctx := t.Context()
+	_, err = wf.Run(ctx, ShowInput{FilePath: inputPath})
+	require.NoError(t, err)
+
+	// Transcoded output file must exist in the output directory with .mkv extension.
+	inputBase := filepath.Base(inputPath)
+	mkvBase := strings.TrimSuffix(inputBase, filepath.Ext(inputBase)) + ".mkv"
+	_, statErr := os.Stat(filepath.Join(outputDir, mkvBase))
+	assert.NoError(t, statErr, "transcoded output file should exist in outputDir")
+
+	// Original source file must be deleted by the cleanup step.
+	_, statErr = os.Stat(inputPath)
+	assert.True(t, os.IsNotExist(statErr), "source file should be deleted by cleanup step")
+}
+
+func TestShowWorkflow_RefreshSeriesIsCalledAfterTranscode(t *testing.T) {
+	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
+		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")
+	}
+
+	client, err := hatchet.NewClient()
+	require.NoError(t, err)
+
+	inputPath := copyTestVideo(t)
+	outputDir := t.TempDir()
+
+	sonarrStub := &stubEpisodeLibrary{episode: medialib.Episode{ID: 1, SeriesID: 42, SeriesTitle: "Test Show"}}
+	wf := NewShowWorkflow(client, ShowWorkflowConfig{OutputDir: outputDir}, sonarrStub, &webhook.Client{})
+	startShowWorker(t, client, wf)
+
+	ctx := t.Context()
+	_, err = wf.Run(ctx, ShowInput{FilePath: inputPath})
+	require.NoError(t, err)
+
+	// RefreshSeries must have been called with the correct series ID.
+	assert.Equal(t, []int64{42}, sonarrStub.refreshCalls, "RefreshSeries should be called once with the series ID")
+}
+
+func TestShowWorkflow_NonVideoFileIsDeletedByProbeAndDownstreamStepsSkipped(t *testing.T) {
+	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
+		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")
+	}
+
+	client, err := hatchet.NewClient()
+	require.NoError(t, err)
+
+	// Write a plain text file that ffprobe will not recognise as a media file.
+	inputPath := filepath.Join(t.TempDir(), "not-a-video.txt")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a video"), 0o600))
+	outputDir := t.TempDir()
+
+	sonarrStub := &stubEpisodeLibrary{episode: medialib.Episode{ID: 1, SeriesID: 1}}
+	wf := NewShowWorkflow(client, ShowWorkflowConfig{OutputDir: outputDir}, sonarrStub, &webhook.Client{})
+	startShowWorker(t, client, wf)
+
+	ctx := t.Context()
+	// The probe step marks IsValidMedia=false without error; all downstream steps are skipped.
+	_, err = wf.Run(ctx, ShowInput{FilePath: inputPath})
+	require.NoError(t, err)
+
+	// The probe step deleted the unrecognised file.
+	_, statErr := os.Stat(inputPath)
+	assert.True(t, os.IsNotExist(statErr), "non-video file should be deleted by probe step")
+
+	// Nothing should have been written to the output directory.
+	entries, _ := os.ReadDir(outputDir)
+	assert.Empty(t, entries, "output directory should be empty when file is not a valid video")
+
+	// Sonarr should not have been called.
+	assert.Empty(t, sonarrStub.refreshCalls, "RefreshSeries should not be called for non-video files")
+}
+
+func TestShowWorkflow_LookupFailureCausesWorkflowToFail(t *testing.T) {
+	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
+		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")
+	}
+
+	client, err := hatchet.NewClient()
+	require.NoError(t, err)
+
+	inputPath := copyTestVideo(t)
+	outputDir := t.TempDir()
+
+	// Sonarr stub returns ErrNotFound for every lookup.
+	sonarrStub := &stubEpisodeLibrary{err: medialib.ErrNotFound}
+	wf := NewShowWorkflow(client, ShowWorkflowConfig{OutputDir: outputDir}, sonarrStub, &webhook.Client{})
+	startShowWorker(t, client, wf)
+
+	ctx := t.Context()
+	_, err = wf.Run(ctx, ShowInput{FilePath: inputPath})
+	assert.Error(t, err, "workflow should fail when the episode is not found in Sonarr")
+
+	// Source file must not be deleted when a step fails.
+	_, statErr := os.Stat(inputPath)
+	assert.NoError(t, statErr, "source file should not be deleted when lookup fails")
+}

--- a/workflows/show/lookup.go
+++ b/workflows/show/lookup.go
@@ -1,0 +1,24 @@
+package show
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+)
+
+// lookupOutput is the output of the lookup step.
+type lookupOutput struct {
+	SeriesID int64 `json:"series_id"`
+}
+
+// runLookup identifies the episode at filePath in Sonarr. It returns an error
+// wrapping medialib.ErrNotFound if the file is not recognised.
+func runLookup(ctx context.Context, filePath string, sonarrClient medialib.EpisodeLibrary) (lookupOutput, error) {
+	episode, err := sonarrClient.GetEpisodeByFilePath(ctx, filePath)
+	if err != nil {
+		return lookupOutput{}, fmt.Errorf("lookup episode: %w", err)
+	}
+
+	return lookupOutput{SeriesID: episode.SeriesID}, nil
+}

--- a/workflows/show/lookup_test.go
+++ b/workflows/show/lookup_test.go
@@ -1,0 +1,40 @@
+package show
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+)
+
+func TestRunLookup(t *testing.T) {
+	tests := []struct {
+		name     string
+		stub     *stubEpisodeLibrary
+		expected lookupOutput
+		errFunc  require.ErrorAssertionFunc
+	}{
+		{
+			name:     "found episode returns its series ID",
+			stub:     &stubEpisodeLibrary{episode: medialib.Episode{ID: 10, SeriesID: 42, SeriesTitle: "Breaking Bad"}},
+			expected: lookupOutput{SeriesID: 42},
+			errFunc:  require.NoError,
+		},
+		{
+			name:    "library returns ErrNotFound propagates error",
+			stub:    &stubEpisodeLibrary{err: medialib.ErrNotFound},
+			errFunc: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runLookup(t.Context(), "/media/shows/Breaking.Bad.S01E01.mkv", tt.stub)
+
+			tt.errFunc(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/workflows/show/show.go
+++ b/workflows/show/show.go
@@ -105,7 +105,7 @@ func NewShowWorkflow(
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
-		return struct{}{}, shared.NotifyWorkflowFailure(ctx, showWorkflowName, input.FilePath, webhookClient)
+		return struct{}{}, shared.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), showWorkflowName, input.FilePath, webhookClient)
 	})
 
 	return wf

--- a/workflows/show/show.go
+++ b/workflows/show/show.go
@@ -2,10 +2,7 @@
 package show
 
 import (
-	"errors"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
@@ -85,7 +82,7 @@ func NewShowWorkflow(
 			return struct{}{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		return struct{}{}, shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir)
+		return struct{}{}, shared.RunTranscode(ctx, input.FilePath, probe.VideoCodec, probe.Format, cfg.OutputDir)
 	}, hatchet.WithParents(probeTask, lookupTask), skipIfInvalid)
 
 	// notify-sonarr: trigger a Sonarr library rescan for the series.
@@ -108,32 +105,7 @@ func NewShowWorkflow(
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
-		stepErrors := ctx.StepRunErrors()
-		if len(stepErrors) == 0 {
-			return struct{}{}, nil
-		}
-
-		steps := make([]string, 0, len(stepErrors))
-		for stepName := range stepErrors {
-			steps = append(steps, stepName)
-		}
-		sort.Strings(steps)
-
-		errs := make([]error, 0, len(stepErrors))
-		for _, stepName := range steps {
-			errs = append(errs, fmt.Errorf("%s: %s", stepName, stepErrors[stepName]))
-		}
-
-		if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
-			Workflow: showWorkflowName,
-			FilePath: input.FilePath,
-			Step:     strings.Join(steps, ", "),
-			Err:      errors.Join(errs...),
-		}); err != nil {
-			return struct{}{}, fmt.Errorf("notify failure: %w", err)
-		}
-
-		return struct{}{}, nil
+		return struct{}{}, shared.NotifyWorkflowFailure(ctx, showWorkflowName, input.FilePath, webhookClient)
 	})
 
 	return wf

--- a/workflows/show/show.go
+++ b/workflows/show/show.go
@@ -1,5 +1,5 @@
-// Package movie provides the Hatchet workflow definition for processing movie files.
-package movie
+// Package show provides the Hatchet workflow definition for processing TV episode files.
+package show
 
 import (
 	"errors"
@@ -16,40 +16,40 @@ import (
 )
 
 const (
-	movieWorkflowName = "MovieWorkflow"
+	showWorkflowName = "ShowWorkflow"
 	// defaultTaskRetries is the number of retry attempts for retriable workflow steps.
 	defaultTaskRetries = 3
 )
 
-// MovieWorkflowConfig holds the configuration for the movie processing workflow.
-type MovieWorkflowConfig struct {
+// ShowWorkflowConfig holds the configuration for the show processing workflow.
+type ShowWorkflowConfig struct {
 	// OutputDir is the local directory where transcoded files are written.
 	OutputDir string
 	// WebhookURL is the endpoint to notify on workflow failure.
 	WebhookURL string
 }
 
-// MovieInput is the workflow's trigger payload.
-type MovieInput struct {
+// ShowInput is the workflow's trigger payload.
+type ShowInput struct {
 	FilePath string `json:"file_path"`
 }
 
-// NewMovieWorkflow returns a Hatchet workflow that transcodes a movie file to the
-// standard format, moves it to the output directory, and notifies Radarr.
+// NewShowWorkflow returns a Hatchet workflow that transcodes a TV episode file to the
+// standard format, moves it to the output directory, and notifies Sonarr.
 //
-// Steps (in order): probe → lookup → transcode → notify-radarr → cleanup.
+// Steps (in order): probe → lookup → transcode → notify-sonarr → cleanup.
 // If the source file is not a valid media file with a video stream the file is
 // deleted and all other steps are skipped without triggering the failure webhook.
-func NewMovieWorkflow(
+func NewShowWorkflow(
 	client *hatchet.Client,
-	cfg MovieWorkflowConfig,
-	radarrClient medialib.MovieLibrary,
+	cfg ShowWorkflowConfig,
+	sonarrClient medialib.EpisodeLibrary,
 	webhookClient *webhook.Client,
 ) *hatchet.Workflow {
 	maxRuns := int32(1)
 	cancelNewest := types.CancelNewest
 
-	wf := client.NewWorkflow(movieWorkflowName,
+	wf := client.NewWorkflow(showWorkflowName,
 		hatchet.WithWorkflowConcurrency(types.Concurrency{
 			Expression:    "input.file_path",
 			MaxRuns:       &maxRuns,
@@ -60,7 +60,7 @@ func NewMovieWorkflow(
 	// probe: read codec/container info. Deletes the file and returns IsValidMedia=false
 	// (without error) when the file is not a recognisable media file or has no video stream,
 	// which causes all downstream steps to be skipped via WithSkipIf.
-	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MovieInput) (shared.ProbeOutput, error) {
+	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input ShowInput) (shared.ProbeOutput, error) {
 		return shared.RunProbe(ctx, input.FilePath)
 	})
 
@@ -70,16 +70,16 @@ func NewMovieWorkflow(
 	// not checked. Verified in hatchet/pkg/repository/trigger.go.
 	skipIfInvalid := hatchet.WithSkipIf(hatchet.ParentCondition(probeTask, "output.is_valid_media == false"))
 
-	// lookup: identify the movie in Radarr; fails with ErrNotFound if unrecognised.
-	lookupTask := wf.NewTask("lookup", func(ctx hatchet.Context, input MovieInput) (lookupOutput, error) {
-		return runLookup(ctx, input.FilePath, radarrClient)
+	// lookup: identify the episode in Sonarr; fails with ErrNotFound if unrecognised.
+	lookupTask := wf.NewTask("lookup", func(ctx hatchet.Context, input ShowInput) (lookupOutput, error) {
+		return runLookup(ctx, input.FilePath, sonarrClient)
 	}, hatchet.WithParents(probeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// transcode: re-encode or copy the video stream directly into cfg.OutputDir under a
 	// temp name, then atomically rename it to the final path. Writing to the output
 	// directory (rather than the system temp dir) means the rename is always within the
 	// same filesystem, so it is guaranteed to be atomic on Linux.
-	transcodeTask := wf.NewTask("transcode", func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
+	transcodeTask := wf.NewTask("transcode", func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
 		var probe shared.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			return struct{}{}, fmt.Errorf("get probe output: %w", err)
@@ -88,26 +88,26 @@ func NewMovieWorkflow(
 		return struct{}{}, shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir)
 	}, hatchet.WithParents(probeTask, lookupTask), skipIfInvalid)
 
-	// notify-radarr: trigger a Radarr library rescan for the movie.
-	notifyTask := wf.NewTask("notify-radarr", func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
+	// notify-sonarr: trigger a Sonarr library rescan for the series.
+	notifyTask := wf.NewTask("notify-sonarr", func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
 		var lu lookupOutput
 		if err := ctx.ParentOutput(lookupTask, &lu); err != nil {
 			return struct{}{}, fmt.Errorf("get lookup output: %w", err)
 		}
 
-		if err := radarrClient.RefreshMovie(ctx, lu.MovieID); err != nil {
-			return struct{}{}, fmt.Errorf("notify radarr: %w", err)
+		if err := sonarrClient.RefreshSeries(ctx, lu.SeriesID); err != nil {
+			return struct{}{}, fmt.Errorf("notify sonarr: %w", err)
 		}
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, lookupTask, transcodeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// cleanup: delete the original source file after successful processing.
-	_ = wf.NewTask("cleanup", func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
+	_ = wf.NewTask("cleanup", func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
 		return struct{}{}, shared.RunCleanup(input.FilePath)
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
-	wf.OnFailure(func(ctx hatchet.Context, input MovieInput) (struct{}, error) {
+	wf.OnFailure(func(ctx hatchet.Context, input ShowInput) (struct{}, error) {
 		stepErrors := ctx.StepRunErrors()
 		if len(stepErrors) == 0 {
 			return struct{}{}, nil
@@ -125,7 +125,7 @@ func NewMovieWorkflow(
 		}
 
 		if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
-			Workflow: movieWorkflowName,
+			Workflow: showWorkflowName,
 			FilePath: input.FilePath,
 			Step:     strings.Join(steps, ", "),
 			Err:      errors.Join(errs...),

--- a/workflows/show/testhelpers_test.go
+++ b/workflows/show/testhelpers_test.go
@@ -1,0 +1,43 @@
+package show
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib"
+)
+
+// testVideoPath points to the small H.264/MP4 clip shared with the ffprobe package.
+const testVideoPath = "../../pkg/ffprobe/testdata/video.mp4"
+
+// copyTestVideo copies the shared test video to a temp file and returns its path.
+// The file is NOT registered for cleanup so tests can verify deletion behaviour.
+func copyTestVideo(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(testVideoPath)
+	require.NoError(t, err)
+
+	dst := filepath.Join(t.TempDir(), "video.mp4")
+	require.NoError(t, os.WriteFile(dst, src, 0o600))
+	return dst
+}
+
+// stubEpisodeLibrary implements medialib.EpisodeLibrary for testing.
+type stubEpisodeLibrary struct {
+	episode      medialib.Episode
+	err          error
+	refreshCalls []int64
+}
+
+func (s *stubEpisodeLibrary) GetEpisodeByFilePath(_ context.Context, _ string) (medialib.Episode, error) {
+	return s.episode, s.err
+}
+
+func (s *stubEpisodeLibrary) RefreshSeries(_ context.Context, seriesID int64) error {
+	s.refreshCalls = append(s.refreshCalls, seriesID)
+	return s.err
+}


### PR DESCRIPTION
## Summary
- Extract shared probe/transcode/cleanup step logic from `workflows/movie` into new `workflows/shared` package (per review feedback)
- Refactor `workflows/movie` to delegate to `workflows/shared` — no behaviour change
- Add `workflows/show`: `ShowWorkflow` mirrors `MovieWorkflow` but uses the Sonarr `EpisodeLibrary` (`GetEpisodeByFilePath` + `RefreshSeries`), with concurrency key on `file_path` (`CancelNewest`, `maxRuns=1`) and sorted step names in `OnFailure`

## Test plan
- [x] Unit tests pass: `workflows/shared` (probe, transcode, cleanup, selectVideoCodec, NotifyWorkflowFailure), `workflows/show` (lookup), `workflows/movie` (lookup)
- [x] Integration tests in `workflows/show/integration_test.go` cover: valid video transcoded + source deleted, `RefreshSeries` called, non-video file deleted (no webhook/downstream), lookup failure causes workflow failure + source preserved
- [x] `make build`, `make lint` clean; `make test` clean except pre-existing `pkg/ffprobe/TestProbe_CancelledContext` failure unrelated to this PR

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)