### PR TITLE
feat(watcher): expose scan and dispatch metrics

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -44,14 +44,7 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("HATCHET_CLIENT_TOKEN is not set")
 	}
 
-	var metricsOpts []metrics.Option
-	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
-		metricsOpts = append(metricsOpts, metrics.WithMetricsAddr(addr))
-	}
-	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		metricsOpts = append(metricsOpts, metrics.WithOTLPEndpoint(endpoint))
-	}
-	metricsProvider, err := metrics.New(ctx, metricsOpts...)
+	metricsProvider, err := metrics.NewFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("init metrics: %w", err)
 	}

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
@@ -44,17 +43,11 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("HATCHET_CLIENT_TOKEN is not set")
 	}
 
-	metricsProvider, err := metrics.NewFromEnv(ctx)
+	metricsProvider, shutdown, err := metrics.NewFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("init metrics: %w", err)
 	}
-	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := metricsProvider.Shutdown(shutdownCtx); err != nil {
-			log.Printf("metrics shutdown error: %v", err)
-		}
-	}()
+	defer shutdown()
 
 	client, err := hatchet.NewClient()
 	if err != nil {

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+
+	"github.com/solidDoWant/media-processor/pkg/metrics"
 )
 
 func main() {
@@ -41,6 +44,25 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("HATCHET_CLIENT_TOKEN is not set")
 	}
 
+	var metricsOpts []metrics.Option
+	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
+		metricsOpts = append(metricsOpts, metrics.WithMetricsAddr(addr))
+	}
+	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		metricsOpts = append(metricsOpts, metrics.WithOTLPEndpoint(endpoint))
+	}
+	metricsProvider, err := metrics.New(ctx, metricsOpts...)
+	if err != nil {
+		return fmt.Errorf("init metrics: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := metricsProvider.Shutdown(shutdownCtx); err != nil {
+			log.Printf("metrics shutdown error: %v", err)
+		}
+	}()
+
 	client, err := hatchet.NewClient()
 	if err != nil {
 		return fmt.Errorf("connect to Hatchet: %w", err)
@@ -48,7 +70,10 @@ func run(ctx context.Context, configPath string) error {
 
 	log.Println("connected to Hatchet")
 
-	scanWorkflow := NewScanWorkflow(client, cfg)
+	scanWorkflow, err := NewScanWorkflow(client, cfg, metricsProvider.MeterProvider())
+	if err != nil {
+		return fmt.Errorf("create scan workflow: %w", err)
+	}
 
 	worker, err := client.NewWorker("mediaprocessor-watcher",
 		hatchet.WithWorkflows(scanWorkflow),

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -7,16 +7,94 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/workflows/media"
 )
 
+func mappingNameAttr(name string) attribute.KeyValue {
+	return attribute.String("mapping_name", name)
+}
+
+func mediaTypeAttr(mt medialib.MediaType) attribute.KeyValue {
+	return attribute.String("media_type", string(mt))
+}
+
+func statusAttr(status string) attribute.KeyValue {
+	return attribute.String("status", status)
+}
+
 // dispatchFunc submits a workflow run for the given absolute file path, media type, and mapping name.
 type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string) error
+
+// scanInstruments holds all OTel instruments used during scan. Instruments are registered
+// once at startup and reused across every scan invocation.
+type scanInstruments struct {
+	scansTotal           otelmetric.Int64Counter
+	scanDuration         otelmetric.Float64Histogram
+	lastSuccessfulScan   otelmetric.Float64Gauge
+	filesDiscoveredTotal otelmetric.Int64Counter
+	dispatchesTotal      otelmetric.Int64Counter
+	dispatchErrorsTotal  otelmetric.Int64Counter
+}
+
+// newScanInstruments registers all watcher scan instruments with the given MeterProvider.
+func newScanInstruments(mp otelmetric.MeterProvider) (*scanInstruments, error) {
+	meter := mp.Meter("github.com/solidDoWant/media-processor/cmd/watcher")
+
+	scansTotal, err := meter.Int64Counter("watcher_scans_total",
+		otelmetric.WithDescription("Total number of per-mapping directory scans completed."))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_scans_total: %w", err)
+	}
+
+	scanDuration, err := meter.Float64Histogram("watcher_scan_duration_seconds",
+		otelmetric.WithDescription("Wall-clock duration of each per-mapping directory walk in seconds."),
+		otelmetric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_scan_duration_seconds: %w", err)
+	}
+
+	lastSuccessfulScan, err := meter.Float64Gauge("watcher_last_successful_scan_unix_seconds",
+		otelmetric.WithDescription("Unix timestamp of the most recent successful per-mapping scan."),
+		otelmetric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_last_successful_scan_unix_seconds: %w", err)
+	}
+
+	filesDiscoveredTotal, err := meter.Int64Counter("watcher_files_discovered_total",
+		otelmetric.WithDescription("Total number of files found during directory scans."))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_files_discovered_total: %w", err)
+	}
+
+	dispatchesTotal, err := meter.Int64Counter("watcher_dispatches_total",
+		otelmetric.WithDescription("Total number of workflow dispatches successfully submitted to Hatchet."))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_dispatches_total: %w", err)
+	}
+
+	dispatchErrorsTotal, err := meter.Int64Counter("watcher_dispatch_errors_total",
+		otelmetric.WithDescription("Total number of workflow dispatch failures."))
+	if err != nil {
+		return nil, fmt.Errorf("create watcher_dispatch_errors_total: %w", err)
+	}
+
+	return &scanInstruments{
+		scansTotal:           scansTotal,
+		scanDuration:         scanDuration,
+		lastSuccessfulScan:   lastSuccessfulScan,
+		filesDiscoveredTotal: filesDiscoveredTotal,
+		dispatchesTotal:      dispatchesTotal,
+		dispatchErrorsTotal:  dispatchErrorsTotal,
+	}, nil
+}
 
 // NewScanWorkflow returns a Hatchet standalone task that scans all configured watch
 // directories on the configured cron schedule and spawns a child workflow run for
