### PR TITLE
feat(workflows): set English audio and subtitle tracks as default in output

### DIFF
--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -359,15 +359,15 @@ func (t *Transcoder) outputDisposition(inStream *astiav.Stream) astiav.Dispositi
 		defaultStream = t.defaultSubtitleStream
 	}
 
-	if defaultStream != nil {
-		if inStream.Index() == *defaultStream {
-			disp = disp.Add(astiav.DispositionFlagDefault)
-		} else {
-			disp = disp.Del(astiav.DispositionFlagDefault)
-		}
+	if defaultStream == nil {
+		return disp
 	}
 
-	return disp
+	if inStream.Index() == *defaultStream {
+		return disp.Add(astiav.DispositionFlagDefault)
+	}
+
+	return disp.Del(astiav.DispositionFlagDefault)
 }
 
 // readAllPackets is the main decode/encode loop.

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -89,19 +89,19 @@ func (b *TranscodeBuilder) ExcludeStreams(indices ...int) *TranscodeBuilder {
 
 // WithDefaultAudioStream marks the audio stream at the given input stream index
 // as the default audio track in the output. All other audio stream dispositions
-// have their default flag cleared. If not called, audio stream dispositions are
-// copied from the input unchanged.
-func (b *TranscodeBuilder) WithDefaultAudioStream(idx int) *TranscodeBuilder {
-	b.defaultAudioStream = &idx
+// have their default flag cleared. A nil argument is a no-op: audio stream
+// dispositions are copied from the input unchanged.
+func (b *TranscodeBuilder) WithDefaultAudioStream(idx *int) *TranscodeBuilder {
+	b.defaultAudioStream = idx
 	return b
 }
 
 // WithDefaultSubtitleStream marks the subtitle stream at the given input stream
 // index as the default subtitle track in the output. All other subtitle stream
-// dispositions have their default flag cleared. If not called, subtitle stream
-// dispositions are copied from the input unchanged.
-func (b *TranscodeBuilder) WithDefaultSubtitleStream(idx int) *TranscodeBuilder {
-	b.defaultSubtitleStream = &idx
+// dispositions have their default flag cleared. A nil argument is a no-op:
+// subtitle stream dispositions are copied from the input unchanged.
+func (b *TranscodeBuilder) WithDefaultSubtitleStream(idx *int) *TranscodeBuilder {
+	b.defaultSubtitleStream = idx
 	return b
 }
 

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -350,24 +350,23 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, inputFmt *astiav
 // override configured via WithDefaultAudioStream or WithDefaultSubtitleStream.
 func (t *Transcoder) outputDisposition(inStream *astiav.Stream) astiav.DispositionFlags {
 	disp := inStream.DispositionFlags()
+
+	var defaultStream *int
 	switch inStream.CodecParameters().MediaType() {
 	case astiav.MediaTypeAudio:
-		if t.defaultAudioStream != nil {
-			if inStream.Index() == *t.defaultAudioStream {
-				disp = disp.Add(astiav.DispositionFlagDefault)
-			} else {
-				disp = disp.Del(astiav.DispositionFlagDefault)
-			}
-		}
+		defaultStream = t.defaultAudioStream
 	case astiav.MediaTypeSubtitle:
-		if t.defaultSubtitleStream != nil {
-			if inStream.Index() == *t.defaultSubtitleStream {
-				disp = disp.Add(astiav.DispositionFlagDefault)
-			} else {
-				disp = disp.Del(astiav.DispositionFlagDefault)
-			}
+		defaultStream = t.defaultSubtitleStream
+	}
+
+	if defaultStream != nil {
+		if inStream.Index() == *defaultStream {
+			disp = disp.Add(astiav.DispositionFlagDefault)
+		} else {
+			disp = disp.Del(astiav.DispositionFlagDefault)
 		}
 	}
+
 	return disp
 }
 

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -18,6 +18,8 @@ type TranscodeBuilder struct {
 	progressCh            chan<- Progress
 	startHook             func()
 	excludeStreams        map[int]bool
+	defaultAudioStream    *int // input stream index to mark as default audio; nil = preserve input dispositions
+	defaultSubtitleStream *int // input stream index to mark as default subtitle; nil = preserve input dispositions
 }
 
 // NewTranscode returns a builder for a transcode job from inputPath to outputPath.
@@ -82,6 +84,24 @@ func (b *TranscodeBuilder) ExcludeStreams(indices ...int) *TranscodeBuilder {
 	for _, idx := range indices {
 		b.excludeStreams[idx] = true
 	}
+	return b
+}
+
+// WithDefaultAudioStream marks the audio stream at the given input stream index
+// as the default audio track in the output. All other audio stream dispositions
+// have their default flag cleared. If not called, audio stream dispositions are
+// copied from the input unchanged.
+func (b *TranscodeBuilder) WithDefaultAudioStream(idx int) *TranscodeBuilder {
+	b.defaultAudioStream = &idx
+	return b
+}
+
+// WithDefaultSubtitleStream marks the subtitle stream at the given input stream
+// index as the default subtitle track in the output. All other subtitle stream
+// dispositions have their default flag cleared. If not called, subtitle stream
+// dispositions are copied from the input unchanged.
+func (b *TranscodeBuilder) WithDefaultSubtitleStream(idx int) *TranscodeBuilder {
+	b.defaultSubtitleStream = &idx
 	return b
 }
 
@@ -284,6 +304,9 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, inputFmt *astiav
 		}
 		s.setOutputStream(outStream)
 
+		// Copy disposition from the input stream and apply any default-flag overrides.
+		outStream.SetDispositionFlags(t.outputDisposition(inStream))
+
 		if encCtx := s.encoderContext(); encCtx != nil {
 			// Re-encoded stream: populate output parameters from the encoder.
 			if err := outStream.CodecParameters().FromCodecContext(encCtx); err != nil {
@@ -320,6 +343,32 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, inputFmt *astiav
 	}
 
 	return outputFmt, closeIO, nil
+}
+
+// outputDisposition computes the disposition flags for an output stream by
+// copying from the corresponding input stream and applying any default-flag
+// override configured via WithDefaultAudioStream or WithDefaultSubtitleStream.
+func (t *Transcoder) outputDisposition(inStream *astiav.Stream) astiav.DispositionFlags {
+	disp := inStream.DispositionFlags()
+	switch inStream.CodecParameters().MediaType() {
+	case astiav.MediaTypeAudio:
+		if t.defaultAudioStream != nil {
+			if inStream.Index() == *t.defaultAudioStream {
+				disp = disp.Add(astiav.DispositionFlagDefault)
+			} else {
+				disp = disp.Del(astiav.DispositionFlagDefault)
+			}
+		}
+	case astiav.MediaTypeSubtitle:
+		if t.defaultSubtitleStream != nil {
+			if inStream.Index() == *t.defaultSubtitleStream {
+				disp = disp.Add(astiav.DispositionFlagDefault)
+			} else {
+				disp = disp.Del(astiav.DispositionFlagDefault)
+			}
+		}
+	}
+	return disp
 }
 
 // readAllPackets is the main decode/encode loop.

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -300,7 +300,7 @@ func TestTranscode_WithDefaultAudioStream(t *testing.T) {
 			output := filepath.Join(t.TempDir(), "out.mkv")
 			require.NoError(t, ffmpeg.NewTranscode(testVideoPath, output).
 				ToContainer(ffmpeg.ContainerMKV).
-				WithDefaultAudioStream(tt.audioIdx).
+				WithDefaultAudioStream(&tt.audioIdx).
 				Build().
 				Run(t.Context()))
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -7,12 +7,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asticode/go-astiav"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
 	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
+
+// probeStreamDispositions opens a media file and returns a map of stream index
+// to DispositionFlags by reading stream metadata via go-astiav directly.
+// This is used in tests because ffprobe.StreamInfo does not expose disposition.
+func probeStreamDispositions(t *testing.T, path string) map[int]astiav.DispositionFlags {
+	t.Helper()
+	fmtCtx := astiav.AllocFormatContext()
+	require.NotNil(t, fmtCtx, "failed to allocate format context")
+	defer fmtCtx.Free()
+	require.NoError(t, fmtCtx.OpenInput(path, nil, nil))
+	defer fmtCtx.CloseInput()
+	require.NoError(t, fmtCtx.FindStreamInfo(nil))
+	result := make(map[int]astiav.DispositionFlags)
+	for _, s := range fmtCtx.Streams() {
+		result[s.Index()] = s.DispositionFlags()
+	}
+	return result
+}
 
 // testVideoPath is the shared input file for all transcode tests.
 const testVideoPath = "../../pkg/ffprobe/testdata/video.mp4"
@@ -234,6 +253,70 @@ func TestTranscode_ExcludeStreams(t *testing.T) {
 	}
 	assert.Equal(t, len(inputInfo.Streams)-1, len(outputInfo.Streams),
 		"output must have one fewer stream than the input")
+}
+
+// TestTranscode_DispositionPreserved verifies that input stream dispositions
+// are copied to output streams unchanged when no WithDefault* setter is called.
+func TestTranscode_DispositionPreserved(t *testing.T) {
+	inputDisps := probeStreamDispositions(t, testVideoPath)
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	require.NoError(t, ffmpeg.NewTranscode(testVideoPath, output).
+		ToContainer(ffmpeg.ContainerMKV).
+		Build().
+		Run(t.Context()))
+
+	outputDisps := probeStreamDispositions(t, output)
+	require.Len(t, outputDisps, len(inputDisps), "stream count must match")
+	for idx, inputDisp := range inputDisps {
+		assert.Equal(t, inputDisp, outputDisps[idx],
+			"stream %d: disposition must be preserved from input", idx)
+	}
+}
+
+// TestTranscode_WithDefaultAudioStream verifies that WithDefaultAudioStream
+// marks the specified audio stream as default and clears the flag from all
+// other audio streams.
+func TestTranscode_WithDefaultAudioStream(t *testing.T) {
+	// Test fixture (video.mp4): stream 0 = video, stream 1 = audio (both default=1 in input).
+	tests := []struct {
+		name        string
+		audioIdx    int
+		wantDefault bool
+	}{
+		{
+			name:        "specified audio stream index is marked default",
+			audioIdx:    1, // audio stream index in test fixture
+			wantDefault: true,
+		},
+		{
+			name:        "audio stream loses default when a different index is designated",
+			audioIdx:    999, // nonexistent; stream 1 is the only audio and loses its default
+			wantDefault: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := filepath.Join(t.TempDir(), "out.mkv")
+			require.NoError(t, ffmpeg.NewTranscode(testVideoPath, output).
+				ToContainer(ffmpeg.ContainerMKV).
+				WithDefaultAudioStream(tt.audioIdx).
+				Build().
+				Run(t.Context()))
+
+			outInfo, err := ffprobe.Probe(t.Context(), output)
+			require.NoError(t, err)
+			disps := probeStreamDispositions(t, output)
+
+			for _, s := range outInfo.Streams {
+				if s.CodecType == ffprobe.CodecTypeAudio {
+					assert.Equal(t, tt.wantDefault,
+						disps[s.Index].Has(astiav.DispositionFlagDefault),
+						"audio stream %d: default disposition mismatch", s.Index)
+				}
+			}
+		})
+	}
 }
 
 // TestDetectHardwareEncoders_ValidResult verifies that DetectHardwareEncoders

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -62,16 +62,16 @@ func nonEnglishSubtitleIndices(streams []StreamInfo) []int {
 	return exclude
 }
 
-// firstEnglishIndex returns the input stream Index of the first StreamInfo
-// element tagged "eng". The second return value is false when no English stream
-// is found.
-func firstEnglishIndex(streams []StreamInfo) (int, bool) {
+// firstEnglishIndex returns a pointer to the input stream Index of the first
+// StreamInfo element tagged "eng", or nil when no English stream is found.
+func firstEnglishIndex(streams []StreamInfo) *int {
 	for _, s := range streams {
 		if s.Language == "eng" {
-			return s.Index, true
+			idx := s.Index
+			return &idx
 		}
 	}
-	return 0, false
+	return nil
 }
 
 // RunTranscode transcodes filePath into outputDir, writing to a temp file named
@@ -93,11 +93,11 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
 		ExcludeStreams(excludeIndices...)
-	if idx, ok := firstEnglishIndex(probe.AudioStreams); ok {
-		builder = builder.WithDefaultAudioStream(idx)
+	if idx := firstEnglishIndex(probe.AudioStreams); idx != nil {
+		builder = builder.WithDefaultAudioStream(*idx)
 	}
-	if idx, ok := firstEnglishIndex(probe.SubtitleStreams); ok {
-		builder = builder.WithDefaultSubtitleStream(idx)
+	if idx := firstEnglishIndex(probe.SubtitleStreams); idx != nil {
+		builder = builder.WithDefaultSubtitleStream(*idx)
 	}
 
 	if err := builder.Build().Run(ctx); err != nil {

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -67,8 +67,7 @@ func nonEnglishSubtitleIndices(streams []StreamInfo) []int {
 func firstEnglishIndex(streams []StreamInfo) *int {
 	for _, s := range streams {
 		if s.Language == "eng" {
-			idx := s.Index
-			return &idx
+			return &s.Index
 		}
 	}
 	return nil
@@ -89,18 +88,14 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	tempPath := filepath.Join(outputDir, "._"+mkvBase+".tmp")
 	finalPath := filepath.Join(outputDir, mkvBase)
 
-	builder := ffmpeg.NewTranscode(filePath, tempPath).
+	if err := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
-		ExcludeStreams(excludeIndices...)
-	if idx := firstEnglishIndex(probe.AudioStreams); idx != nil {
-		builder = builder.WithDefaultAudioStream(*idx)
-	}
-	if idx := firstEnglishIndex(probe.SubtitleStreams); idx != nil {
-		builder = builder.WithDefaultSubtitleStream(*idx)
-	}
-
-	if err := builder.Build().Run(ctx); err != nil {
+		ExcludeStreams(excludeIndices...).
+		WithDefaultAudioStream(firstEnglishIndex(probe.AudioStreams)).
+		WithDefaultSubtitleStream(firstEnglishIndex(probe.SubtitleStreams)).
+		Build().
+		Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return errors.Join(
 				fmt.Errorf("transcode: %w", err),

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -65,9 +65,9 @@ func nonEnglishSubtitleIndices(streams []StreamInfo) []int {
 // firstEnglishIndex returns a pointer to the input stream Index of the first
 // StreamInfo element tagged "eng", or nil when no English stream is found.
 func firstEnglishIndex(streams []StreamInfo) *int {
-	for _, s := range streams {
-		if s.Language == "eng" {
-			return &s.Index
+	for _, stream := range streams {
+		if stream.Language == "eng" {
+			return &stream.Index
 		}
 	}
 	return nil

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -62,6 +62,18 @@ func nonEnglishSubtitleIndices(streams []StreamInfo) []int {
 	return exclude
 }
 
+// firstEnglishIndex returns the input stream Index of the first StreamInfo
+// element tagged "eng". The second return value is false when no English stream
+// is found.
+func firstEnglishIndex(streams []StreamInfo) (int, bool) {
+	for _, s := range streams {
+		if s.Language == "eng" {
+			return s.Index, true
+		}
+	}
+	return 0, false
+}
+
 // RunTranscode transcodes filePath into outputDir, writing to a temp file named
 // "._<stem>.mkv.tmp" and atomically renaming it to "<stem>.mkv" on success.
 // The output always carries a .mkv extension to match the forced MKV container.
@@ -77,12 +89,18 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	tempPath := filepath.Join(outputDir, "._"+mkvBase+".tmp")
 	finalPath := filepath.Join(outputDir, mkvBase)
 
-	if err := ffmpeg.NewTranscode(filePath, tempPath).
+	builder := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
-		ExcludeStreams(excludeIndices...).
-		Build().
-		Run(ctx); err != nil {
+		ExcludeStreams(excludeIndices...)
+	if idx, ok := firstEnglishIndex(probe.AudioStreams); ok {
+		builder = builder.WithDefaultAudioStream(idx)
+	}
+	if idx, ok := firstEnglishIndex(probe.SubtitleStreams); ok {
+		builder = builder.WithDefaultSubtitleStream(idx)
+	}
+
+	if err := builder.Build().Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return errors.Join(
 				fmt.Errorf("transcode: %w", err),

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -166,11 +166,11 @@ func TestNonEnglishSubtitleIndices(t *testing.T) {
 }
 
 func TestFirstEnglishIndex(t *testing.T) {
+	intPtr := func(i int) *int { return &i }
 	tests := []struct {
-		name      string
-		streams   []StreamInfo
-		wantIdx   int
-		wantFound bool
+		name    string
+		streams []StreamInfo
+		want    *int
 	}{
 		{
 			name: "first eng stream is returned when multiple languages are present",
@@ -179,42 +179,37 @@ func TestFirstEnglishIndex(t *testing.T) {
 				{Index: 3, Language: "eng"},
 				{Index: 4, Language: "eng"},
 			},
-			wantIdx:   3,
-			wantFound: true,
+			want: intPtr(3),
 		},
 		{
-			name:      "single eng stream is returned",
-			streams:   []StreamInfo{{Index: 5, Language: "eng"}},
-			wantIdx:   5,
-			wantFound: true,
+			name:    "single eng stream is returned",
+			streams: []StreamInfo{{Index: 5, Language: "eng"}},
+			want:    intPtr(5),
 		},
 		{
-			name: "no eng stream returns not found",
+			name: "no eng stream returns nil",
 			streams: []StreamInfo{
 				{Index: 1, Language: "jpn"},
 				{Index: 2, Language: "fra"},
 			},
-			wantFound: false,
+			want: nil,
 		},
 		{
-			name:      "empty slice returns not found",
-			streams:   nil,
-			wantFound: false,
+			name:    "empty slice returns nil",
+			streams: nil,
+			want:    nil,
 		},
 		{
-			name:      "untagged stream is not treated as English",
-			streams:   []StreamInfo{{Index: 1, Language: ""}},
-			wantFound: false,
+			name:    "untagged stream is not treated as English",
+			streams: []StreamInfo{{Index: 1, Language: ""}},
+			want:    nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIdx, gotFound := firstEnglishIndex(tt.streams)
-			assert.Equal(t, tt.wantFound, gotFound)
-			if tt.wantFound {
-				assert.Equal(t, tt.wantIdx, gotIdx)
-			}
+			got := firstEnglishIndex(tt.streams)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -165,6 +165,60 @@ func TestNonEnglishSubtitleIndices(t *testing.T) {
 	}
 }
 
+func TestFirstEnglishIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		streams   []StreamInfo
+		wantIdx   int
+		wantFound bool
+	}{
+		{
+			name: "first eng stream is returned when multiple languages are present",
+			streams: []StreamInfo{
+				{Index: 2, Language: "jpn"},
+				{Index: 3, Language: "eng"},
+				{Index: 4, Language: "eng"},
+			},
+			wantIdx:   3,
+			wantFound: true,
+		},
+		{
+			name:      "single eng stream is returned",
+			streams:   []StreamInfo{{Index: 5, Language: "eng"}},
+			wantIdx:   5,
+			wantFound: true,
+		},
+		{
+			name: "no eng stream returns not found",
+			streams: []StreamInfo{
+				{Index: 1, Language: "jpn"},
+				{Index: 2, Language: "fra"},
+			},
+			wantFound: false,
+		},
+		{
+			name:      "empty slice returns not found",
+			streams:   nil,
+			wantFound: false,
+		},
+		{
+			name:      "untagged stream is not treated as English",
+			streams:   []StreamInfo{{Index: 1, Language: ""}},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIdx, gotFound := firstEnglishIndex(tt.streams)
+			assert.Equal(t, tt.wantFound, gotFound)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantIdx, gotIdx)
+			}
+		})
+	}
+}
+
 func TestRunTranscode(t *testing.T) {
 	// The fixture video has one audio stream (index 1) tagged "und" (undefined
 	// language). nonEnglishAudioIndices returns nil when no "eng" stream is


### PR DESCRIPTION
Fixes #35

## Summary

- Extends `TranscodeBuilder` with `WithDefaultAudioStream(idx *int)` and `WithDefaultSubtitleStream(idx *int)` methods; a nil argument is a no-op so callers can pass the result of `firstEnglishIndex` directly
- Fixes a pre-existing bug where output stream dispositions were always zeroed (input dispositions not copied); now all streams copy their input disposition before any override is applied
- Adds a `firstEnglishIndex` helper to `workflows/shared` and wires it into `RunTranscode` so the first English audio/subtitle stream is designated as default; no-op when no English stream exists

## Test plan

- [ ] `TestTranscode_DispositionPreserved` — input dispositions copied to output unchanged when no setter is called
- [ ] `TestTranscode_WithDefaultAudioStream` — specified stream gets default flag; other audio streams have it cleared
- [ ] `TestFirstEnglishIndex` — correct stream index selected across all language-tag combinations
- [ ] All existing tests still pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)