### PR TITLE
chore(lint): fix all wsl_v5 whitespace violations

### DIFF
--- a/cmd/watcher/config_test.go
+++ b/cmd/watcher/config_test.go
@@ -184,5 +184,6 @@ func writeTempConfig(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
 	return path
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	configPath := flag.String("config", "config.yaml", "path to watcher config file")
+
 	flag.Parse()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -134,8 +134,10 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterPro
 					},
 					hatchet.WithRunKey(filePath),
 				)
+
 				return err
 			}
+
 			return struct{}{}, scan(ctx, cfg, instruments, dispatch)
 		},
 		hatchet.WithWorkflowCron(string(cfg.CronSchedule)),
@@ -146,6 +148,7 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterPro
 			LimitStrategy: &strategy,
 		}),
 	)
+
 	return task, nil
 }
 
@@ -191,6 +194,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 		errorOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr(scanStatusError))
 
 		var mappingErrs []error
+
 		start := time.Now()
 
 		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
@@ -217,6 +221,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
+
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)
 			} else {
 				instruments.dispatchesTotal.Add(ctx, 1, fileOpt)
@@ -239,6 +244,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 			instruments.lastSuccessfulScan.Record(ctx, float64(time.Now().Unix()), mappingOpt)
 		} else {
 			instruments.scansTotal.Add(ctx, 1, errorOpt)
+
 			errs = append(errs, mappingErrs...)
 		}
 	}

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -20,8 +20,10 @@ import (
 // noopInstruments returns a scanInstruments backed by a no-op MeterProvider.
 func noopInstruments(t *testing.T) *scanInstruments {
 	t.Helper()
+
 	inst, err := newScanInstruments(noop.NewMeterProvider())
 	require.NoError(t, err)
+
 	return inst
 }
 
@@ -29,20 +31,25 @@ func noopInstruments(t *testing.T) *scanInstruments {
 // values can be inspected in acceptance tests.
 func newTestInstruments(t *testing.T) (*scanInstruments, *sdkmetric.ManualReader) {
 	t.Helper()
+
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
 	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
 
 	inst, err := newScanInstruments(provider)
 	require.NoError(t, err)
+
 	return inst, reader
 }
 
 // collectMetrics gathers all current metric data from the reader.
 func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
 	t.Helper()
+
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
+
 	return rm
 }
 
@@ -55,6 +62,7 @@ func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics 
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -66,6 +74,7 @@ func attrKey(name string) attribute.Key { return attribute.Key(name) }
 func findCounterDP(dps []metricdata.DataPoint[int64], attrs map[string]string) *metricdata.DataPoint[int64] {
 	for i := range dps {
 		match := true
+
 		for k, v := range attrs {
 			val, ok := dps[i].Attributes.Value(attrKey(k))
 			if !ok || val.AsString() != v {
@@ -73,10 +82,12 @@ func findCounterDP(dps []metricdata.DataPoint[int64], attrs map[string]string) *
 				break
 			}
 		}
+
 		if match {
 			return &dps[i]
 		}
 	}
+
 	return nil
 }
 
@@ -133,6 +144,7 @@ func TestValidateWatchDirs(t *testing.T) {
 				f, err := os.CreateTemp(t.TempDir(), "notadir")
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
+
 				return &Config{Watches: []WatchEntry{{Name: "movies", Path: f.Name(), MediaType: medialib.MovieType}}}
 			}(),
 			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
@@ -170,7 +182,9 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 		mediaType   medialib.MediaType
 		mappingName string
 	}
+
 	var calls []call
+
 	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string) error {
 		calls = append(calls, call{fp, mt, mn})
 		return nil
@@ -201,6 +215,7 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 	}
 
 	var dispatched []string
+
 	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string) error {
 		dispatched = append(dispatched, fp)
 		return nil
@@ -227,6 +242,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 	}
 
 	var count int
+
 	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
 		count++
 		return errors.New("simulated dispatch failure")
@@ -403,12 +419,16 @@ func TestScan_DurationObservedPerMapping(t *testing.T) {
 	require.Len(t, h.DataPoints, 2, "expected one histogram data point per mapping")
 
 	mappingNames := make(map[string]bool)
+
 	for _, dp := range h.DataPoints {
 		val, ok := dp.Attributes.Value(attrKey("mapping_name"))
 		require.True(t, ok, "mapping_name label should be present")
+
 		mappingNames[val.AsString()] = true
+
 		assert.EqualValues(t, 1, dp.Count, "each mapping should have exactly one observation")
 	}
+
 	assert.True(t, mappingNames["movies"])
 	assert.True(t, mappingNames["shows"])
 }

--- a/internal/watcherconfig/validate.go
+++ b/internal/watcherconfig/validate.go
@@ -27,9 +27,11 @@ func NewValidator() *validator.Validate {
 	if err := v.RegisterValidation("mediatype", validateMediaType); err != nil {
 		panic("failed to register validation \"mediatype\": " + err.Error())
 	}
+
 	if err := v.RegisterValidation("hatchetcron", validateHatchetCron); err != nil {
 		panic("failed to register validation \"hatchetcron\": " + err.Error())
 	}
+
 	return v
 }
 
@@ -41,6 +43,7 @@ func validateMediaType(fl validator.FieldLevel) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/pkg/ffmpeg/log.go
+++ b/pkg/ffmpeg/log.go
@@ -14,10 +14,12 @@ func init() {
 	astiav.SetLogCallback(func(_ astiav.Classer, l astiav.LogLevel, _, msg string) {
 		ctx := context.Background()
 		logger := slog.Default()
+
 		level := astiavLevelToSlog(l)
 		if !logger.Enabled(ctx, level) {
 			return
 		}
+
 		logger.Log(ctx, level, strings.TrimRight(msg, "\n"), "source", "ffmpeg")
 	})
 }

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -42,6 +42,7 @@ func (sd *streamDecoderState) free() {
 	if sd.codecContext != nil {
 		sd.codecContext.Free()
 	}
+
 	if sd.frame != nil {
 		sd.frame.Free()
 	}
@@ -82,6 +83,7 @@ func (css *copyStreamState) receiveAndWritePackets(encCtx *astiav.CodecContext, 
 			if errors.Is(err, astiav.ErrEof) || errors.Is(err, astiav.ErrEagain) {
 				return nil
 			}
+
 			return fmt.Errorf("ffmpeg: receiving encoded packet: %w", err)
 		}
 
@@ -97,6 +99,7 @@ func (css *copyStreamState) receiveAndWritePackets(encCtx *astiav.CodecContext, 
 			encPkt.Unref()
 			return fmt.Errorf("ffmpeg: writing encoded packet: %w", err)
 		}
+
 		encPkt.Unref()
 	}
 }