@@ -24,11 +102,16 @@ type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.
 //
 // Overlapping scans are dropped (CANCEL_NEWEST, max 1 concurrent run) so a slow
 // scan does not pile up behind a cron backlog.
-func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTask {
+func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterProvider) (*hatchet.StandaloneTask, error) {
 	maxRuns := int32(1)
 	strategy := types.CancelNewest
 
-	return client.NewStandaloneTask(
+	instruments, err := newScanInstruments(mp)
+	if err != nil {
+		return nil, fmt.Errorf("register scan metrics: %w", err)
+	}
+
+	task := client.NewStandaloneTask(
 		"directory-scan",
 		func(ctx hatchet.Context, _ struct{}) (struct{}, error) {
 			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string) error {
@@ -44,7 +127,7 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTas
 				)
 				return err
 			}
-			return struct{}{}, scan(ctx, cfg, dispatch)
+			return struct{}{}, scan(ctx, cfg, instruments, dispatch)
 		},
 		hatchet.WithWorkflowCron(string(cfg.CronSchedule)),
 		hatchet.WithWorkflowConcurrency(types.Concurrency{
@@ -54,6 +137,7 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config) *hatchet.StandaloneTas
 			LimitStrategy: &strategy,
 		}),
 	)
+	return task, nil
 }
 
 // validateWatchDirs returns an error listing every configured watch directory that does
@@ -82,7 +166,7 @@ func validateWatchDirs(cfg *Config) error {
 // per-file errors (access errors and dispatch errors) are collected and returned as an
 // aggregate so a single failure does not abort the scan. The walk respects ctx
 // cancellation and returns immediately on shutdown.
-func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
+func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispatch dispatchFunc) error {
 	var errs []error
 
 	for _, w := range cfg.Watches {
@@ -90,13 +174,20 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 			return err
 		}
 
+		mappingAttr := otelmetric.WithAttributes(
+			mappingNameAttr(w.Name),
+		)
+
+		var mappingErrs []error
+		start := time.Now()
+
 		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return ctxErr
 			}
 
 			if err != nil {
-				errs = append(errs, fmt.Errorf("scan error at %q: %w", path, err))
+				mappingErrs = append(mappingErrs, fmt.Errorf("scan error at %q: %w", path, err))
 				return nil
 			}
 