@@ -116,6 +119,7 @@ func remuxPacket(packet *astiav.Packet, inStream, outStream *astiav.Stream, outp
 // sendProgress emits a non-blocking progress update on ch.
 func sendProgress(ch chan<- Progress, frames int64, packet *astiav.Packet, outStream *astiav.Stream, totalDuration int64) {
 	var percentComplete float64
+
 	if totalDuration > 0 {
 		tb := outStream.TimeBase()
 		ptsInMicros := float64(packet.Pts()) * float64(tb.Num()) / float64(tb.Den()) * 1e6

--- a/pkg/ffmpeg/stream_audio.go
+++ b/pkg/ffmpeg/stream_audio.go
@@ -80,6 +80,7 @@ func (ass *audioStreamState) setupDecoder(inStream *astiav.Stream) error {
 	if err := ass.decoder.codecContext.Open(ass.decoder.codec, nil); err != nil {
 		return fmt.Errorf("opening decoder: %w", err)
 	}
+
 	ass.decoder.codecContext.SetTimeBase(inStream.TimeBase())
 
 	ass.decoder.frame = astiav.AllocFrame()
@@ -114,6 +115,7 @@ func (ass *audioStreamState) setupEncoder(_ HWAccel, outputFmt *astiav.FormatCon
 			}
 		}
 	}
+
 	ass.encoder.codecContext.SetSampleRate(sampleRate)
 
 	// Determine channel layout: if a target is requested, prefer it; then the
@@ -122,6 +124,7 @@ func (ass *audioStreamState) setupEncoder(_ HWAccel, outputFmt *astiav.FormatCon
 	if ass.encoder.targetChannelLayout != nil {
 		channelLayout = *ass.encoder.targetChannelLayout
 	}
+
 	if layouts := ass.encoder.codec.SupportedChannelLayouts(); len(layouts) > 0 {
 		supported := slices.ContainsFunc(layouts, func(layout astiav.ChannelLayout) bool {
 			return layout.Equal(channelLayout)
@@ -143,6 +146,7 @@ func (ass *audioStreamState) setupEncoder(_ HWAccel, outputFmt *astiav.FormatCon
 			}
 		}
 	}
+
 	ass.encoder.codecContext.SetChannelLayout(channelLayout)
 
 	// Prefer the decoder's sample format if the encoder supports it;
@@ -155,6 +159,7 @@ func (ass *audioStreamState) setupEncoder(_ HWAccel, outputFmt *astiav.FormatCon
 			sampleFormat = fmts[0]
 		}
 	}
+
 	ass.encoder.codecContext.SetSampleFormat(sampleFormat)
 
 	ass.encoder.codecContext.SetTimeBase(astiav.NewRational(1, ass.encoder.codecContext.SampleRate()))
@@ -222,6 +227,7 @@ func (ass *audioStreamState) setupEncoder(_ HWAccel, outputFmt *astiav.FormatCon
 			if nbSamples <= 0 {
 				nbSamples = 1024
 			}
+
 			ass.encoder.frame.SetNbSamples(nbSamples)
 
 			if err := ass.encoder.frame.AllocBuffer(0); err != nil {
@@ -299,6 +305,7 @@ func (ass *audioStreamState) encodeAudioFrame(frame *astiav.Frame, outputFmt *as
 				ass.encoder.frame.SetSampleFormat(ass.encoder.codecContext.SampleFormat())
 				ass.encoder.frame.SetSampleRate(ass.encoder.codecContext.SampleRate())
 			}
+
 			return fmt.Errorf("ffmpeg: writing to audio FIFO: %w", err)
 		}
 
@@ -338,6 +345,7 @@ func (ass *audioStreamState) drainFifo(outputFmt *astiav.FormatContext, progress
 		if err := ass.encoder.fifoFrame.MakeWritable(); err != nil {
 			return fmt.Errorf("ffmpeg: making FIFO frame writable: %w", err)
 		}
+
 		if _, err := ass.encoder.fifo.Read(ass.encoder.fifoFrame); err != nil {
 			return fmt.Errorf("ffmpeg: reading from audio FIFO: %w", err)
 		}
@@ -350,6 +358,7 @@ func (ass *audioStreamState) drainFifo(outputFmt *astiav.FormatContext, progress
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -384,6 +393,7 @@ func (ass *audioStreamState) flush(outputFmt *astiav.FormatContext, progressCh c
 			// Flush any samples remaining in the resampler's internal delay buffer.
 			if err := ass.encoder.resampleContext.ConvertFrame(nil, ass.encoder.frame); err != nil {
 				ass.encoder.frame.Unref()
+
 				if !errors.Is(err, astiav.ErrEagain) && !errors.Is(err, astiav.ErrEof) {
 					return fmt.Errorf("ffmpeg: flushing resampled audio: %w", err)
 				}
@@ -392,6 +402,7 @@ func (ass *audioStreamState) flush(outputFmt *astiav.FormatContext, progressCh c
 					ass.encoder.frame.Unref()
 					return fmt.Errorf("ffmpeg: writing flushed resampled audio to FIFO: %w", err)
 				}
+
 				ass.encoder.frame.Unref()
 				ass.encoder.frame.SetChannelLayout(ass.encoder.codecContext.ChannelLayout())
 				ass.encoder.frame.SetSampleFormat(ass.encoder.codecContext.SampleFormat())
@@ -409,22 +420,27 @@ func (ass *audioStreamState) flush(outputFmt *astiav.FormatContext, progressCh c
 			if err := ass.encoder.fifoFrame.MakeWritable(); err != nil {
 				return fmt.Errorf("ffmpeg: making tail FIFO frame writable: %w", err)
 			}
+
 			ass.encoder.fifoFrame.SetNbSamples(frameSize)
+
 			if err := ass.encoder.fifoFrame.SamplesFillSilence(); err != nil {
 				return fmt.Errorf("ffmpeg: zeroing tail audio frame: %w", err)
 			}
 			// Read only the remaining samples so they land at the start of the
 			// silence-padded buffer.
 			ass.encoder.fifoFrame.SetNbSamples(remaining)
+
 			if _, err := ass.encoder.fifo.Read(ass.encoder.fifoFrame); err != nil {
 				return fmt.Errorf("ffmpeg: reading tail samples from audio FIFO: %w", err)
 			}
 			// Restore full frame size so the encoder receives a complete frame.
 			ass.encoder.fifoFrame.SetNbSamples(frameSize)
 			ass.encoder.fifoFrame.SetPts(ass.encoder.nextPts)
+
 			if err := ass.encoder.codecContext.SendFrame(ass.encoder.fifoFrame); err != nil {
 				return fmt.Errorf("ffmpeg: sending tail audio frame to encoder: %w", err)
 			}
+
 			if err := ass.receiveAndWritePackets(ass.encoder.codecContext, ass.encoder.packet, outputFmt, progressCh, totalDuration); err != nil {
 				return err
 			}

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -104,6 +104,7 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 			return fmt.Errorf("no decoder for codec ID %v", inStream.CodecParameters().CodecID())
 		}
 	}
+
 	vss.decoder.codec = codec
 
 	vss.decoder.codecContext = astiav.AllocCodecContext(codec)
@@ -132,8 +133,10 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 				slog.Debug("ffmpeg: preferred hardware pixel format not offered by decoder, using fallback",
 					"preferred", vss.decoder.hwPixFmt, "fallback", pixelFormats[0])
 				vss.decoder.hwPixFmt = pixelFormats[0]
+
 				return pixelFormats[0]
 			}
+
 			return astiav.PixelFormatNone
 		})
 	}
@@ -141,6 +144,7 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 	if err := vss.decoder.codecContext.Open(codec, nil); err != nil {
 		return fmt.Errorf("opening decoder: %w", err)
 	}
+
 	vss.decoder.codecContext.SetTimeBase(inStream.TimeBase())
 
 	vss.decoder.frame = astiav.AllocFrame()
@@ -158,6 +162,7 @@ func (vss *videoStreamState) setupEncoder(hwAccel HWAccel, outputFmt *astiav.For
 	if err != nil {
 		return err
 	}
+
 	vss.encoder.codec = codec
 	vss.encoder.usesHardwareAccelerator = supportsHardwareAcceleration
 
@@ -193,6 +198,7 @@ func (vss *videoStreamState) selectVideoEncoder(hwAccel HWAccel) (enc *astiav.Co
 				if err != nil {
 					slog.Debug("ffmpeg: hardware encoder device context creation failed, falling back to software",
 						"encoder", hwEncName, "error", err)
+
 					hwDevCtx = nil
 				}
 			}
@@ -202,6 +208,7 @@ func (vss *videoStreamState) selectVideoEncoder(hwAccel HWAccel) (enc *astiav.Co
 					// Newly created — store so free() releases it via dec.free().
 					vss.decoder.hwDevCtx = hwDevCtx
 				}
+
 				return astiav.FindEncoderByName(hwEncName), p, true, nil
 			}
 		}
@@ -260,11 +267,14 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 		// Software path: prefer YUV420P; fall back to the encoder's first
 		// supported format if it does not support YUV420P.
 		encPixFmt := astiav.PixelFormatYuv420P
+
 		fmts := enc.SupportedPixelFormats()
 		if len(fmts) > 0 && !slices.Contains(fmts, astiav.PixelFormatYuv420P) {
 			encPixFmt = fmts[0]
 		}
+
 		vss.encoder.codecContext.SetPixelFormat(encPixFmt)
+
 		return nil
 	}
 
@@ -273,6 +283,7 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt {
 		vss.isHWDecode = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
+
 		return nil
 	}
 
@@ -280,8 +291,10 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	if err := vss.setupHWFramesContext(profile); err != nil {
 		return err
 	}
+
 	vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 	vss.encoder.codecContext.SetHardwareFramesContext(vss.encoder.hardwareFrameContext)
+
 	return nil
 }
 
@@ -292,14 +305,17 @@ func (vss *videoStreamState) setupHWFramesContext(profile hwProfile) error {
 	if vss.encoder.hardwareFrameContext == nil {
 		return errors.New("failed to allocate hardware frames context")
 	}
+
 	vss.encoder.hardwareFrameContext.SetHardwarePixelFormat(profile.hwPixFmt)
 	vss.encoder.hardwareFrameContext.SetSoftwarePixelFormat(profile.swPixFmt)
 	vss.encoder.hardwareFrameContext.SetWidth(vss.decoder.codecContext.Width())
 	vss.encoder.hardwareFrameContext.SetHeight(vss.decoder.codecContext.Height())
 	vss.encoder.hardwareFrameContext.SetInitialPoolSize(20)
+
 	if err := vss.encoder.hardwareFrameContext.Initialize(); err != nil {
 		return fmt.Errorf("initializing hardware frames context: %w", err)
 	}
+
 	return nil
 }
 