@@ -106,12 +197,20 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 
 			absPath, err := filepath.Abs(path)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("resolve absolute path for %q: %w", path, err))
+				mappingErrs = append(mappingErrs, fmt.Errorf("resolve absolute path for %q: %w", path, err))
 				return nil
 			}
 
+			instruments.filesDiscoveredTotal.Add(ctx, 1,
+				otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
+
 			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name); dispatchErr != nil {
-				errs = append(errs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
+				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
+				instruments.dispatchErrorsTotal.Add(ctx, 1,
+					otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
+			} else {
+				instruments.dispatchesTotal.Add(ctx, 1,
+					otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
 			}
 
 			return nil
@@ -120,7 +219,20 @@ func scan(ctx context.Context, cfg *Config, dispatch dispatchFunc) error {
 				return err
 			}
 
-			errs = append(errs, fmt.Errorf("walk directory %q: %w", w.Path, err))
+			mappingErrs = append(mappingErrs, fmt.Errorf("walk directory %q: %w", w.Path, err))
+		}
+
+		duration := time.Since(start).Seconds()
+		instruments.scanDuration.Record(ctx, duration, mappingAttr)
+
+		if len(mappingErrs) == 0 {
+			instruments.scansTotal.Add(ctx, 1,
+				otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr("success")))
+			instruments.lastSuccessfulScan.Record(ctx, float64(time.Now().Unix()), mappingAttr)
+		} else {
+			instruments.scansTotal.Add(ctx, 1,
+				otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr("error")))
+			errs = append(errs, mappingErrs...)
 		}
 	}
 

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -44,9 +44,12 @@ type scanInstruments struct {
 	dispatchErrorsTotal  otelmetric.Int64Counter
 }
 
+// meterName is the OTel instrumentation scope name for this package.
+const meterName = "github.com/solidDoWant/media-processor/cmd/watcher"
+
 // newScanInstruments registers all watcher scan instruments with the given MeterProvider.
 func newScanInstruments(mp otelmetric.MeterProvider) (*scanInstruments, error) {
-	meter := mp.Meter("github.com/solidDoWant/media-processor/cmd/watcher")
+	meter := mp.Meter(meterName)
 
 	scansTotal, err := meter.Int64Counter("watcher_scans_total",
 		otelmetric.WithDescription("Total number of per-mapping directory scans completed."))

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -47,6 +47,12 @@ type scanInstruments struct {
 // meterName is the OTel instrumentation scope name for this package.
 const meterName = "github.com/solidDoWant/media-processor/cmd/watcher"
 
+// scan status label values used with watcher_scans_total.
+const (
+	scanStatusSuccess = "success"
+	scanStatusError   = "error"
+)
+
 // newScanInstruments registers all watcher scan instruments with the given MeterProvider.
 func newScanInstruments(mp otelmetric.MeterProvider) (*scanInstruments, error) {
 	meter := mp.Meter(meterName)
@@ -177,9 +183,12 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 			return err
 		}
 
-		mappingAttr := otelmetric.WithAttributes(
-			mappingNameAttr(w.Name),
-		)
+		// Precompute attribute option sets once per watch entry to avoid repeated
+		// allocation inside the WalkDir callback (one set per file found).
+		mappingOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name))
+		fileOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType))
+		successOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr(scanStatusSuccess))
+		errorOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr(scanStatusError))
 
 		var mappingErrs []error
 		start := time.Now()
@@ -204,16 +213,13 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				return nil
 			}
 
-			instruments.filesDiscoveredTotal.Add(ctx, 1,
-				otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
+			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
 
 			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
-				instruments.dispatchErrorsTotal.Add(ctx, 1,
-					otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
+				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)
 			} else {
-				instruments.dispatchesTotal.Add(ctx, 1,
-					otelmetric.WithAttributes(mappingNameAttr(w.Name), mediaTypeAttr(w.MediaType)))
+				instruments.dispatchesTotal.Add(ctx, 1, fileOpt)
 			}
 
 			return nil
@@ -226,15 +232,13 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 		}
 
 		duration := time.Since(start).Seconds()
-		instruments.scanDuration.Record(ctx, duration, mappingAttr)
+		instruments.scanDuration.Record(ctx, duration, mappingOpt)
 
 		if len(mappingErrs) == 0 {
-			instruments.scansTotal.Add(ctx, 1,
-				otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr("success")))
-			instruments.lastSuccessfulScan.Record(ctx, float64(time.Now().Unix()), mappingAttr)
+			instruments.scansTotal.Add(ctx, 1, successOpt)
+			instruments.lastSuccessfulScan.Record(ctx, float64(time.Now().Unix()), mappingOpt)
 		} else {
-			instruments.scansTotal.Add(ctx, 1,
-				otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr("error")))
+			instruments.scansTotal.Add(ctx, 1, errorOpt)
 			errs = append(errs, mappingErrs...)
 		}
 	}

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -9,9 +9,76 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 )
+
+// noopInstruments returns a scanInstruments backed by a no-op MeterProvider.
+func noopInstruments(t *testing.T) *scanInstruments {
+	t.Helper()
+	inst, err := newScanInstruments(noop.NewMeterProvider())
+	require.NoError(t, err)
+	return inst
+}
+
+// newTestInstruments returns a scanInstruments backed by a ManualReader so metric
+// values can be inspected in acceptance tests.
+func newTestInstruments(t *testing.T) (*scanInstruments, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	inst, err := newScanInstruments(provider)
+	require.NoError(t, err)
+	return inst, reader
+}
+
+// collectMetrics gathers all current metric data from the reader.
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	return rm
+}
+
+// findMetric returns the first Metrics entry whose Name matches name, or nil.
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+// attrKey converts a label name to an OTel attribute.Key for use in test assertions.
+func attrKey(name string) attribute.Key { return attribute.Key(name) }
+
+// findCounterDP returns the int64 sum data point whose attributes match the given
+// mapping_name (and optionally status/media_type), or nil if not found.
+func findCounterDP(dps []metricdata.DataPoint[int64], attrs map[string]string) *metricdata.DataPoint[int64] {
+	for i := range dps {
+		match := true
+		for k, v := range attrs {
+			val, ok := dps[i].Attributes.Value(attrKey(k))
+			if !ok || val.AsString() != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return &dps[i]
+		}
+	}
+	return nil
+}
 
 // TestValidateWatchDirs verifies that validateWatchDirs returns a descriptive error
 // when a configured watch directory does not exist, and succeeds when all dirs are present.
@@ -109,7 +176,7 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 		return nil
 	}
 
-	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
 	require.Len(t, calls, 1)
 	assert.Equal(t, filePath, calls[0].filePath)
 	assert.Equal(t, medialib.MovieType, calls[0].mediaType)
@@ -139,7 +206,7 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 		return nil
 	}
 
-	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
 	require.Len(t, dispatched, 1)
 	assert.Equal(t, filePath, dispatched[0])
 }
@@ -165,7 +232,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 		return errors.New("simulated dispatch failure")
 	}
 
-	require.Error(t, scan(t.Context(), cfg, dispatch))
+	require.Error(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
 	assert.Equal(t, 2, count)
 }
 
@@ -187,7 +254,7 @@ func TestScan_ContextCancellationStopsWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately before scan starts
 
-	err := scan(ctx, cfg, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil })
+	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil })
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -214,8 +281,259 @@ func TestScan_MultipleWatchEntries(t *testing.T) {
 		return nil
 	}
 
-	require.NoError(t, scan(t.Context(), cfg, dispatch))
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
 
 	assert.Equal(t, medialib.MovieType, dispatched[filepath.Join(movieDir, "movie.mkv")])
 	assert.Equal(t, medialib.ShowType, dispatched[filepath.Join(showDir, "show.mkv")])