@@ -339,6 +355,7 @@ func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
 		if err != nil {
 			return fmt.Errorf("creating software scale context: %w", err)
 		}
+
 		vss.encoder.softwareFrameContext = softwareFrameContext
 
 		vss.encoder.frame = astiav.AllocFrame()
@@ -360,6 +377,7 @@ func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
 		if vss.encoder.frame == nil {
 			return errors.New("failed to allocate hardware frame")
 		}
+
 		if err := vss.encoder.frame.AllocHardwareBuffer(vss.encoder.hardwareFrameContext); err != nil {
 			return fmt.Errorf("allocating hardware frame buffer: %w", err)
 		}
@@ -407,6 +425,7 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 			if err := vss.encoder.softwareFrameContext.ScaleFrame(frame, vss.encoder.frame); err != nil {
 				return fmt.Errorf("ffmpeg: scaling video frame: %w", err)
 			}
+
 			vss.encoder.frame.SetPts(frame.Pts())
 			vss.encoder.frame.SetPictureType(astiav.PictureTypeNone)
 			encFrame = vss.encoder.frame
@@ -417,6 +436,7 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 			if err := encFrame.TransferHardwareData(vss.encoder.frame); err != nil {
 				return fmt.Errorf("ffmpeg: uploading frame to hardware: %w", err)
 			}
+
 			vss.encoder.frame.SetPts(encFrame.Pts())
 			vss.encoder.frame.SetPictureType(astiav.PictureTypeNone)
 			encFrame = vss.encoder.frame

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -97,9 +97,11 @@ func (b *TranscodeBuilder) ExcludeStreams(indices ...int) *TranscodeBuilder {
 	if b.excludeStreams == nil {
 		b.excludeStreams = make(map[int]bool)
 	}
+
 	for _, idx := range indices {
 		b.excludeStreams[idx] = true
 	}
+
 	return b
 }
 
@@ -129,7 +131,9 @@ func (b *TranscodeBuilder) WithAudioStreamTitles(titles map[int]string) *Transco
 	if titles == nil {
 		return b
 	}
+
 	b.audioStreamTitles = titles
+
 	return b
 }
 
@@ -141,7 +145,9 @@ func (b *TranscodeBuilder) WithSubtitleStreamTitles(titles map[int]string) *Tran
 	if titles == nil {
 		return b
 	}
+
 	b.subtitleStreamTitles = titles
+
 	return b
 }
 
@@ -163,7 +169,9 @@ func (b *TranscodeBuilder) WithDownmixTitle(title string) *TranscodeBuilder {
 	if title == "" {
 		return b
 	}
+
 	b.downmixTitle = title
+
 	return b
 }
 
@@ -255,6 +263,7 @@ func (t *Transcoder) resolveHWAccel() HWAccel {
 	if t.hwAccel != HWAccelAuto {
 		return t.hwAccel
 	}
+
 	return GetHardwareEncoder(t.videoCodec, HWAccelAuto)
 }
 
@@ -275,21 +284,25 @@ func (t *Transcoder) openInputContext(ctx context.Context) (*astiav.FormatContex
 	cancelWatch := func() {
 		close(watchDone)
 	}
+
 	go func() {
 		select {
 		case <-ctx.Done():
 			interrupter.Interrupt()
 		case <-watchDone:
 		}
+
 		interrupter.Free()
 	}()
 
 	if err := inputFmt.OpenInput(t.inputPath, nil, nil); err != nil {
 		cancelWatch()
 		inputFmt.Free()
+
 		if ctx.Err() != nil {
 			return nil, nil, nil, ctx.Err()
 		}
+
 		return nil, nil, nil, fmt.Errorf("ffmpeg: opening input %q: %w", t.inputPath, err)
 	}
 
@@ -297,9 +310,11 @@ func (t *Transcoder) openInputContext(ctx context.Context) (*astiav.FormatContex
 		cancelWatch()
 		inputFmt.CloseInput()
 		inputFmt.Free()
+
 		if ctx.Err() != nil {
 			return nil, nil, nil, ctx.Err()
 		}
+
 		return nil, nil, nil, fmt.Errorf("ffmpeg: finding stream info: %w", err)
 	}
 
@@ -314,7 +329,9 @@ func (t *Transcoder) buildDownmixState(inputFmt *astiav.FormatContext, sourceIdx
 		if inStream.Index() != sourceIdx {
 			continue
 		}
+
 		layout2Point1 := astiav.ChannelLayout2Point1
+
 		state := &audioStreamState{
 			copyStreamState: copyStreamState{inStream: inStream},
 			encoder: audioEncoderState{
@@ -325,8 +342,10 @@ func (t *Transcoder) buildDownmixState(inputFmt *astiav.FormatContext, sourceIdx
 		if err := state.setupDecoder(inStream); err != nil {
 			return nil, fmt.Errorf("ffmpeg: setting up downmix decoder for stream %d: %w", sourceIdx, err)
 		}
+
 		return state, nil
 	}
+
 	return nil, fmt.Errorf("ffmpeg: downmix source stream %d not found in input", sourceIdx)
 }
 
@@ -350,6 +369,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 		base := copyStreamState{inStream: inStream}
 
 		var s stream
+
 		switch {
 		case mediaType == astiav.MediaTypeVideo && t.videoCodec != CodecCopy:
 			videoState := &videoStreamState{copyStreamState: base, encoder: videoEncoderState{codecID: t.videoCodec}, hardwareDevicePath: t.hardwareDevicePath}
@@ -357,6 +377,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 				freeStreams(streams)
 				return nil, fmt.Errorf("ffmpeg: setting up decoder for stream %d: %w", inStream.Index(), err)
 			}
+
 			s = videoState
 		case mediaType == astiav.MediaTypeAudio && t.audioCodec != CodecCopy:
 			audioState := &audioStreamState{copyStreamState: base, encoder: audioEncoderState{codecID: t.audioCodec}}
@@ -364,6 +385,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 				freeStreams(streams)
 				return nil, fmt.Errorf("ffmpeg: setting up decoder for stream %d: %w", inStream.Index(), err)
 			}
+
 			s = audioState
 		default:
 			s = &copyStreamState{inStream: inStream}
@@ -386,6 +408,7 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 	if err != nil {
 		return nil, noopClose, fmt.Errorf("ffmpeg: allocating output format context: %w", err)
 	}
+
 	if outputFmt == nil {
 		return nil, noopClose, errors.New("ffmpeg: nil output format context")
 	}
@@ -407,6 +430,7 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 			outputFmt.Free()
 			return nil, noopClose, errors.New("ffmpeg: failed to create output stream")
 		}
+
 		s.setOutputStream(outStream)
 
 		// Copy disposition from the input stream and apply any default-flag overrides.
@@ -418,6 +442,7 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 				outputFmt.Free()
 				return nil, noopClose, fmt.Errorf("ffmpeg: updating codec parameters for stream %d: %w", inStream.Index(), err)
 			}
+
 			outStream.SetTimeBase(encCtx.TimeBase())
 		} else {
 			// Copy stream: copy parameters from the input stream.
@@ -439,8 +464,10 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 				if err := titleDict.Set("title", title, astiav.NewDictionaryFlags()); err != nil {
 					titleDict.Free()
 					outputFmt.Free()
+
 					return nil, noopClose, fmt.Errorf("ffmpeg: setting title metadata for stream %d: %w", inStream.Index(), err)
 				}
+
 				outStream.SetMetadata(titleDict)
 			}
 		}
@@ -452,8 +479,10 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 				if err := titleDict.Set("title", title, astiav.NewDictionaryFlags()); err != nil {
 					titleDict.Free()
 					outputFmt.Free()
+
 					return nil, noopClose, fmt.Errorf("ffmpeg: setting title metadata for stream %d: %w", inStream.Index(), err)
 				}
+
 				outStream.SetMetadata(titleDict)
 			}
 		}
@@ -471,63 +500,78 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 			outputFmt.Free()
 			return nil, noopClose, errors.New("ffmpeg: failed to create downmix output stream")
 		}
+
 		downmix.setOutputStream(downmixOut)
 
 		if err := downmixOut.CodecParameters().FromCodecContext(downmix.encoderContext()); err != nil {
 			outputFmt.Free()
 			return nil, noopClose, fmt.Errorf("ffmpeg: updating codec parameters for downmix stream: %w", err)
 		}
+
 		downmixOut.SetTimeBase(downmix.encoderContext().TimeBase())
 
 		// Set default disposition only if no regular audio stream is already default.
 		hasDefaultAudio := false