+}
+
+// TestScan_MetricsPresenceAfterScan verifies that watcher_scans_total,
+// watcher_scan_duration_seconds, and watcher_last_successful_scan_unix_seconds are
+// all present in the metric output after at least one scan has completed.
+func TestScan_MetricsPresenceAfterScan(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+
+	for _, name := range []string{
+		"watcher_scans_total",
+		"watcher_scan_duration_seconds",
+		"watcher_last_successful_scan_unix_seconds",
+	} {
+		assert.NotNil(t, findMetric(rm, name), "expected metric %q to be present", name)
+	}
+}
+
+// TestScan_SuccessCounterIncrements verifies that watcher_scans_total{status="success",
+// mapping_name="..."} increments by 1 when a mapping's walk completes without errors.
+func TestScan_SuccessCounterIncrements(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_scans_total")
+	require.NotNil(t, m, "watcher_scans_total should be present")
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	dp := findCounterDP(sum.DataPoints, map[string]string{"mapping_name": "movies", "status": "success"})
+	require.NotNil(t, dp, "expected data point with mapping_name=movies status=success")
+	assert.EqualValues(t, 1, dp.Value)
+}
+
+// TestScan_ErrorCounterIncrements verifies that watcher_scans_total{status="error",
+// mapping_name="..."} increments when a mapping's walk or dispatch produces at least one error.
+func TestScan_ErrorCounterIncrements(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
+		return errors.New("simulated dispatch failure")
+	})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_scans_total")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	dp := findCounterDP(sum.DataPoints, map[string]string{"mapping_name": "movies", "status": "error"})
+	require.NotNil(t, dp, "expected data point with mapping_name=movies status=error")
+	assert.EqualValues(t, 1, dp.Value)
+}
+
+// TestScan_DurationObservedPerMapping verifies that watcher_scan_duration_seconds
+// records one observation per mapping, labelled with mapping_name.
+func TestScan_DurationObservedPerMapping(t *testing.T) {
+	t.Parallel()
+
+	movieDir := t.TempDir()
+	showDir := t.TempDir()
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: movieDir, MediaType: medialib.MovieType},
+			{Name: "shows", Path: showDir, MediaType: medialib.ShowType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_scan_duration_seconds")
+	require.NotNil(t, m)
+
+	h, ok := m.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, h.DataPoints, 2, "expected one histogram data point per mapping")
+
+	mappingNames := make(map[string]bool)
+	for _, dp := range h.DataPoints {
+		val, ok := dp.Attributes.Value(attrKey("mapping_name"))
+		require.True(t, ok, "mapping_name label should be present")
+		mappingNames[val.AsString()] = true
+		assert.EqualValues(t, 1, dp.Count, "each mapping should have exactly one observation")
+	}
+	assert.True(t, mappingNames["movies"])
+	assert.True(t, mappingNames["shows"])
+}
+
+// TestScan_LastSuccessfulScanSetOnSuccess verifies that watcher_last_successful_scan_unix_seconds
+// is set to a non-zero Unix timestamp after a successful mapping scan.
+func TestScan_LastSuccessfulScanSetOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_last_successful_scan_unix_seconds")
+	require.NotNil(t, m)
+
+	g, ok := m.Data.(metricdata.Gauge[float64])
+	require.True(t, ok)
+	require.Len(t, g.DataPoints, 1)
+	assert.Greater(t, g.DataPoints[0].Value, float64(0), "last successful scan timestamp should be non-zero")
+}
+
+// TestScan_FilesDiscoveredCounter verifies that watcher_files_discovered_total increments
+// by the number of files found, with correct mapping_name and media_type labels.
+func TestScan_FilesDiscoveredCounter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.mkv"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_files_discovered_total")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	dp := findCounterDP(sum.DataPoints, map[string]string{
+		"mapping_name": "movies",
+		"media_type":   string(medialib.MovieType),
+	})
+	require.NotNil(t, dp, "expected data point with mapping_name=movies media_type=movie")
+	assert.EqualValues(t, 2, dp.Value)
+}
+
+// TestScan_DispatchesTotalCounter verifies that watcher_dispatches_total increments by 1
+// per successful dispatch with correct mapping_name and media_type labels.
+func TestScan_DispatchesTotalCounter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_dispatches_total")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	dp := findCounterDP(sum.DataPoints, map[string]string{
+		"mapping_name": "movies",
+		"media_type":   string(medialib.MovieType),
+	})
+	require.NotNil(t, dp, "expected data point with mapping_name=movies media_type=movie")
+	assert.EqualValues(t, 1, dp.Value)
+}
+
+// TestScan_DispatchErrorsCounter verifies that watcher_dispatch_errors_total increments
+// by 1 when a dispatch call to Hatchet fails, with correct labels.
+func TestScan_DispatchErrorsCounter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	instruments, reader := newTestInstruments(t)
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
+		return errors.New("hatchet unavailable")
+	})
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "watcher_dispatch_errors_total")
+	require.NotNil(t, m)
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	dp := findCounterDP(sum.DataPoints, map[string]string{
+		"mapping_name": "movies",
+		"media_type":   string(medialib.MovieType),
+	})
+	require.NotNil(t, dp, "expected data point with mapping_name=movies media_type=movie")
+	assert.EqualValues(t, 1, dp.Value)
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -30,14 +30,7 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	var metricsOpts []metrics.Option
-	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
-		metricsOpts = append(metricsOpts, metrics.WithMetricsAddr(addr))
-	}
-	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		metricsOpts = append(metricsOpts, metrics.WithOTLPEndpoint(endpoint))
-	}
-	metricsProvider, err := metrics.New(ctx, metricsOpts...)
+	metricsProvider, err := metrics.NewFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("init metrics: %w", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
@@ -30,17 +29,11 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	metricsProvider, err := metrics.NewFromEnv(ctx)
+	metricsProvider, shutdown, err := metrics.NewFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("init metrics: %w", err)
 	}
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := metricsProvider.Shutdown(ctx); err != nil {
-			log.Printf("metrics shutdown error: %v", err)
-		}
-	}()
+	defer shutdown()
 
 	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
 		return fmt.Errorf("HATCHET_CLIENT_TOKEN is not set")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -140,7 +140,10 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 // METRICS_ADDR enables the Prometheus /metrics pull endpoint.
 // OTEL_EXPORTER_OTLP_ENDPOINT enables OTLP gRPC push export.
 // If neither variable is set, a no-op Provider is returned.