+
 		for _, inStream := range inputFmt.Streams() {
 			if inStream.CodecParameters().MediaType() != astiav.MediaTypeAudio {
 				continue
 			}
+
 			if _, ok := streams[inStream.Index()]; !ok {
 				continue
 			}
+
 			if t.outputDisposition(inStream).Has(astiav.DispositionFlagDefault) {
 				hasDefaultAudio = true
 				break
 			}
 		}
+
 		downmixDisp := astiav.DispositionFlags(0)
 		if !hasDefaultAudio {
 			downmixDisp = downmixDisp.Add(astiav.DispositionFlagDefault)
 		}
+
 		downmixOut.SetDispositionFlags(downmixDisp)
 
 		// Build metadata dict for the downmix stream: inherit language from the
 		// source stream and optionally derive the title from the encoder layout.
 		downmixMeta := astiav.NewDictionary()
+
 		if meta := downmix.inStream.Metadata(); meta != nil {
 			if srcLang := meta.Get("language", nil, astiav.NewDictionaryFlags()); srcLang != nil {
 				if err := downmixMeta.Set("language", srcLang.Value(), astiav.NewDictionaryFlags()); err != nil {
 					downmixMeta.Free()
 					outputFmt.Free()
+
 					return nil, noopClose, fmt.Errorf("ffmpeg: setting language metadata for downmix stream: %w", err)
 				}
 			}
 		}
+
 		if t.autoDownmixTitle {
 			channelLabel := channelLayoutLabel(downmix.encoderContext().ChannelLayout())
+
 			title := channelLabel
 			if t.downmixTitle != "" {
 				title = t.downmixTitle + " " + channelLabel
 			}
+
 			if err := downmixMeta.Set("title", title, astiav.NewDictionaryFlags()); err != nil {
 				downmixMeta.Free()
 				outputFmt.Free()
+
 				return nil, noopClose, fmt.Errorf("ffmpeg: setting title metadata for downmix stream: %w", err)
 			}
 		}
+
 		downmixOut.SetMetadata(downmixMeta)
 	}
 
 	// Open the IO context for file-based output formats.
 	closeIO := noopClose
+
 	if !outputFmt.OutputFormat().Flags().Has(astiav.IOFormatFlagNofile) {
 		ioCtx, err := astiav.OpenIOContext(t.outputPath, astiav.NewIOContextFlags(astiav.IOContextFlagWrite), nil, nil)
 		if err != nil {
@@ -536,6 +580,7 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 		}
 
 		closeIO = func() { _ = ioCtx.Close() }
+
 		outputFmt.SetPb(ioCtx)
 	}
 
@@ -549,6 +594,7 @@ func (t *Transcoder) outputDisposition(inStream *astiav.Stream) astiav.Dispositi
 	disp := inStream.DispositionFlags()
 
 	var defaultStream *int
+
 	switch inStream.CodecParameters().MediaType() {
 	case astiav.MediaTypeAudio:
 		defaultStream = t.defaultAudioStream
@@ -599,14 +645,18 @@ func (t *Transcoder) readAllPackets(ctx context.Context, inputFmt, outputFmt *as
 				packet.Unref()
 				return fmt.Errorf("ffmpeg: cloning packet for downmix: %w", err)
 			}
+
 			if dmErr := downmix.processPacket(downmixPkt, outputFmt, t.progressCh, totalDuration); dmErr != nil {
 				downmixPkt.Unref()
 				packet.Unref()
+
 				if interrupter.Interrupted() {
 					return ctx.Err()
 				}
+
 				return dmErr
 			}
+
 			downmixPkt.Unref()
 		}
 
@@ -645,6 +695,7 @@ func channelLayoutLabel(layout astiav.ChannelLayout) string {
 		if end < 0 {
 			end = len(desc)
 		}
+
 		return desc[:end]
 	}
 	// Named layout: no LFE channel.