-func NewFromEnv(ctx context.Context) (*Provider, error) {
+//
+// The returned shutdown func must be deferred by the caller. It shuts down all
+// exporters with a 10-second deadline and writes any error to stderr.
+func NewFromEnv(ctx context.Context) (*Provider, func(), error) {
 	var opts []Option
 	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
 		opts = append(opts, WithMetricsAddr(addr))
@@ -148,5 +151,16 @@ func NewFromEnv(ctx context.Context) (*Provider, error) {
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
 		opts = append(opts, WithOTLPEndpoint(endpoint))
 	}
-	return New(ctx, opts...)
+	p, err := New(ctx, opts...)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := p.Shutdown(shutdownCtx); err != nil {
+			fmt.Fprintf(os.Stderr, "metrics shutdown error: %v\n", err)
+		}
+	}
+	return p, shutdown, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -135,3 +135,18 @@ func (p *Provider) MeterProvider() otelmetric.MeterProvider {
 func (p *Provider) Shutdown(ctx context.Context) error {
 	return p.shutdown(ctx)
 }
+
+// NewFromEnv creates a Provider using standard environment variables.
+// METRICS_ADDR enables the Prometheus /metrics pull endpoint.
+// OTEL_EXPORTER_OTLP_ENDPOINT enables OTLP gRPC push export.
+// If neither variable is set, a no-op Provider is returned.
+func NewFromEnv(ctx context.Context) (*Provider, error) {
+	var opts []Option
+	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
+		opts = append(opts, WithMetricsAddr(addr))
+	}
+	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		opts = append(opts, WithOTLPEndpoint(endpoint))
+	}
+	return New(ctx, opts...)
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -160,9 +160,15 @@ func TestNewFromEnv_OTLPEndpoint_CreatesProvider(t *testing.T) {
 	t.Setenv("METRICS_ADDR", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+l.Addr().String())
 
-	p, shutdown, err := metrics.NewFromEnv(t.Context())
+	// Use p.Shutdown with a short deadline rather than the fixed-10s shutdown func
+	// so the test does not block for the full flush timeout against a dummy listener.
+	p, _, err := metrics.NewFromEnv(t.Context())
 	require.NoError(t, err)
-	t.Cleanup(shutdown)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
 	require.NotNil(t, p.MeterProvider())
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -133,11 +133,10 @@ func TestNewFromEnv_NoEnvVars_ReturnsNoopProvider(t *testing.T) {
 	t.Setenv("METRICS_ADDR", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 
-	p, err := metrics.NewFromEnv(t.Context())
+	p, shutdown, err := metrics.NewFromEnv(t.Context())
 	require.NoError(t, err)
+	t.Cleanup(shutdown)
 	require.NotNil(t, p.MeterProvider())
-
-	require.NoError(t, p.Shutdown(t.Context()))
 }
 
 func TestNewFromEnv_MetricsAddr_StartsPrometheusEndpoint(t *testing.T) {
@@ -145,13 +144,10 @@ func TestNewFromEnv_MetricsAddr_StartsPrometheusEndpoint(t *testing.T) {
 	t.Setenv("METRICS_ADDR", addr)
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 
-	p, err := metrics.NewFromEnv(t.Context())
+	p, shutdown, err := metrics.NewFromEnv(t.Context())
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = p.Shutdown(ctx) //nolint:errcheck
-	})
+	t.Cleanup(shutdown)
+	require.NotNil(t, p)
 
 	resp, err := (&http.Client{Timeout: 5 * time.Second}).Get("http://" + addr + "/metrics") //nolint:noctx
 	require.NoError(t, err)
@@ -164,13 +160,10 @@ func TestNewFromEnv_OTLPEndpoint_CreatesProvider(t *testing.T) {
 	t.Setenv("METRICS_ADDR", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+l.Addr().String())
 
-	p, err := metrics.NewFromEnv(t.Context())
+	p, shutdown, err := metrics.NewFromEnv(t.Context())
 	require.NoError(t, err)
+	t.Cleanup(shutdown)
 	require.NotNil(t, p.MeterProvider())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_ = p.Shutdown(ctx)
 }
 
 func TestGracefulShutdown_FlushesOTLP(t *testing.T) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -129,6 +129,50 @@ func TestBothExporters_Active(t *testing.T) {
 	require.NotNil(t, mp)
 }
 
+func TestNewFromEnv_NoEnvVars_ReturnsNoopProvider(t *testing.T) {
+	t.Setenv("METRICS_ADDR", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+
+	p, err := metrics.NewFromEnv(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, p.MeterProvider())
+
+	require.NoError(t, p.Shutdown(t.Context()))
+}
+
+func TestNewFromEnv_MetricsAddr_StartsPrometheusEndpoint(t *testing.T) {
+	addr := freeAddr(t)
+	t.Setenv("METRICS_ADDR", addr)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+
+	p, err := metrics.NewFromEnv(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx) //nolint:errcheck
+	})
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Get("http://" + addr + "/metrics") //nolint:noctx
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewFromEnv_OTLPEndpoint_CreatesProvider(t *testing.T) {
+	l := bindListener(t)
+	t.Setenv("METRICS_ADDR", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+l.Addr().String())
+
+	p, err := metrics.NewFromEnv(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, p.MeterProvider())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = p.Shutdown(ctx)
+}
+
 func TestGracefulShutdown_FlushesOTLP(t *testing.T) {
 	l := bindListener(t)
 


### PR DESCRIPTION
Instruments the watcher process with OTel metrics using the same `pkg/metrics` infrastructure and environment variables (`METRICS_ADDR`, `OTEL_EXPORTER_OTLP_ENDPOINT`) as the worker.

## Changes

- **`cmd/watcher/main.go`**: Initializes a `pkg/metrics.Provider` at startup, defers `Shutdown`, passes `MeterProvider` to `NewScanWorkflow`.
- **`cmd/watcher/watcher.go`**: Adds `scanInstruments` struct with 6 instruments registered once at startup; updates `NewScanWorkflow` to accept a `MeterProvider`; updates `scan()` to record per-mapping timing, status, file counts, and dispatch outcomes.
- **`cmd/watcher/watcher_test.go`**: Updates existing `scan()` calls to pass noop instruments; adds 8 new acceptance tests backed by `sdkmetric.ManualReader`.

Fixes #60