@@ -657,13 +708,13 @@ func (t *Transcoder) flushAllEncoders(ctx context.Context, outputFmt *astiav.For
 	for _, s := range streams {
 		toFlush = append(toFlush, s)
 	}
+
 	if downmix != nil {
 		toFlush = append(toFlush, downmix)
 	}
 
 	for _, s := range toFlush {
 		err := s.flush(outputFmt, t.progressCh, totalDuration)
-
 		if err == nil {
 			continue
 		}
@@ -674,5 +725,6 @@ func (t *Transcoder) flushAllEncoders(ctx context.Context, outputFmt *astiav.For
 
 		return err
 	}
+
 	return nil
 }

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -20,16 +20,22 @@ import (
 // This is used in tests because ffprobe.StreamInfo does not expose disposition.
 func probeStreamDispositions(t *testing.T, path string) map[int]astiav.DispositionFlags {
 	t.Helper()
+
 	fmtCtx := astiav.AllocFormatContext()
+
 	require.NotNil(t, fmtCtx, "failed to allocate format context")
 	defer fmtCtx.Free()
+
 	require.NoError(t, fmtCtx.OpenInput(path, nil, nil))
 	defer fmtCtx.CloseInput()
+
 	require.NoError(t, fmtCtx.FindStreamInfo(nil))
+
 	result := make(map[int]astiav.DispositionFlags)
 	for _, s := range fmtCtx.Streams() {
 		result[s.Index()] = s.DispositionFlags()
 	}
+
 	return result
 }
 
@@ -58,12 +64,14 @@ func TestTranscode_H265_MKV(t *testing.T) {
 	assert.Equal(t, "matroska,webm", info.Format)
 
 	var foundH265 bool
+
 	for _, s := range info.Streams {
 		if s.CodecType == ffprobe.CodecTypeVideo && s.CodecName == "hevc" {
 			foundH265 = true
 			break
 		}
 	}
+
 	assert.True(t, foundH265, "output must contain an H.265 video stream")
 }
 
@@ -160,12 +168,14 @@ func TestTranscode_HWAccelAuto(t *testing.T) {
 	require.NoError(t, err)
 
 	var foundH265 bool
+
 	for _, s := range info.Streams {
 		if s.CodecType == ffprobe.CodecTypeVideo && s.CodecName == "hevc" {
 			foundH265 = true
 			break
 		}
 	}
+
 	assert.True(t, foundH265, "output must contain an H.265 video stream regardless of HW path")
 }
 
@@ -189,6 +199,7 @@ func TestTranscode_ProgressChannel(t *testing.T) {
 	for p := range progressCh {
 		updates = append(updates, p)
 	}
+
 	assert.NotEmpty(t, updates, "must receive at least one progress update")
 
 	for _, p := range updates {
@@ -224,6 +235,7 @@ func TestTranscode_CancelDuringRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	done := make(chan error, 1)
+
 	go func() {
 		done <- ffmpeg.NewTranscode(testVideoPath, output).
 			ToVideoCodec(ffmpeg.CodecH265).
@@ -251,12 +263,14 @@ func TestTranscode_ExcludeStreams(t *testing.T) {
 
 	// Locate the first audio stream index to exclude.
 	audioIndex := -1
+
 	for _, s := range inputInfo.Streams {
 		if s.CodecType == ffprobe.CodecTypeAudio {
 			audioIndex = s.Index
 			break
 		}
 	}
+
 	require.NotEqual(t, -1, audioIndex, "test fixture must have at least one audio stream")
 
 	output := filepath.Join(t.TempDir(), "out.mkv")
@@ -274,6 +288,7 @@ func TestTranscode_ExcludeStreams(t *testing.T) {
 		assert.NotEqual(t, ffprobe.CodecTypeAudio, s.CodecType,
 			"excluded audio stream must not appear in the output")
 	}
+
 	assert.Equal(t, len(inputInfo.Streams)-1, len(outputInfo.Streams),
 		"output must have one fewer stream than the input")
 }
@@ -290,6 +305,7 @@ func TestTranscode_DispositionPreserved(t *testing.T) {
 
 	outputDisps := probeStreamDispositions(t, output)
 	require.Len(t, outputDisps, len(inputDisps), "stream count must match")
+
 	for idx, inputDisp := range inputDisps {
 		assert.Equal(t, inputDisp, outputDisps[idx],
 			"stream %d: disposition must be preserved from input", idx)
@@ -351,12 +367,14 @@ func TestTranscode_WithDownmix(t *testing.T) {
 	require.NoError(t, err)
 
 	audioIndex := -1
+
 	for _, s := range inputInfo.Streams {
 		if s.CodecType == ffprobe.CodecTypeAudio {
 			audioIndex = s.Index
 			break
 		}
 	}
+
 	require.NotEqual(t, -1, audioIndex, "test fixture must have at least one audio stream")
 
 	output := filepath.Join(t.TempDir(), "out.mkv")
@@ -375,18 +393,23 @@ func TestTranscode_WithDownmix(t *testing.T) {
 		"output must contain one additional stream from the downmix")
 
 	// Locate the AC-3 downmix stream and verify its properties.
-	var ac3Stream *ffprobe.StreamInfo
-	var regularAudioStream *ffprobe.StreamInfo
+	var (
+		ac3Stream          *ffprobe.StreamInfo
+		regularAudioStream *ffprobe.StreamInfo
+	)
+
 	for i, s := range outputInfo.Streams {
 		if s.CodecType != ffprobe.CodecTypeAudio {
 			continue
 		}
+
 		if s.CodecName == "ac3" {
 			ac3Stream = &outputInfo.Streams[i]
 		} else if regularAudioStream == nil {
 			regularAudioStream = &outputInfo.Streams[i]
 		}
 	}
+
 	require.NotNil(t, ac3Stream, "output must contain an AC-3 audio stream from the downmix")
 
 	// Language tag must match the regular output audio stream. Both are derived
@@ -400,7 +423,9 @@ func TestTranscode_WithDownmix(t *testing.T) {
 	// Determine whether any non-downmix audio stream is already default so we
 	// can assert the correct default disposition on the downmix.
 	outputDisps := probeStreamDispositions(t, output)
+
 	var existingDefault bool
+
 	for _, s := range outputInfo.Streams {
 		if s.CodecType == ffprobe.CodecTypeAudio && s.CodecName != "ac3" {
 			if outputDisps[s.Index].Has(astiav.DispositionFlagDefault) {
@@ -424,6 +449,7 @@ func TestDetectHardwareEncoders_ValidResult(t *testing.T) {
 		ffmpeg.HWAccelVAAPI,
 		ffmpeg.HWAccelQSV,
 	}
+
 	for _, codec := range []ffmpeg.Codec{ffmpeg.CodecH264, ffmpeg.CodecH265} {
 		accs := ffmpeg.DetectHardwareEncoders(codec)
 		for _, hw := range accs {

--- a/pkg/ffprobe/ffprobe.go
+++ b/pkg/ffprobe/ffprobe.go
@@ -80,12 +80,14 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 
 	watchDone := make(chan struct{})
 	defer close(watchDone)
+
 	go func() {
 		select {
 		case <-ctx.Done():
 			interrupter.Interrupt()
 		case <-watchDone:
 		}
+
 		interrupter.Free()
 	}()
 
@@ -94,6 +96,7 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 		if interrupter.Interrupted() {
 			return nil, ctx.Err()
 		}
+
 		return nil, fmt.Errorf("ffprobe: opening %q: %w", path, err)
 	}
 	defer formatContext.CloseInput()
@@ -103,6 +106,7 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 		if interrupter.Interrupted() {
 			return nil, ctx.Err()
 		}
+
 		return nil, fmt.Errorf("ffprobe: finding stream info for %q: %w", path, err)
 	}
 
@@ -125,6 +129,7 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 			BitsPerSecond: codecParams.BitRate(),
 			Tags:          dictionaryToMap(stream.Metadata()),
 		}
+
 		switch codecParams.MediaType() {
 		case astiav.MediaTypeVideo:
 			streamInfo.WidthPixels = codecParams.Width()
@@ -136,6 +141,7 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 			streamInfo.AudioChannelCount = layout.Channels()
 			streamInfo.HasLFE = hasLFEChannel(layout)
 		}
+
 		info.Streams = append(info.Streams, streamInfo)
 	}
 
@@ -149,11 +155,14 @@ func Probe(ctx context.Context, path string) (*MediaInfo, error) {
 // "5.0") return false.
 func hasLFEChannel(layout astiav.ChannelLayout) bool {
 	desc := layout.String()
+
 	idx := strings.Index(desc, ".")
 	if idx < 0 || idx+1 >= len(desc) {
 		return false
 	}
+
 	c := desc[idx+1]
+
 	return c >= '1' && c <= '9'
 }
 
@@ -163,15 +172,19 @@ func dictionaryToMap(dict *astiav.Dictionary) map[string]string {
 	if dict == nil {
 		return nil
 	}
+
 	result := make(map[string]string)
+
 	var prev *astiav.DictionaryEntry
 	for {
 		entry := dict.Get("", prev, astiav.NewDictionaryFlags(astiav.DictionaryFlagIgnoreSuffix))
 		if entry == nil {
 			break
 		}
+
 		result[entry.Key()] = entry.Value()
 		prev = entry
 	}
+
 	return result
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -12,6 +12,7 @@ import (
 // as "info". An unrecognised value logs a warning and falls back to INFO.
 func Setup(level string) {
 	var l slog.Level
+
 	switch strings.ToLower(level) {
 	case "debug":
 		l = slog.LevelDebug
@@ -25,6 +26,7 @@ func Setup(level string) {
 		// Warn using the current default before reconfiguring.
 		slog.Warn("unrecognised LOG_LEVEL value, falling back to INFO", "value", level)
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 		return
 	}
 

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -31,6 +31,7 @@ func TestSetup(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("level="+tc.input, func(t *testing.T) {
 			prev := slog.Default()
+
 			t.Cleanup(func() { slog.SetDefault(prev) })
 
 			logging.Setup(tc.input)
@@ -46,6 +47,7 @@ func TestSetup(t *testing.T) {
 
 func TestSetupUnrecognised(t *testing.T) {
 	prev := slog.Default()
+
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
 	var buf bytes.Buffer

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -52,6 +52,7 @@ func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.
 			path = c.cfg.RemotePathPrefix + after
 		}
 	}
+
 	path = filepath.Clean(path)
 
 	// Guard against path traversal: if a remote prefix is configured, reject
@@ -104,6 +105,7 @@ func (c *Client) GetInfo(ctx context.Context, path string) (medialib.MediaInfo, 
 	if err != nil {
 		return nil, err
 	}
+
 	return &movie, nil
 }
 

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -121,6 +121,7 @@ func TestGetMovieByFilePath(t *testing.T) {
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
+
 			errFunc(t, err)
 
 			if err == nil {
@@ -202,6 +203,7 @@ func TestGetInfo(t *testing.T) {
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
+
 			errFunc(t, err)
 
 			if err == nil {

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -51,6 +51,7 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 			path = c.cfg.RemotePathPrefix + after
 		}
 	}
+
 	path = filepath.Clean(path)
 
 	// Guard against path traversal: if a remote prefix is configured, reject
@@ -96,6 +97,7 @@ func (c *Client) GetInfo(ctx context.Context, path string) (medialib.MediaInfo, 
 	if err != nil {
 		return nil, err
 	}
+
 	return &episode, nil
 }
 

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -126,6 +126,7 @@ func TestGetEpisodeByFilePath(t *testing.T) {
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
+
 			errFunc(t, err)
 
 			if err == nil {
@@ -240,6 +241,7 @@ func TestGetInfo(t *testing.T) {
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
+
 			errFunc(t, err)
 
 			if err == nil {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,15 +53,19 @@ func New(ctx context.Context, opts ...Option) (*Provider, error) {
 		opt(cfg)
 	}
 
-	var readers []sdkmetric.Reader
-	var shutdownFuncs []func(context.Context) error
+	var (
+		readers       []sdkmetric.Reader
+		shutdownFuncs []func(context.Context) error
+	)
 
 	if cfg.metricsAddr != "" {
 		promRegistry := prometheus.NewRegistry()
+
 		promReader, err := prometheusexporter.New(prometheusexporter.WithRegisterer(promRegistry))
 		if err != nil {
 			return nil, fmt.Errorf("create prometheus exporter: %w", err)
 		}
+
 		readers = append(readers, promReader)
 
 		listener, err := net.Listen("tcp", cfg.metricsAddr)
@@ -72,11 +76,13 @@ func New(ctx context.Context, opts ...Option) (*Provider, error) {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
 		srv := &http.Server{Handler: mux}
+
 		go func() {
 			if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				fmt.Fprintf(os.Stderr, "metrics HTTP server error: %v\n", err)
 			}
 		}()
+
 		shutdownFuncs = append(shutdownFuncs, srv.Shutdown)
 	}
 
@@ -87,12 +93,15 @@ func New(ctx context.Context, opts ...Option) (*Provider, error) {
 			// because ctx may already be cancelled (a common reason for init failure).
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cleanupCancel()
+
 			var cleanupErrs []error
 			for _, shutdownFunc := range shutdownFuncs {
 				cleanupErrs = append(cleanupErrs, shutdownFunc(cleanupCtx))
 			}
+
 			return nil, errors.Join(append(cleanupErrs, fmt.Errorf("create OTLP metric exporter: %w", err))...)
 		}
+
 		readers = append(readers, sdkmetric.NewPeriodicReader(otlpExporter))
 	}
 
@@ -107,6 +116,7 @@ func New(ctx context.Context, opts ...Option) (*Provider, error) {
 	for _, reader := range readers {
 		sdkOpts = append(sdkOpts, sdkmetric.WithReader(reader))
 	}
+
 	sdkProvider := sdkmetric.NewMeterProvider(sdkOpts...)
 	shutdownFuncs = append(shutdownFuncs, sdkProvider.Shutdown)
 
@@ -120,6 +130,7 @@ func New(ctx context.Context, opts ...Option) (*Provider, error) {
 			for i := len(shutdownFuncs) - 1; i >= 0; i-- {
 				errs = append(errs, shutdownFuncs[i](ctx))
 			}
+
 			return errors.Join(errs...)
 		},
 	}, nil
@@ -148,19 +159,24 @@ func NewFromEnv(ctx context.Context) (*Provider, func(), error) {
 	if addr := os.Getenv("METRICS_ADDR"); addr != "" {
 		opts = append(opts, WithMetricsAddr(addr))
 	}
+
 	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
 		opts = append(opts, WithOTLPEndpoint(endpoint))
 	}
+
 	p, err := New(ctx, opts...)
 	if err != nil {
 		return nil, func() {}, err
 	}
+
 	shutdown := func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+
 		if err := p.Shutdown(shutdownCtx); err != nil {
 			fmt.Fprintf(os.Stderr, "metrics shutdown error: %v\n", err)
 		}
 	}
+
 	return p, shutdown, nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -18,10 +18,13 @@ import (
 // freeAddr returns a local TCP address with an available port.
 func freeAddr(t *testing.T) string {
 	t.Helper()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+
 	addr := l.Addr().String()
 	require.NoError(t, l.Close())
+
 	return addr
 }
 
@@ -30,9 +33,11 @@ func freeAddr(t *testing.T) string {
 // closed by the HTTP server's Shutdown when a Provider is active.
 func bindListener(t *testing.T) net.Listener {
 	t.Helper()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = l.Close() })
+
 	return l
 }
 
@@ -41,9 +46,11 @@ func TestPrometheusEndpoint_Enabled(t *testing.T) {
 
 	p, err := metrics.New(t.Context(), metrics.WithMetricsAddr(addr))
 	require.NoError(t, err)
+
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
 		_ = p.Shutdown(ctx) //nolint:errcheck
 	}()
 
@@ -58,6 +65,7 @@ func TestPrometheusEndpoint_Enabled(t *testing.T) {
 	// Verify the response Content-Type is Prometheus text exposition format.
 	contentType := resp.Header.Get("Content-Type")
 	assert.True(t, strings.HasPrefix(contentType, "text/plain"), "metrics endpoint should return Prometheus text exposition format, got: %s", contentType)
+
 	_, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 }
@@ -89,6 +97,7 @@ func TestOTLPExporter_Enabled(t *testing.T) {
 	// the listener is not a real gRPC server — the important thing is it is called).
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
 	_ = p.Shutdown(ctx) // error tolerated: no real gRPC server behind the listener
 }
 
@@ -99,6 +108,7 @@ func TestOTLPExporter_Disabled(t *testing.T) {
 	// Shutdown must succeed without attempting any OTLP export.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+
 	require.NoError(t, p.Shutdown(ctx))
 }
 
@@ -114,6 +124,7 @@ func TestBothExporters_Active(t *testing.T) {
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
 		_ = p.Shutdown(ctx) //nolint:errcheck
 	})
 
@@ -167,6 +178,7 @@ func TestNewFromEnv_OTLPEndpoint_CreatesProvider(t *testing.T) {
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
+
 		_ = p.Shutdown(ctx)
 	})
 	require.NotNil(t, p.MeterProvider())
@@ -184,11 +196,15 @@ func TestGracefulShutdown_FlushesOTLP(t *testing.T) {
 	// the gRPC connection timeout can expire before we declare failure.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer shutdownCancel()
+
 	shutdownDone := make(chan struct{})
+
 	go func() {
 		defer close(shutdownDone)
+
 		_ = p.Shutdown(shutdownCtx)
 	}()
+
 	select {
 	case <-shutdownDone:
 		// passed: Shutdown completed (with or without error from the dummy server)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -49,6 +49,7 @@ func DefaultPayload(e FailureEvent) ([]byte, error) {
 	if e.Err != nil {
 		errMsg = e.Err.Error()
 	}
+
 	return json.Marshal(defaultPayloadShape{
 		Workflow: e.Workflow,
 		FilePath: e.FilePath,
@@ -80,18 +81,21 @@ func (c *Client) NotifyFailure(ctx context.Context, event FailureEvent) error {
 	if err != nil {
 		return fmt.Errorf("webhook: create request: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	timeout := c.Timeout
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
+
 	httpClient := &http.Client{Timeout: timeout}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("webhook: send request: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -26,10 +26,13 @@ var testEvent = webhook.FailureEvent{
 // required fields when using the default payload builder.
 func TestNotifyFailure_DefaultPayloadContents(t *testing.T) {
 	var gotBody []byte
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
 		var err error
+
 		gotBody, err = io.ReadAll(r.Body)
 		require.NoError(t, err)
 		w.WriteHeader(http.StatusOK)
@@ -89,10 +92,13 @@ func TestNotifyFailure_StatusCodes(t *testing.T) {
 
 			client := &webhook.Client{URL: srv.URL}
 			err := client.NotifyFailure(t.Context(), testEvent)
+
 			if tc.errFunc == nil {
 				tc.errFunc = require.NoError
 			}
+
 			tc.errFunc(t, err)
+
 			if tc.errMsg != "" {
 				assert.ErrorContains(t, err, tc.errMsg)
 			}
@@ -138,8 +144,10 @@ func TestNotifyFailure_UnreachableEndpoint(t *testing.T) {
 // instead of the default, enabling arbitrary endpoint formats such as Discord.
 func TestNotifyFailure_CustomPayloadFunc(t *testing.T) {
 	var gotBody []byte
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
+
 		gotBody, err = io.ReadAll(r.Body)
 		require.NoError(t, err)
 		w.WriteHeader(http.StatusNoContent)

--- a/workflows/media/attrs.go
+++ b/workflows/media/attrs.go
@@ -23,6 +23,7 @@ func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode sh
 	if hardwareAccelerated {
 		hw = "true"
 	}
+
 	return []attribute.KeyValue{
 		attribute.String("source_codec", probe.VideoCodec),
 		attribute.String("destination_codec", transcode.DestCodec),
@@ -50,5 +51,6 @@ func highCardinalityAttrs(mediaType medialib.MediaType, info medialib.MediaInfo)
 			attribute.String("episode_number", strconv.Itoa(info.GetEpisodeNumber())),
 		)
 	}
+
 	return attrs
 }

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -66,12 +66,15 @@ func NewMediaWorkflow(
 	if meterProvider == nil {
 		meterProvider = noop.NewMeterProvider()
 	}
+
 	recorder, err := NewRecorder(meterProvider, cfg.HighCardinalityLabels)
 	if err != nil {
 		// Instrument registration errors are non-fatal: log for observability and fall
 		// back to a noop recorder so the workflow can still run without metrics.
 		slog.Warn("media: failed to create metrics recorder, falling back to noop", "error", err)
+
 		var noopErr error
+
 		recorder, noopErr = NewRecorder(noop.NewMeterProvider(), false)
 		if noopErr != nil {
 			// noop.NewMeterProvider() instrument registration never returns errors in
@@ -98,11 +101,14 @@ func NewMediaWorkflow(
 	// StartedAt is set here (not inside RunProbe) so existing RunProbe tests are unaffected.
 	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (shared.ProbeOutput, error) {
 		start := time.Now()
+
 		out, err := shared.RunProbe(ctx, input.FilePath)
 		if err != nil {
 			return out, err
 		}
+
 		out.StartedAt = start
+
 		return out, nil
 	})
 
@@ -132,9 +138,11 @@ func NewMediaWorkflow(
 		if err != nil {
 			return struct{}{}, err
 		}
+
 		if err := library.RefreshByFilePath(ctx, input.FilePath); err != nil {
 			return struct{}{}, fmt.Errorf("notify library: %w", err)
 		}
+
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
@@ -150,12 +158,14 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			return struct{}{}, fmt.Errorf("get probe output for metrics: %w", err)
 		}
+
 		var transcode shared.TranscodeOutput
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
 			return struct{}{}, fmt.Errorf("get transcode output for metrics: %w", err)
 		}
 
 		var mediaInfo medialib.MediaInfo
+
 		if cfg.HighCardinalityLabels {
 			library, libErr := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
 			if libErr == nil {
@@ -174,6 +184,7 @@ func NewMediaWorkflow(
 		hardwareAccelerated := cfg.HardwareDevicePath != ""
 		totalElapsed := time.Since(probe.StartedAt)
 		recorder.RecordRun(ctx, input, probe, transcode, mediaInfo, hardwareAccelerated, totalElapsed)
+
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask, notifyTask, cleanupTask), skipIfInvalid)
 

--- a/workflows/media/recorder.go
+++ b/workflows/media/recorder.go
@@ -125,6 +125,7 @@ func (r *Recorder) RecordRun(
 	if r.highCardinality && mediaInfo != nil {
 		attrs = append(attrs, highCardinalityAttrs(input.MediaType, mediaInfo)...)
 	}
+
 	opts := otelmetric.WithAttributes(attrs...)
 
 	r.audioTrackCount.Record(ctx, float64(len(probe.AudioStreams)), opts)

--- a/workflows/media/recorder_test.go
+++ b/workflows/media/recorder_test.go
@@ -20,20 +20,25 @@ func attributeKey(name string) attribute.Key { return attribute.Key(name) }
 // newTestRecorder creates a Recorder backed by a ManualReader and returns both.
 func newTestRecorder(t *testing.T, highCardinality bool) (*Recorder, *sdkmetric.ManualReader) {
 	t.Helper()
+
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
 	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
 
 	rec, err := NewRecorder(provider, highCardinality)
 	require.NoError(t, err)
+
 	return rec, reader
 }
 
 // collectMetrics gathers all current metric data from the reader.
 func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
 	t.Helper()
+
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
+
 	return rm
 }
 
@@ -46,6 +51,7 @@ func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics 
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -55,6 +61,7 @@ func histogramDataPoints(t *testing.T, m *metricdata.Metrics) []metricdata.Histo
 	require.NotNil(t, m, "expected metric to be present")
 	h, ok := m.Data.(metricdata.Histogram[float64])
 	require.True(t, ok, "expected metric %q to be a float64 histogram", m.Name)
+
 	return h.DataPoints
 }
 

--- a/workflows/media/testhelpers_test.go
+++ b/workflows/media/testhelpers_test.go
@@ -18,11 +18,13 @@ const testVideoPath = "../../pkg/ffprobe/testdata/video.mp4"
 // The file is NOT registered for cleanup so tests can verify deletion behaviour.
 func copyTestVideo(t *testing.T) string {
 	t.Helper()
+
 	src, err := os.ReadFile(testVideoPath)
 	require.NoError(t, err)
 
 	dst := filepath.Join(t.TempDir(), "video.mp4")
 	require.NoError(t, os.WriteFile(dst, src, 0o600))
+
 	return dst
 }
 

--- a/workflows/shared/audio_title.go
+++ b/workflows/shared/audio_title.go
@@ -13,8 +13,10 @@ func stripLanguageName(title, langName string) string {
 	if langName == "" {
 		return title
 	}
+
 	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(langName) + `\b`)
 	stripped := re.ReplaceAllLiteralString(title, "")
+
 	return strings.TrimSpace(strings.Join(strings.Fields(stripped), " "))
 }
 
@@ -61,10 +63,12 @@ func channelConfigLabel(channelCount int, hasLFE bool) string {
 	if hasLFE {
 		lfe = 1
 	}
+
 	nonLFE := channelCount - lfe
 	if nonLFE < 0 {
 		nonLFE = 0
 	}
+
 	return fmt.Sprintf("%d.%d", nonLFE, lfe)
 }
 
@@ -82,7 +86,9 @@ func stripChannelConfigLabel(title string) string {
 	}
 
 	var buf strings.Builder
+
 	prevEnd := 0
+
 	for _, match := range matches {
 		start, end := match[0], match[1]
 		// If the matched label is immediately followed by ".<digit>", it is
@@ -90,12 +96,16 @@ func stripChannelConfigLabel(title string) string {
 		if end < len(title) && title[end] == '.' && end+1 < len(title) && title[end+1] >= '0' && title[end+1] <= '9' {
 			buf.WriteString(title[prevEnd:end])
 			prevEnd = end
+
 			continue
 		}
+
 		buf.WriteString(title[prevEnd:start])
 		buf.WriteByte(' ')
+
 		prevEnd = end
 	}
+
 	buf.WriteString(title[prevEnd:])
 
 	return strings.TrimSpace(strings.Join(strings.Fields(buf.String()), " "))
@@ -116,12 +126,15 @@ func buildAudioStreamTitle(sourceTitle, langName, channelLabel string) string {
 	if stripped != "" {
 		parts = append(parts, stripped)
 	}
+
 	if langName != "" {
 		parts = append(parts, langName)
 	}
+
 	if channelLabel != "" {
 		parts = append(parts, channelLabel)
 	}
+
 	return strings.Join(parts, " ")
 }
 
@@ -133,9 +146,11 @@ func buildSubtitleStreamTitle(sourceTitle, langName string) string {
 	if langName == "" {
 		return sourceTitle
 	}
+
 	stripped := stripLanguageName(sourceTitle, langName)
 	if stripped == "" {
 		return langName
 	}
+
 	return stripped + " " + langName
 }

--- a/workflows/shared/cleanup_test.go
+++ b/workflows/shared/cleanup_test.go
@@ -21,6 +21,7 @@ func TestRunCleanup(t *testing.T) {
 			setupPath: func(t *testing.T) string {
 				p := filepath.Join(t.TempDir(), "source.mkv")
 				require.NoError(t, os.WriteFile(p, []byte("data"), 0o600))
+
 				return p
 			},
 			errFunc:     require.NoError,
@@ -43,6 +44,7 @@ func TestRunCleanup(t *testing.T) {
 			err := RunCleanup(path)
 
 			tt.errFunc(t, err)
+
 			if tt.fileDeleted {
 				_, statErr := os.Stat(path)
 				assert.True(t, os.IsNotExist(statErr), "expected file to be deleted")

--- a/workflows/shared/language.go
+++ b/workflows/shared/language.go
@@ -9,9 +9,11 @@ func iso639Name(tag string) string {
 	if tag == "" {
 		return ""
 	}
+
 	lang := iso639.FromAnyCode(tag)
 	if lang == nil {
 		return tag
 	}
+
 	return lang.Name
 }

--- a/workflows/shared/onfailure.go
+++ b/workflows/shared/onfailure.go
@@ -23,6 +23,7 @@ func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, wo
 	for stepName := range stepErrors {
 		steps = append(steps, stepName)
 	}
+
 	sort.Strings(steps)
 
 	errs := make([]error, 0, len(stepErrors))

--- a/workflows/shared/onfailure_test.go
+++ b/workflows/shared/onfailure_test.go
@@ -58,10 +58,12 @@ func TestNotifyWorkflowFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			called := false
+
 			var gotPayload map[string]string
 
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				called = true
+
 				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload))
 				w.WriteHeader(http.StatusOK)
 			}))

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -78,12 +78,16 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 		return ProbeOutput{IsValidMedia: false}, nil
 	}
 
-	var audioStreams []AudioStreamInfo
-	var subtitleStreams []StreamInfo
+	var (
+		audioStreams    []AudioStreamInfo
+		subtitleStreams []StreamInfo
+	)
+
 	for _, s := range info.Streams {
 		switch s.CodecType {
 		case ffprobe.CodecTypeAudio:
 			reported := s.AudioChannelCount
+
 			effective := reported
 			if effective == 0 {
 				// ffprobe reports 0 when the channel layout is unknown. Use a
@@ -91,6 +95,7 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 				// incorrectly suppress synthesis by matching the stereo threshold.
 				effective = 6
 			}
+
 			audioStreams = append(audioStreams, AudioStreamInfo{
 				StreamInfo:            StreamInfo{Index: s.Index, Language: s.Tags["language"], Title: s.Tags["title"]},
 				ReportedChannelCount:  reported,

--- a/workflows/shared/probe_test.go
+++ b/workflows/shared/probe_test.go
@@ -23,6 +23,7 @@ func TestRunProbe(t *testing.T) {
 			setupPath: func(t *testing.T) string {
 				p := filepath.Join(t.TempDir(), "notavideo.txt")
 				require.NoError(t, os.WriteFile(p, []byte("hello"), 0o600))
+
 				return p
 			},
 			expected:    ProbeOutput{IsValidMedia: false},

--- a/workflows/shared/testhelpers_test.go
+++ b/workflows/shared/testhelpers_test.go
@@ -15,10 +15,12 @@ const testVideoPath = "../../pkg/ffprobe/testdata/video.mp4"
 // The file is NOT registered for cleanup so tests can verify deletion behaviour.
 func copyTestVideo(t *testing.T) string {
 	t.Helper()
+
 	src, err := os.ReadFile(testVideoPath)
 	require.NoError(t, err)
 
 	dst := filepath.Join(t.TempDir(), "video.mp4")
 	require.NoError(t, os.WriteFile(dst, src, 0o600))
+
 	return dst
 }

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -32,21 +32,26 @@ func SelectVideoCodec(videoCodecName, format string) ffmpeg.Codec {
 // language tag), nil is returned so all streams are preserved as a safe fallback.
 func nonEnglishAudioIndices(streams []AudioStreamInfo) []int {
 	hasEnglish := false
+
 	for _, s := range streams {
 		if s.Language == "eng" {
 			hasEnglish = true
 			break
 		}
 	}
+
 	if !hasEnglish {
 		return nil
 	}
+
 	var exclude []int
+
 	for _, s := range streams {
 		if s.Language != "eng" {
 			exclude = append(exclude, s.Index)
 		}
 	}
+
 	return exclude
 }
 
@@ -59,15 +64,18 @@ func nonEnglishAudioIndices(streams []AudioStreamInfo) []int {
 // candidates without blocking or triggering synthesis incorrectly.
 func downmixSourceIndex(streams []AudioStreamInfo) *int {
 	var firstSurround *int
+
 	for _, s := range streams {
 		if s.EffectiveChannelCount > 0 && s.EffectiveChannelCount <= 3 {
 			return nil
 		}
+
 		if s.EffectiveChannelCount >= 4 && firstSurround == nil {
 			idx := s.Index
 			firstSurround = &idx
 		}
 	}
+
 	return firstSurround
 }
 
@@ -76,11 +84,13 @@ func downmixSourceIndex(streams []AudioStreamInfo) *int {
 // no safe-fallback: subtitles are always excluded unless explicitly tagged "eng".
 func nonEnglishSubtitleIndices(streams []StreamInfo) []int {
 	var exclude []int
+
 	for _, s := range streams {
 		if s.Language != "eng" {
 			exclude = append(exclude, s.Index)
 		}
 	}
+
 	return exclude
 }
 
@@ -92,6 +102,7 @@ func firstEnglishIndex(streams []StreamInfo) *int {
 			return &stream.Index
 		}
 	}
+
 	return nil
 }
 
@@ -140,6 +151,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	if err != nil {
 		return TranscodeOutput{}, fmt.Errorf("stat source file: %w", err)
 	}
+
 	srcSize := srcInfo.Size()
 
 	videoCodec := SelectVideoCodec(probe.VideoCodec, probe.Format)
@@ -152,6 +164,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	for _, idx := range audioExclude {
 		excludeSet[idx] = true
 	}
+
 	retainedAudio := make([]AudioStreamInfo, 0, len(probe.AudioStreams))
 	for _, s := range probe.AudioStreams {
 		if !excludeSet[s.Index] {
@@ -180,8 +193,10 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 			if langName != "" {
 				audioTitles[s.Index] = langName
 			}
+
 			continue
 		}
+
 		label := channelConfigLabel(s.ReportedChannelCount, s.HasLFE)
 		audioTitles[s.Index] = buildAudioStreamTitle(s.Title, langName, label)
 	}
@@ -189,14 +204,17 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	// Build per-stream title map for retained subtitle streams.
 	subtitleExclude := nonEnglishSubtitleIndices(probe.SubtitleStreams)
 	subtitleExcludeSet := make(map[int]bool, len(subtitleExclude))
+
 	for _, idx := range subtitleExclude {
 		subtitleExcludeSet[idx] = true
 	}
+
 	subtitleTitles := make(map[int]string, len(probe.SubtitleStreams))
 	for _, s := range probe.SubtitleStreams {
 		if subtitleExcludeSet[s.Index] {
 			continue
 		}
+
 		title := buildSubtitleStreamTitle(s.Title, iso639Name(s.Language))
 		if title != "" {
 			subtitleTitles[s.Index] = title
@@ -206,7 +224,9 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	// Resolve the language name for the downmix source stream so the downmix
 	// title can be prefixed with the human-readable language name.
 	downmixSrcIdx := downmixSourceIndex(retainedAudio)
+
 	var downmixLangName string
+
 	if downmixSrcIdx != nil {
 		for _, s := range retainedAudio {
 			if s.Index == *downmixSrcIdx {

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -28,6 +28,7 @@ func audioStreamInfo(index int, lang string, channels int) AudioStreamInfo {
 	if effective == 0 {
 		effective = 6
 	}
+
 	return AudioStreamInfo{
 		StreamInfo:            StreamInfo{Index: index, Language: lang},
 		ReportedChannelCount:  channels,
@@ -371,6 +372,7 @@ func TestRunTranscode(t *testing.T) {
 				outputDir := t.TempDir()
 				stale := filepath.Join(outputDir, "._"+mkvOutputName(inputPath)+".tmp")
 				require.NoError(t, os.WriteFile(stale, []byte("stale partial data"), 0o600))
+
 				return inputPath, outputDir
 			},
 			probe:   h264Probe,
@@ -391,6 +393,7 @@ func TestRunTranscode(t *testing.T) {
 				outputDir := t.TempDir()
 				oldContent := []byte("old output")
 				require.NoError(t, os.WriteFile(filepath.Join(outputDir, mkvOutputName(inputPath)), oldContent, 0o600))
+
 				return inputPath, outputDir
 			},
 			probe:   h264Probe,
@@ -406,6 +409,7 @@ func TestRunTranscode(t *testing.T) {
 			setup: func(t *testing.T) (string, string) {
 				p := filepath.Join(t.TempDir(), "not-a-video.txt")
 				require.NoError(t, os.WriteFile(p, []byte("not a video"), 0o600))
+
 				return p, t.TempDir()
 			},
 			probe:   ProbeOutput{IsValidMedia: false},
@@ -421,9 +425,11 @@ func TestRunTranscode(t *testing.T) {
 				if os.Getuid() == 0 {
 					t.Skip("skipping permission test: chmod has no effect when running as root")
 				}
+
 				outputDir := t.TempDir()
 				require.NoError(t, os.Chmod(outputDir, 0o555))
 				t.Cleanup(func() { _ = os.Chmod(outputDir, 0o755) })
+
 				return copyTestVideo(t), outputDir
 			},
 			probe:   h264Probe,
@@ -446,12 +452,15 @@ func TestRunTranscode(t *testing.T) {
 				out := filepath.Join(outputDir, mkvOutputName(inputPath))
 				info, err := ffprobe.Probe(t.Context(), out)
 				require.NoError(t, err)
+
 				var audioCount int
+
 				for _, s := range info.Streams {
 					if s.CodecType == ffprobe.CodecTypeAudio {
 						audioCount++
 					}
 				}
+
 				assert.Equal(t, 2, audioCount, "output should contain original audio stream plus one downmixed stream")
 			},
 		},
@@ -475,13 +484,16 @@ func TestRunTranscode(t *testing.T) {
 				out := filepath.Join(outputDir, mkvOutputName(inputPath))
 				info, err := ffprobe.Probe(t.Context(), out)
 				require.NoError(t, err)
+
 				for _, s := range info.Streams {
 					if s.CodecType == ffprobe.CodecTypeAudio {
 						assert.Equal(t, "Undetermined 2.0", s.Tags["title"],
 							"stereo audio stream should have title 'Undetermined 2.0'")
+
 						return
 					}
 				}
+
 				t.Fatal("no audio stream found in output")
 			},
 		},
@@ -507,11 +519,13 @@ func TestRunTranscode(t *testing.T) {
 				// "Undetermined 2.1" when the AC-3 encoder supports the 2.1
 				// layout, or "Undetermined 2.0" when it falls back to stereo.
 				var lastAudio ffprobe.StreamInfo
+
 				for _, s := range info.Streams {
 					if s.CodecType == ffprobe.CodecTypeAudio {
 						lastAudio = s
 					}
 				}
+
 				title := lastAudio.Tags["title"]
 				assert.True(t, title == "Undetermined 2.1" || title == "Undetermined 2.0",
 					"downmix stream title should be 'Undetermined 2.1' or 'Undetermined 2.0', got %q", title)
@@ -526,9 +540,11 @@ func TestRunTranscode(t *testing.T) {
 			out, err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir, "")
 
 			tt.errFunc(t, err)
+
 			if tt.checkOutput != nil {
 				tt.checkOutput(t, out, inputPath)
 			}
+
 			if tt.check != nil {
 				tt.check(t, outputDir, inputPath)
 			}


### PR DESCRIPTION
Fixes #66

## Summary

- Add blank lines before `if`/`for`/`switch`/`go`/`defer`/`return`/`select` statements as required by `wsl_v5` across 37 files
- Remove one unnecessary blank line in `pkg/ffmpeg/transcode.go`
- All fixes applied via `golangci-lint run --fix`

## Test plan

- [x] `golangci-lint run ./...` exits 0 with no issues
- [x] `make test` passes (all packages green, race detector enabled)