### PR TITLE
feat(medialib): fetch poster artwork from arr libraries and embed in output MKV

### DIFF
--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -178,8 +178,9 @@ func (b *TranscodeBuilder) WithDownmixTitle(title string) *TranscodeBuilder {
 }
 
 // WithCoverArt embeds imageBytes as a cover art attachment stream in the MKV
-// output. mimeType must be "image/jpeg" or "image/png"; any other value is
-// treated as a no-op. When called with a valid MIME type, any existing
+// output. This method is a no-op when the output container is not
+// ContainerMKV. mimeType must be "image/jpeg" or "image/png"; any other value
+// is treated as a no-op. When called with a valid MIME type, any existing
 // attachment streams present in the source file are excluded from the output
 // so that only the supplied artwork is embedded. A nil or empty imageBytes
 // slice is a no-op.
@@ -392,11 +393,12 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 
 		mediaType := inStream.CodecParameters().MediaType()
 
-		// When cover art is being embedded, drop all existing attachment streams
-		// so the output contains only the freshly fetched poster. MKV attachments
-		// are written as MediaTypeAttachment but read back by the matroska demuxer
-		// as video streams with DispositionFlagAttachedPic, so we must check both.
-		if len(t.coverArtBytes) > 0 {
+		// When cover art is being embedded into a Matroska output, drop all
+		// existing attachment streams so the output contains only the freshly
+		// fetched poster. MKV attachments are written as MediaTypeAttachment but
+		// read back by the matroska demuxer as video streams with
+		// DispositionFlagAttachedPic, so we must check both.
+		if len(t.coverArtBytes) > 0 && t.container == ContainerMKV {
 			if mediaType == astiav.MediaTypeAttachment {
 				continue
 			}
@@ -610,8 +612,8 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 		downmixOut.SetMetadata(downmixMeta)
 	}
 
-	// Add cover art attachment stream after all regular streams.
-	if len(t.coverArtBytes) > 0 {
+	// Add cover art attachment stream after all regular streams (MKV only).
+	if len(t.coverArtBytes) > 0 && t.container == ContainerMKV {
 		if err := t.addCoverArtStream(outputFmt); err != nil {
 			outputFmt.Free()
 			return nil, noopClose, err

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -178,12 +178,19 @@ func (b *TranscodeBuilder) WithDownmixTitle(title string) *TranscodeBuilder {
 }
 
 // WithCoverArt embeds imageBytes as a cover art attachment stream in the MKV
-// output. mimeType must be "image/jpeg" or "image/png". When called, any
-// existing attachment streams present in the source file are excluded from the
-// output so that only the supplied artwork is embedded. A nil or empty
-// imageBytes slice is a no-op.
+// output. mimeType must be "image/jpeg" or "image/png"; any other value is
+// treated as a no-op. When called with a valid MIME type, any existing
+// attachment streams present in the source file are excluded from the output
+// so that only the supplied artwork is embedded. A nil or empty imageBytes
+// slice is a no-op.
 func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *TranscodeBuilder {
 	if len(imageBytes) == 0 {
+		return b
+	}
+
+	switch mimeType {
+	case "image/jpeg", "image/png":
+	default:
 		return b
 	}
 

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -211,6 +211,15 @@ func (b *TranscodeBuilder) WithDownmix(idx *int) *TranscodeBuilder {
 	return b
 }
 
+// effectiveContainerIsMKV reports whether the output container is Matroska,
+// either because it was explicitly set via ToContainer or because the output
+// filename has a .mkv extension (the case where the container is inferred by
+// astiav.AllocOutputFormatContext from the filename).
+func (b *TranscodeBuilder) effectiveContainerIsMKV() bool {
+	return b.container == ContainerMKV ||
+		(b.container == "" && strings.HasSuffix(strings.ToLower(b.outputPath), ".mkv"))
+}
+
 // Build returns a runnable Transcoder.
 func (b *TranscodeBuilder) Build() *Transcoder {
 	return &Transcoder{TranscodeBuilder: *b}
@@ -398,7 +407,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 		// fetched poster. MKV attachments are written as MediaTypeAttachment but
 		// read back by the matroska demuxer as video streams with
 		// DispositionFlagAttachedPic, so we must check both.
-		if len(t.coverArtBytes) > 0 && t.container == ContainerMKV {
+		if len(t.coverArtBytes) > 0 && t.effectiveContainerIsMKV() {
 			if mediaType == astiav.MediaTypeAttachment {
 				continue
 			}
@@ -613,7 +622,7 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 	}
 
 	// Add cover art attachment stream after all regular streams (MKV only).
-	if len(t.coverArtBytes) > 0 && t.container == ContainerMKV {
+	if len(t.coverArtBytes) > 0 && t.effectiveContainerIsMKV() {
 		if err := t.addCoverArtStream(outputFmt); err != nil {
 			outputFmt.Free()
 			return nil, noopClose, err

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -685,21 +685,26 @@ func (t *Transcoder) addCoverArtStream(outputFmt *astiav.FormatContext) error {
 	cp := artStream.CodecParameters()
 	cp.SetMediaType(astiav.MediaTypeAttachment)
 
+	var (
+		codecID  astiav.CodecID
+		filename string
+	)
+
 	switch t.coverArtMimeType {
+	case "image/jpeg":
+		codecID = astiav.CodecIDMjpeg
+		filename = "cover.jpg"
 	case "image/png":
-		cp.SetCodecID(astiav.CodecIDPng)
+		codecID = astiav.CodecIDPng
+		filename = "cover.png"
 	default:
-		// Treat image/jpeg and any unknown type as MJPEG.
-		cp.SetCodecID(astiav.CodecIDMjpeg)
+		return fmt.Errorf("ffmpeg: unsupported cover art MIME type %q", t.coverArtMimeType)
 	}
+
+	cp.SetCodecID(codecID)
 
 	if err := cp.SetExtraData(t.coverArtBytes); err != nil {
 		return fmt.Errorf("ffmpeg: setting cover art extradata: %w", err)
-	}
-
-	filename := "cover.jpg"
-	if t.coverArtMimeType == "image/png" {
-		filename = "cover.png"
 	}
 
 	meta := astiav.NewDictionary()

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -27,6 +27,8 @@ type TranscodeBuilder struct {
 	subtitleStreamTitles  map[int]string // per-stream title overrides for subtitle streams; nil = no overrides
 	autoDownmixTitle      bool           // derive downmix stream title from actual encoder channel layout
 	downmixTitle          string         // title prefix prepended to the downmix channel layout label
+	coverArtBytes         []byte         // raw image bytes to embed as MKV attachment; nil = no cover art
+	coverArtMimeType      string         // MIME type of coverArtBytes ("image/jpeg" or "image/png")
 }
 
 // NewTranscode returns a builder for a transcode job from inputPath to outputPath.
@@ -171,6 +173,22 @@ func (b *TranscodeBuilder) WithDownmixTitle(title string) *TranscodeBuilder {
 	}
 
 	b.downmixTitle = title
+
+	return b
+}
+
+// WithCoverArt embeds imageBytes as a cover art attachment stream in the MKV
+// output. mimeType must be "image/jpeg" or "image/png". When called, any
+// existing attachment streams present in the source file are excluded from the
+// output so that only the supplied artwork is embedded. A nil or empty
+// imageBytes slice is a no-op.
+func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *TranscodeBuilder {
+	if len(imageBytes) == 0 {
+		return b
+	}
+
+	b.coverArtBytes = imageBytes
+	b.coverArtMimeType = mimeType
 
 	return b
 }
@@ -366,6 +384,22 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 		}
 
 		mediaType := inStream.CodecParameters().MediaType()
+
+		// When cover art is being embedded, drop all existing attachment streams
+		// so the output contains only the freshly fetched poster. MKV attachments
+		// are written as MediaTypeAttachment but read back by the matroska demuxer
+		// as video streams with DispositionFlagAttachedPic, so we must check both.
+		if len(t.coverArtBytes) > 0 {
+			if mediaType == astiav.MediaTypeAttachment {
+				continue
+			}
+
+			if mediaType == astiav.MediaTypeVideo &&
+				inStream.DispositionFlags().Has(astiav.DispositionFlagAttachedPic) {
+				continue
+			}
+		}
+
 		base := copyStreamState{inStream: inStream}
 
 		var s stream
@@ -569,6 +603,14 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 		downmixOut.SetMetadata(downmixMeta)
 	}
 
+	// Add cover art attachment stream after all regular streams.
+	if len(t.coverArtBytes) > 0 {
+		if err := t.addCoverArtStream(outputFmt); err != nil {
+			outputFmt.Free()
+			return nil, noopClose, err
+		}
+	}
+
 	// Open the IO context for file-based output formats.
 	closeIO := noopClose
 
@@ -611,6 +653,52 @@ func (t *Transcoder) outputDisposition(inStream *astiav.Stream) astiav.Dispositi
 	}
 
 	return disp.Del(astiav.DispositionFlagDefault)
+}
+
+// addCoverArtStream appends a cover art attachment stream to outputFmt using
+// t.coverArtBytes and t.coverArtMimeType. The image bytes are stored in the
+// stream's codec parameters extradata; no packets are written for this stream.
+func (t *Transcoder) addCoverArtStream(outputFmt *astiav.FormatContext) error {
+	artStream := outputFmt.NewStream(nil)
+	if artStream == nil {
+		return errors.New("ffmpeg: failed to create cover art attachment stream")
+	}
+
+	cp := artStream.CodecParameters()
+	cp.SetMediaType(astiav.MediaTypeAttachment)
+
+	switch t.coverArtMimeType {
+	case "image/png":
+		cp.SetCodecID(astiav.CodecIDPng)
+	default:
+		// Treat image/jpeg and any unknown type as MJPEG.
+		cp.SetCodecID(astiav.CodecIDMjpeg)
+	}
+
+	if err := cp.SetExtraData(t.coverArtBytes); err != nil {
+		return fmt.Errorf("ffmpeg: setting cover art extradata: %w", err)
+	}
+
+	filename := "cover.jpg"
+	if t.coverArtMimeType == "image/png" {
+		filename = "cover.png"
+	}
+
+	meta := astiav.NewDictionary()
+
+	if err := meta.Set("mimetype", t.coverArtMimeType, astiav.NewDictionaryFlags()); err != nil {
+		meta.Free()
+		return fmt.Errorf("ffmpeg: setting cover art mimetype metadata: %w", err)
+	}
+
+	if err := meta.Set("filename", filename, astiav.NewDictionaryFlags()); err != nil {
+		meta.Free()
+		return fmt.Errorf("ffmpeg: setting cover art filename metadata: %w", err)
+	}
+
+	artStream.SetMetadata(meta)
+
+	return nil
 }
 
 // readAllPackets is the main decode/encode loop.

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -440,6 +440,178 @@ func TestTranscode_WithDownmix(t *testing.T) {
 		"downmix default disposition must be set iff no other audio stream is already default")
 }
 
+// attachmentInfo describes an attachment stream found in a media file.
+type attachmentInfo struct {
+	data     []byte
+	mimeType string
+	filename string
+}
+
+// probeAttachments opens path and returns attachment stream info.
+// The matroska demuxer reads MKV attachment elements as video streams with
+// AV_DISPOSITION_ATTACHED_PIC; they are identified by a "mimetype" metadata
+// key. Image data is returned from the first packet on each such stream.
+func probeAttachments(t *testing.T, path string) []attachmentInfo {
+	t.Helper()
+
+	fmtCtx := astiav.AllocFormatContext()
+
+	require.NotNil(t, fmtCtx)
+
+	defer fmtCtx.Free()
+
+	require.NoError(t, fmtCtx.OpenInput(path, nil, nil))
+
+	defer fmtCtx.CloseInput()
+
+	require.NoError(t, fmtCtx.FindStreamInfo(nil))
+
+	// Build a map of stream index → attachmentInfo for streams that carry a
+	// "mimetype" metadata tag (the signature of an MKV attachment stream).
+	attachStreams := make(map[int]*attachmentInfo)
+
+	for _, s := range fmtCtx.Streams() {
+		meta := s.Metadata()
+		if meta == nil {
+			continue
+		}
+
+		mt := meta.Get("mimetype", nil, astiav.NewDictionaryFlags())
+		if mt == nil {
+			continue
+		}
+
+		info := &attachmentInfo{mimeType: mt.Value()}
+
+		if fn := meta.Get("filename", nil, astiav.NewDictionaryFlags()); fn != nil {
+			info.filename = fn.Value()
+		}
+
+		attachStreams[s.Index()] = info
+	}
+
+	// Read packets to collect image bytes for each attachment stream.
+	pkt := astiav.AllocPacket()
+
+	require.NotNil(t, pkt)
+
+	defer pkt.Free()
+
+	for {
+		if err := fmtCtx.ReadFrame(pkt); err != nil {
+			break
+		}
+
+		if info, ok := attachStreams[pkt.StreamIndex()]; ok && info.data == nil {
+			d := pkt.Data()
+			copied := make([]byte, len(d))
+			copy(copied, d)
+			info.data = copied
+		}
+
+		pkt.Unref()
+	}
+
+	result := make([]attachmentInfo, 0, len(attachStreams))
+	for _, info := range attachStreams {
+		result = append(result, *info)
+	}
+
+	return result
+}
+
+// TestTranscode_WithCoverArt_JPEG verifies that a JPEG cover art attachment is
+// embedded in the output MKV with the correct bytes and metadata.
+func TestTranscode_WithCoverArt_JPEG(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01}
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	err := ffmpeg.NewTranscode(testVideoPath, output).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCoverArt(jpegBytes, "image/jpeg").
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	attachments := probeAttachments(t, output)
+	require.Len(t, attachments, 1, "output must contain exactly one attachment stream")
+	assert.Equal(t, jpegBytes, attachments[0].data)
+	assert.Equal(t, "image/jpeg", attachments[0].mimeType)
+	assert.Equal(t, "cover.jpg", attachments[0].filename)
+}
+
+// TestTranscode_WithCoverArt_PNG verifies that a PNG cover art attachment is
+// embedded in the output MKV with the correct bytes and metadata.
+func TestTranscode_WithCoverArt_PNG(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	err := ffmpeg.NewTranscode(testVideoPath, output).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCoverArt(pngBytes, "image/png").
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	attachments := probeAttachments(t, output)
+	require.Len(t, attachments, 1, "output must contain exactly one attachment stream")
+	assert.Equal(t, pngBytes, attachments[0].data)
+	assert.Equal(t, "image/png", attachments[0].mimeType)
+	assert.Equal(t, "cover.png", attachments[0].filename)
+}
+
+// TestTranscode_WithCoverArt_ExistingAttachmentsStripped verifies that when
+// cover art is provided, any existing attachment streams in the source file are
+// excluded from the output — only the new poster is embedded.
+func TestTranscode_WithCoverArt_ExistingAttachmentsStripped(t *testing.T) {
+	oldArt := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01}
+	newArt := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	dir := t.TempDir()
+
+	// Step 1: create an MKV with an existing JPEG attachment.
+	withOld := filepath.Join(dir, "with_old.mkv")
+	err := ffmpeg.NewTranscode(testVideoPath, withOld).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCoverArt(oldArt, "image/jpeg").
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	// Sanity check: the intermediate file has exactly one attachment.
+	require.Len(t, probeAttachments(t, withOld), 1, "intermediate file must have one attachment")
+
+	// Step 2: transcode the MKV again with new PNG artwork. The old attachment
+	// must be stripped and only the new one embedded.
+	withNew := filepath.Join(dir, "with_new.mkv")
+	err = ffmpeg.NewTranscode(withOld, withNew).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCoverArt(newArt, "image/png").
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	attachments := probeAttachments(t, withNew)
+	require.Len(t, attachments, 1, "output must contain exactly one attachment (old one stripped)")
+	assert.Equal(t, newArt, attachments[0].data)
+	assert.Equal(t, "image/png", attachments[0].mimeType)
+}
+
+// TestTranscode_WithCoverArt_NilBytesIsNoop verifies that calling WithCoverArt
+// with nil bytes is a no-op: the output contains no attachment streams.
+func TestTranscode_WithCoverArt_NilBytesIsNoop(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	err := ffmpeg.NewTranscode(testVideoPath, output).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCoverArt(nil, "image/jpeg").
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	assert.Empty(t, probeAttachments(t, output), "no attachment expected when cover art bytes are nil")
+}
+
 // TestDetectHardwareEncoders_ValidResult verifies that DetectHardwareEncoders
 // returns only valid HWAccel constants for each supported codec. The test is
 // self-adapting: it passes whether or not hardware is present.

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -1,0 +1,86 @@
+// Package artwork provides shared utilities for fetching poster images from
+// arr-style media library services (Radarr, Sonarr).
+package artwork
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golift.io/starr"
+)
+
+const (
+	// MimeJPEG is the MIME type for JPEG images.
+	MimeJPEG = "image/jpeg"
+	// MimePNG is the MIME type for PNG images.
+	MimePNG = "image/png"
+)
+
+// FetchPosterImage finds the poster image in images, fetches it from baseURL
+// using the provided API key, and returns the bytes and MIME type.
+// Returns nil bytes (no error) when no JPEG or PNG poster is available or
+// the image type cannot be validated.
+func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKey string) ([]byte, string, error) {
+	for _, img := range images {
+		if img.CoverType != "poster" {
+			continue
+		}
+
+		// Pre-fetch extension check: only accept JPEG and PNG.
+		ext := strings.ToLower(img.Extension)
+		if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
+			return nil, "", nil
+		}
+
+		imageURL := img.URL
+		if imageURL == "" {
+			imageURL = img.RemoteURL
+		}
+
+		if imageURL == "" {
+			return nil, "", nil
+		}
+
+		// Relative paths are served by the arr instance; prepend the base URL.
+		if strings.HasPrefix(imageURL, "/") {
+			imageURL = strings.TrimRight(baseURL, "/") + imageURL
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+		if err != nil {
+			return nil, "", fmt.Errorf("build image request: %w", err)
+		}
+
+		req.Header.Set("X-Api-Key", apiKey)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, "", fmt.Errorf("fetch poster image: %w", err)
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+
+		// Post-fetch Content-Type validation.
+		ct := resp.Header.Get("Content-Type")
+		// Strip parameters like "; charset=utf-8".
+		if i := strings.Index(ct, ";"); i >= 0 {
+			ct = strings.TrimSpace(ct[:i])
+		}
+
+		if ct != MimeJPEG && ct != MimePNG {
+			return nil, "", nil
+		}
+
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", fmt.Errorf("read poster image: %w", err)
+		}
+
+		return data, ct, nil
+	}
+
+	return nil, "", nil
+}

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
+	"time"
 
 	"golift.io/starr"
 )
@@ -17,13 +19,21 @@ const (
 	MimeJPEG = "image/jpeg"
 	// MimePNG is the MIME type for PNG images.
 	MimePNG = "image/png"
+
+	// fetchTimeout is the per-request deadline for poster image downloads.
+	fetchTimeout = 10 * time.Second
 )
 
 // FetchPosterImage finds the poster image in images, fetches it from baseURL
 // using the provided API key, and returns the bytes and MIME type.
 // Returns nil bytes (no error) when no JPEG or PNG poster is available or
 // the image type cannot be validated.
+//
+// The API key is only sent when the resolved image URL starts with baseURL.
+// RemoteURL values (absolute external URLs) are fetched without the API key.
 func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKey string) ([]byte, string, error) {
+	normalizedBase := strings.TrimRight(baseURL, "/")
+
 	for _, img := range images {
 		if img.CoverType != "poster" {
 			continue
@@ -46,15 +56,22 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 		// Relative paths are served by the arr instance; prepend the base URL.
 		if strings.HasPrefix(imageURL, "/") {
-			imageURL = strings.TrimRight(baseURL, "/") + imageURL
+			imageURL = normalizedBase + imageURL
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+		fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, imageURL, nil)
 		if err != nil {
 			return nil, "", fmt.Errorf("build image request: %w", err)
 		}
 
-		req.Header.Set("X-Api-Key", apiKey)
+		// Only send the API key when fetching from the configured arr instance.
+		// RemoteURL values may point to external CDNs and must not receive it.
+		if strings.HasPrefix(imageURL, normalizedBase) {
+			req.Header.Set("X-Api-Key", apiKey)
+		}
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -63,14 +80,9 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 		defer func() { _ = resp.Body.Close() }()
 
-		// Post-fetch Content-Type validation.
-		ct := resp.Header.Get("Content-Type")
-		// Strip parameters like "; charset=utf-8".
-		if i := strings.Index(ct, ";"); i >= 0 {
-			ct = strings.TrimSpace(ct[:i])
-		}
-
-		if ct != MimeJPEG && ct != MimePNG {
+		// Post-fetch Content-Type validation using the standard MIME parser.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil || (ct != MimeJPEG && ct != MimePNG) {
 			return nil, "", nil
 		}
 

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
@@ -27,7 +28,7 @@ const (
 	// MaxPosterBytes caps the response body read to prevent memory exhaustion
 	// from unexpectedly large responses (e.g. from an external RemoteURL).
 	// Responses larger than this limit are skipped as if no poster were available.
-	MaxPosterBytes = 10 << 20 // 10 MiB
+	MaxPosterBytes = 10 * 1024 * 1024 // 10 MiB
 )
 
 // FetchPosterImage finds the poster image in images, fetches it from baseURL
@@ -72,98 +73,111 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 		},
 	}
 
-	normalizedBase := baseU.Scheme + "://" + baseU.Host + strings.TrimRight(baseU.Path, "/")
+	// normalizedBaseURL is the base URL without trailing slash, query, or
+	// fragment — used to expand relative image paths.
+	normalizedBaseURL := &url.URL{Scheme: baseU.Scheme, Host: baseU.Host, Path: strings.TrimRight(baseU.Path, "/")}
 
 	for _, img := range images {
-		if img.CoverType != "poster" {
-			continue
-		}
-
-		// Pre-fetch extension check: only accept JPEG and PNG.
-		ext := strings.ToLower(img.Extension)
-		if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
-			continue
-		}
-
-		imageURL := img.URL
-		if imageURL == "" {
-			imageURL = img.RemoteURL
-		}
-
-		if imageURL == "" {
-			continue
-		}
-
-		// Relative paths are served by the arr instance; prepend the base URL.
-		if strings.HasPrefix(imageURL, "/") {
-			imageURL = normalizedBase + imageURL
-		}
-
-		imageU, err := url.Parse(imageURL)
+		data, ct, err := fetchPosterCandidate(ctx, img, normalizedBaseURL, isSameBase, httpClient, apiKey)
 		if err != nil {
-			return nil, "", fmt.Errorf("parse image URL: %w", err)
+			return nil, "", err
 		}
 
-		// fetchCtx and cancel are managed explicitly (not via defer) to ensure
-		// resources are released before continuing to the next candidate.
-		fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
-
-		req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, imageURL, nil)
-		if err != nil {
-			cancel()
-
-			return nil, "", fmt.Errorf("build image request: %w", err)
+		if data != nil {
+			return data, ct, nil
 		}
-
-		// Only send the API key when fetching from the configured arr instance.
-		// RemoteURL values may point to external CDNs and must not receive it.
-		if isSameBase(imageU) {
-			req.Header.Set("X-Api-Key", apiKey)
-		}
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			cancel()
-
-			return nil, "", fmt.Errorf("fetch poster image: %w", err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			_ = resp.Body.Close()
-
-			cancel()
-
-			continue
-		}
-
-		// Post-fetch Content-Type validation using the standard MIME parser.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil || (ct != MimeJPEG && ct != MimePNG) {
-			_ = resp.Body.Close()
-
-			cancel()
-
-			continue
-		}
-
-		// Read one byte beyond the cap to detect responses that exceed the limit.
-		// If the read returns more than MaxPosterBytes, skip this candidate rather
-		// than silently truncating the image data.
-		data, err := io.ReadAll(io.LimitReader(resp.Body, MaxPosterBytes+1))
-		_ = resp.Body.Close()
-
-		cancel()
-
-		if err != nil {
-			return nil, "", fmt.Errorf("read poster image: %w", err)
-		}
-
-		if len(data) > MaxPosterBytes {
-			continue
-		}
-
-		return data, ct, nil
 	}
 
 	return nil, "", nil
+}
+
+// fetchPosterCandidate attempts to fetch a single poster image candidate.
+// Returns non-nil bytes and a MIME type on success.
+// Returns nil bytes (no error) when the candidate should be skipped.
+// Returns a non-nil error only for hard failures (unreachable host, URL parse
+// error, or body read error) that should abort the entire fetch.
+func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseURL *url.URL, isSameBase func(*url.URL) bool, httpClient *http.Client, apiKey string) ([]byte, string, error) {
+	if img.CoverType != "poster" {
+		return nil, "", nil
+	}
+
+	// Pre-fetch extension check: only accept JPEG and PNG.
+	ext := strings.ToLower(img.Extension)
+	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
+		slog.WarnContext(ctx, "skipping poster candidate: unsupported extension", "extension", img.Extension)
+
+		return nil, "", nil
+	}
+
+	imageURL := img.URL
+	if imageURL == "" {
+		imageURL = img.RemoteURL
+	}
+
+	if imageURL == "" {
+		slog.WarnContext(ctx, "skipping poster candidate: no URL or RemoteURL set")
+
+		return nil, "", nil
+	}
+
+	// Relative paths are served by the arr instance; prepend the base URL.
+	if strings.HasPrefix(imageURL, "/") {
+		imageURL = normalizedBaseURL.String() + imageURL
+	}
+
+	imageU, err := url.Parse(imageURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse image URL: %w", err)
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("build image request: %w", err)
+	}
+
+	// Only send the API key when fetching from the configured arr instance.
+	// RemoteURL values may point to external CDNs and must not receive it.
+	if isSameBase(imageU) {
+		req.Header.Set("X-Api-Key", apiKey)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch poster image: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.WarnContext(ctx, "skipping poster candidate: non-200 response", "status", resp.StatusCode, "url", imageURL)
+
+		return nil, "", nil
+	}
+
+	// Post-fetch Content-Type validation using the standard MIME parser.
+	ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || (ct != MimeJPEG && ct != MimePNG) {
+		slog.WarnContext(ctx, "skipping poster candidate: unsupported content type", "content_type", resp.Header.Get("Content-Type"), "url", imageURL)
+
+		return nil, "", nil
+	}
+
+	// Read one byte beyond the cap to detect responses that exceed the limit.
+	// If the read returns more than MaxPosterBytes, skip this candidate rather
+	// than silently truncating the image data.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxPosterBytes+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("read poster image: %w", err)
+	}
+
+	if len(data) > MaxPosterBytes {
+		slog.WarnContext(ctx, "skipping poster candidate: response exceeds size limit", "limit_bytes", MaxPosterBytes, "url", imageURL)
+
+		return nil, "", nil
+	}
+
+	return data, ct, nil
 }

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -29,10 +29,23 @@ const (
 // Returns nil bytes (no error) when no JPEG or PNG poster is available or
 // the image type cannot be validated.
 //
-// The API key is only sent when the resolved image URL starts with baseURL.
-// RemoteURL values (absolute external URLs) are fetched without the API key.
+// The API key is only sent for requests whose URL starts with baseURL.
+// Redirects that leave the baseURL origin are not followed, ensuring the
+// API key is never forwarded to an external host.
 func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKey string) ([]byte, string, error) {
 	normalizedBase := strings.TrimRight(baseURL, "/")
+
+	// Use a client that refuses to follow redirects outside the configured
+	// arr instance, preventing API key leakage to external hosts.
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !strings.HasPrefix(req.URL.String(), normalizedBase) {
+				return http.ErrUseLastResponse
+			}
+
+			return nil
+		},
+	}
 
 	for _, img := range images {
 		if img.CoverType != "poster" {
@@ -73,7 +86,7 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 			req.Header.Set("X-Api-Key", apiKey)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return nil, "", fmt.Errorf("fetch poster image: %w", err)
 		}

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -22,6 +23,10 @@ const (
 
 	// fetchTimeout is the per-request deadline for poster image downloads.
 	fetchTimeout = 10 * time.Second
+
+	// maxPosterBytes caps the response body read to prevent memory exhaustion
+	// from unexpectedly large responses (e.g. from an external RemoteURL).
+	maxPosterBytes = 10 << 20 // 10 MiB
 )
 
 // FetchPosterImage finds the poster image in images, fetches it from baseURL
@@ -29,25 +34,44 @@ const (
 // Returns nil bytes (no error) when no JPEG or PNG poster is available or
 // the image type cannot be validated.
 //
-// The API key is only sent for requests whose URL starts with baseURL.
-// Redirects that leave the baseURL origin are not followed, ensuring the
-// API key is never forwarded to an external host.
+// The API key is only sent for requests (including redirects) whose URL shares
+// the same scheme, host, and path prefix as baseURL. Redirects that leave the
+// baseURL origin are still followed, but the API key header is stripped before
+// the redirected request is sent to ensure credentials are never forwarded to
+// an external host.
 func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKey string) ([]byte, string, error) {
-	normalizedBase := strings.TrimRight(baseURL, "/")
+	baseU, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse base URL: %w", err)
+	}
 
-	// Use a client that strips the API key header before following any redirect
-	// whose target URL does not start with the configured arr base URL. This
-	// allows redirects to be followed (e.g. to an external CDN) while ensuring
-	// the API key is exclusively sent to the configured arr instance.
+	// Normalize the base path for prefix comparison. Appending "/" prevents
+	// "/radarr" from matching "/radarr-attacker".
+	basePathPrefix := strings.TrimRight(baseU.Path, "/") + "/"
+
+	// isSameBase reports whether u shares the same scheme, host, and path
+	// prefix as the configured arr instance.
+	isSameBase := func(u *url.URL) bool {
+		return u.Scheme == baseU.Scheme &&
+			u.Host == baseU.Host &&
+			strings.HasPrefix(u.Path+"/", basePathPrefix)
+	}
+
+	// Use a client that strips the API key header on any redirect whose target
+	// does not share the configured arr base origin and path. This allows
+	// redirects to external CDNs to be followed while ensuring the API key is
+	// exclusively sent to the configured arr instance.
 	httpClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if !strings.HasPrefix(req.URL.String(), normalizedBase) {
+			if !isSameBase(req.URL) {
 				req.Header.Del("X-Api-Key")
 			}
 
 			return nil
 		},
 	}
+
+	normalizedBase := baseU.Scheme + "://" + baseU.Host + strings.TrimRight(baseU.Path, "/")
 
 	for _, img := range images {
 		if img.CoverType != "poster" {
@@ -74,6 +98,11 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 			imageURL = normalizedBase + imageURL
 		}
 
+		imageU, err := url.Parse(imageURL)
+		if err != nil {
+			return nil, "", fmt.Errorf("parse image URL: %w", err)
+		}
+
 		fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 		defer cancel()
 
@@ -84,7 +113,7 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 		// Only send the API key when fetching from the configured arr instance.
 		// RemoteURL values may point to external CDNs and must not receive it.
-		if strings.HasPrefix(imageURL, normalizedBase) {
+		if isSameBase(imageU) {
 			req.Header.Set("X-Api-Key", apiKey)
 		}
 
@@ -95,13 +124,17 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 		defer func() { _ = resp.Body.Close() }()
 
+		if resp.StatusCode != http.StatusOK {
+			return nil, "", nil
+		}
+
 		// Post-fetch Content-Type validation using the standard MIME parser.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil || (ct != MimeJPEG && ct != MimePNG) {
 			return nil, "", nil
 		}
 
-		data, err := io.ReadAll(resp.Body)
+		data, err := io.ReadAll(io.LimitReader(resp.Body, maxPosterBytes))
 		if err != nil {
 			return nil, "", fmt.Errorf("read poster image: %w", err)
 		}

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -24,9 +24,10 @@ const (
 	// fetchTimeout is the per-request deadline for poster image downloads.
 	fetchTimeout = 10 * time.Second
 
-	// maxPosterBytes caps the response body read to prevent memory exhaustion
+	// MaxPosterBytes caps the response body read to prevent memory exhaustion
 	// from unexpectedly large responses (e.g. from an external RemoteURL).
-	maxPosterBytes = 10 << 20 // 10 MiB
+	// Responses larger than this limit are skipped as if no poster were available.
+	MaxPosterBytes = 10 << 20 // 10 MiB
 )
 
 // FetchPosterImage finds the poster image in images, fetches it from baseURL
@@ -81,7 +82,7 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 		// Pre-fetch extension check: only accept JPEG and PNG.
 		ext := strings.ToLower(img.Extension)
 		if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
-			return nil, "", nil
+			continue
 		}
 
 		imageURL := img.URL
@@ -90,7 +91,7 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 		}
 
 		if imageURL == "" {
-			return nil, "", nil
+			continue
 		}
 
 		// Relative paths are served by the arr instance; prepend the base URL.
@@ -103,11 +104,14 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 			return nil, "", fmt.Errorf("parse image URL: %w", err)
 		}
 
+		// fetchCtx and cancel are managed explicitly (not via defer) to ensure
+		// resources are released before continuing to the next candidate.
 		fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
-		defer cancel()
 
 		req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, imageURL, nil)
 		if err != nil {
+			cancel()
+
 			return nil, "", fmt.Errorf("build image request: %w", err)
 		}
 
@@ -119,24 +123,43 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
+			cancel()
+
 			return nil, "", fmt.Errorf("fetch poster image: %w", err)
 		}
 
-		defer func() { _ = resp.Body.Close() }()
-
 		if resp.StatusCode != http.StatusOK {
-			return nil, "", nil
+			_ = resp.Body.Close()
+
+			cancel()
+
+			continue
 		}
 
 		// Post-fetch Content-Type validation using the standard MIME parser.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil || (ct != MimeJPEG && ct != MimePNG) {
-			return nil, "", nil
+			_ = resp.Body.Close()
+
+			cancel()
+
+			continue
 		}
 
-		data, err := io.ReadAll(io.LimitReader(resp.Body, maxPosterBytes))
+		// Read one byte beyond the cap to detect responses that exceed the limit.
+		// If the read returns more than MaxPosterBytes, skip this candidate rather
+		// than silently truncating the image data.
+		data, err := io.ReadAll(io.LimitReader(resp.Body, MaxPosterBytes+1))
+		_ = resp.Body.Close()
+
+		cancel()
+
 		if err != nil {
 			return nil, "", fmt.Errorf("read poster image: %w", err)
+		}
+
+		if len(data) > MaxPosterBytes {
+			continue
 		}
 
 		return data, ct, nil

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -78,13 +78,15 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 	normalizedBaseURL := &url.URL{Scheme: baseU.Scheme, Host: baseU.Host, Path: strings.TrimRight(baseU.Path, "/")}
 
 	for _, img := range images {
-		data, ct, err := fetchPosterCandidate(ctx, img, normalizedBaseURL, isSameBase, httpClient, apiKey)
+		data, mimeType, err := fetchPosterCandidate(ctx, img, normalizedBaseURL, isSameBase, httpClient, apiKey)
 		if err != nil {
-			return nil, "", err
+			slog.WarnContext(ctx, "skipping poster candidate: fetch error", "error", err)
+
+			continue
 		}
 
 		if data != nil {
-			return data, ct, nil
+			return data, mimeType, nil
 		}
 	}
 
@@ -93,9 +95,10 @@ func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKe
 
 // fetchPosterCandidate attempts to fetch a single poster image candidate.
 // Returns non-nil bytes and a MIME type on success.
-// Returns nil bytes (no error) when the candidate should be skipped.
-// Returns a non-nil error only for hard failures (unreachable host, URL parse
-// error, or body read error) that should abort the entire fetch.
+// Returns nil bytes (no error) when the candidate should be skipped (unsupported
+// extension, empty URL, non-200 response, unsupported content type, or oversized body).
+// Returns a non-nil error for hard I/O failures (URL parse error, request build
+// error, network error, or body read error); callers should log and skip the candidate.
 func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseURL *url.URL, isSameBase func(*url.URL) bool, httpClient *http.Client, apiKey string) ([]byte, string, error) {
 	if img.CoverType != "poster" {
 		return nil, "", nil
@@ -158,8 +161,8 @@ func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseU
 	}
 
 	// Post-fetch Content-Type validation using the standard MIME parser.
-	ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	if err != nil || (ct != MimeJPEG && ct != MimePNG) {
+	mimeType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || (mimeType != MimeJPEG && mimeType != MimePNG) {
 		slog.WarnContext(ctx, "skipping poster candidate: unsupported content type", "content_type", resp.Header.Get("Content-Type"), "url", imageURL)
 
 		return nil, "", nil
@@ -179,5 +182,5 @@ func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseU
 		return nil, "", nil
 	}
 
-	return data, ct, nil
+	return data, mimeType, nil
 }

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -35,12 +35,14 @@ const (
 func FetchPosterImage(ctx context.Context, images []*starr.Image, baseURL, apiKey string) ([]byte, string, error) {
 	normalizedBase := strings.TrimRight(baseURL, "/")
 
-	// Use a client that refuses to follow redirects outside the configured
-	// arr instance, preventing API key leakage to external hosts.
+	// Use a client that strips the API key header before following any redirect
+	// whose target URL does not start with the configured arr base URL. This
+	// allows redirects to be followed (e.g. to an external CDN) while ensuring
+	// the API key is exclusively sent to the configured arr instance.
 	httpClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if !strings.HasPrefix(req.URL.String(), normalizedBase) {
-				return http.ErrUseLastResponse
+				req.Header.Del("X-Api-Key")
 			}
 
 			return nil

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -1,6 +1,7 @@
 package artwork_test
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -219,4 +220,65 @@ func TestFetchPosterImage_Unreachable(t *testing.T) {
 
 	_, _, err := artwork.FetchPosterImage(t.Context(), imgs, "http://127.0.0.1:1", "key")
 	require.Error(t, err)
+}
+
+// TestFetchPosterImage_FallsBackToNextCandidate verifies that a rejected
+// candidate (unsupported extension, bad Content-Type, non-200 status) causes
+// the function to continue to the next poster image rather than returning
+// immediately with nil.
+func TestFetchPosterImage_FallsBackToNextCandidate(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+	srv := imageServer(t, "test-key", "image/jpeg", jpegBytes)
+	t.Cleanup(srv.Close)
+
+	// The first image has an unsupported extension; the second is a valid JPEG.
+	imgs := []*starr.Image{
+		{CoverType: "poster", Extension: ".webp", URL: "/MediaCover/1/poster.webp"},
+		{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"},
+	}
+
+	gotBytes, gotMime, err := artwork.FetchPosterImage(t.Context(), imgs, srv.URL, "test-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes, gotBytes, "second candidate must be returned when first is rejected")
+	assert.Equal(t, "image/jpeg", gotMime)
+}
+
+// TestFetchPosterImage_OversizedResponseSkipped verifies that a response body
+// larger than MaxPosterBytes is skipped rather than silently truncated.
+func TestFetchPosterImage_OversizedResponseSkipped(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+	// oversizedBody is one byte more than the allowed cap.
+	oversizedBody := bytes.Repeat([]byte{0xFF}, artwork.MaxPosterBytes+1)
+
+	var callCount int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		switch callCount {
+		case 1:
+			// First request: return an oversized body.
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write(oversizedBody)
+		default:
+			// Subsequent requests: return a valid small JPEG.
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write(jpegBytes)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	imgs := []*starr.Image{
+		{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster-large.jpg"},
+		{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster-small.jpg"},
+	}
+
+	gotBytes, gotMime, err := artwork.FetchPosterImage(t.Context(), imgs, srv.URL, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes, gotBytes, "oversized first candidate must be skipped; second must be returned")
+	assert.Equal(t, "image/jpeg", gotMime)
 }

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -179,6 +179,38 @@ func TestFetchPosterImage_RemoteURLExternalHost(t *testing.T) {
 	assert.Equal(t, "image/jpeg", gotMime)
 }
 
+// TestFetchPosterImage_CrossHostRedirectDoesNotSendAPIKey verifies that the API
+// key is not forwarded when the arr server issues a redirect to an external host.
+// The external server records whether it received the key; the test asserts it did not.
+func TestFetchPosterImage_CrossHostRedirectDoesNotSendAPIKey(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+	var keyReceived bool
+
+	// External server: records whether it received the API key.
+	externalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" {
+			keyReceived = true
+		}
+
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(jpegBytes)
+	}))
+	t.Cleanup(externalSrv.Close)
+
+	// Arr server: responds to poster requests with a redirect to the external server.
+	arrSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, externalSrv.URL+"/poster.jpg", http.StatusFound)
+	}))
+	t.Cleanup(arrSrv.Close)
+
+	imgs := []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
+
+	_, _, _ = artwork.FetchPosterImage(t.Context(), imgs, arrSrv.URL, "secret-key")
+
+	assert.False(t, keyReceived, "API key must not be forwarded to external redirect target")
+}
+
 func TestFetchPosterImage_Unreachable(t *testing.T) {
 	imgs := []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
 

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -144,6 +144,41 @@ func TestFetchPosterImage(t *testing.T) {
 	}
 }
 
+// TestFetchPosterImage_RemoteURLExternalHost verifies that the API key is NOT
+// forwarded when the image URL is a RemoteURL pointing to an external host.
+// The external server is configured to reject requests that carry the key,
+// so the test fails if the key is incorrectly forwarded.
+func TestFetchPosterImage_RemoteURLExternalHost(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+	// External CDN: rejects any request that carries an API key.
+	externalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" {
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(jpegBytes)
+	}))
+	t.Cleanup(externalSrv.Close)
+
+	imgs := []*starr.Image{{
+		CoverType: "poster",
+		Extension: ".jpg",
+		URL:       "",
+		RemoteURL: externalSrv.URL + "/poster.jpg",
+	}}
+
+	// baseURL is different from the external server — so the key must not be sent.
+	gotBytes, gotMime, err := artwork.FetchPosterImage(t.Context(), imgs, "http://radarr.local:7878", "secret-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes, gotBytes)
+	assert.Equal(t, "image/jpeg", gotMime)
+}
+
 func TestFetchPosterImage_Unreachable(t *testing.T) {
 	imgs := []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
 

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -1,0 +1,152 @@
+package artwork_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golift.io/starr"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/artwork"
+)
+
+// imageServer returns a test HTTP server that serves the given body with the
+// given Content-Type, requiring the X-Api-Key header to equal wantKey.
+func imageServer(t *testing.T, wantKey, contentType string, body []byte) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != wantKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestFetchPosterImage(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	tests := []struct {
+		name      string
+		images    func(baseURL string) []*starr.Image
+		wantBytes []byte
+		wantMime  string
+		errFunc   require.ErrorAssertionFunc
+	}{
+		{
+			name: "JPEG poster image is returned",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
+			},
+			wantBytes: jpegBytes,
+			wantMime:  "image/jpeg",
+		},
+		{
+			name: "PNG poster image is returned",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: ".png", URL: "/MediaCover/1/poster.png"}}
+			},
+			wantBytes: pngBytes,
+			wantMime:  "image/png",
+		},
+		{
+			name: "non-poster images are skipped",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{
+					{CoverType: "fanart", Extension: ".jpg", URL: "/MediaCover/1/fanart.jpg"},
+				}
+			},
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "unsupported extension returns nil",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: ".webp", URL: "/MediaCover/1/poster.webp"}}
+			},
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "empty extension returns nil",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: "", URL: "/MediaCover/1/poster"}}
+			},
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "empty image list returns nil",
+			images: func(baseURL string) []*starr.Image {
+				return nil
+			},
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "absolute URL (RemoteURL) is used when URL is empty",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "", RemoteURL: baseURL + "/remote/poster.jpg"}}
+			},
+			wantBytes: jpegBytes,
+			wantMime:  "image/jpeg",
+		},
+		{
+			name: "unsupported Content-Type from server returns nil",
+			images: func(baseURL string) []*starr.Image {
+				return []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
+			},
+			wantBytes: nil,
+			wantMime:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var contentType string
+
+			var respBody []byte
+
+			switch tc.name {
+			case "PNG poster image is returned":
+				contentType = "image/png"
+				respBody = pngBytes
+			case "unsupported Content-Type from server returns nil":
+				contentType = "image/webp"
+				respBody = []byte("webp data")
+			default:
+				contentType = "image/jpeg"
+				respBody = jpegBytes
+			}
+
+			srv := imageServer(t, "test-key", contentType, respBody)
+			t.Cleanup(srv.Close)
+
+			imgs := tc.images(srv.URL)
+
+			gotBytes, gotMime, err := artwork.FetchPosterImage(t.Context(), imgs, srv.URL, "test-key")
+
+			errFunc := tc.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, err)
+			assert.Equal(t, tc.wantBytes, gotBytes)
+			assert.Equal(t, tc.wantMime, gotMime)
+		})
+	}
+}
+
+func TestFetchPosterImage_Unreachable(t *testing.T) {
+	imgs := []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
+
+	_, _, err := artwork.FetchPosterImage(t.Context(), imgs, "http://127.0.0.1:1", "key")
+	require.Error(t, err)
+}

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -206,8 +206,11 @@ func TestFetchPosterImage_CrossHostRedirectDoesNotSendAPIKey(t *testing.T) {
 
 	imgs := []*starr.Image{{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/1/poster.jpg"}}
 
-	_, _, _ = artwork.FetchPosterImage(t.Context(), imgs, arrSrv.URL, "secret-key")
+	gotBytes, gotMime, err := artwork.FetchPosterImage(t.Context(), imgs, arrSrv.URL, "secret-key")
 
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes, gotBytes, "redirect must be followed and image returned")
+	assert.Equal(t, "image/jpeg", gotMime)
 	assert.False(t, keyReceived, "API key must not be forwarded to external redirect target")
 }
 

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -186,12 +187,12 @@ func TestFetchPosterImage_RemoteURLExternalHost(t *testing.T) {
 func TestFetchPosterImage_CrossHostRedirectDoesNotSendAPIKey(t *testing.T) {
 	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
 
-	var keyReceived bool
+	var keyReceived atomic.Bool
 
 	// External server: records whether it received the API key.
 	externalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Api-Key") != "" {
-			keyReceived = true
+			keyReceived.Store(true)
 		}
 
 		w.Header().Set("Content-Type", "image/jpeg")
@@ -212,7 +213,7 @@ func TestFetchPosterImage_CrossHostRedirectDoesNotSendAPIKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, jpegBytes, gotBytes, "redirect must be followed and image returned")
 	assert.Equal(t, "image/jpeg", gotMime)
-	assert.False(t, keyReceived, "API key must not be forwarded to external redirect target")
+	assert.False(t, keyReceived.Load(), "API key must not be forwarded to external redirect target")
 }
 
 func TestFetchPosterImage_Unreachable(t *testing.T) {

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -124,8 +124,10 @@ type ArrLibrary interface {
 	// Returns ErrNotFound if no item is identified.
 	GetInfo(ctx context.Context, path string) (MediaInfo, error)
 	// GetPosterImage returns the raw poster image bytes and MIME type for the
-	// media item at path. Returns nil bytes and empty MIME type (with no error)
-	// when no poster is available or the image type is not JPEG or PNG.
-	// Returns an error only when the library service is unreachable.
+	// media item at path. Returns ErrNotFound if the media item at path cannot
+	// be identified in the library. Returns nil bytes and empty MIME type (with
+	// no error) when a media item is found but no poster is available or the
+	// image type is not JPEG or PNG. Other errors indicate the library service
+	// is unreachable or returned an unexpected failure.
 	GetPosterImage(ctx context.Context, path string) (imageBytes []byte, mimeType string, err error)
 }

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -123,4 +123,9 @@ type ArrLibrary interface {
 	// GetInfo returns structured media metadata for the item at path.
 	// Returns ErrNotFound if no item is identified.
 	GetInfo(ctx context.Context, path string) (MediaInfo, error)
+	// GetPosterImage returns the raw poster image bytes and MIME type for the
+	// media item at path. Returns nil bytes and empty MIME type (with no error)
+	// when no poster is available or the image type is not JPEG or PNG.
+	// Returns an error only when the library service is unreachable.
+	GetPosterImage(ctx context.Context, path string) (imageBytes []byte, mimeType string, err error)
 }

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -101,8 +101,9 @@ func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Mov
 
 // GetPosterImage implements medialib.ArrLibrary. It returns the raw poster
 // image bytes and MIME type for the movie at path. Returns nil bytes (no error)
-// when no JPEG or PNG poster is available. Returns an error if the library is
-// unreachable.
+// when no JPEG or PNG poster is available. Returns medialib.ErrNotFound if the
+// path cannot be matched to a movie. Returns other errors if the library is
+// unreachable or a Radarr API call fails.
 func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
 	movie, err := c.GetMovieByFilePath(ctx, path)
 	if err != nil {

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -12,6 +12,7 @@ import (
 	radarrlib "golift.io/starr/radarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/artwork"
 )
 
 // Compile-time assertions that *Client implements medialib.MovieLibrary and medialib.ArrLibrary.
@@ -96,6 +97,24 @@ func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Mov
 	}
 
 	return output.Movie, nil
+}
+
+// GetPosterImage implements medialib.ArrLibrary. It returns the raw poster
+// image bytes and MIME type for the movie at path. Returns nil bytes (no error)
+// when no JPEG or PNG poster is available. Returns an error if the library is
+// unreachable.
+func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
+	movie, err := c.GetMovieByFilePath(ctx, path)
+	if err != nil {
+		return nil, "", fmt.Errorf("get movie for poster: %w", err)
+	}
+
+	full, err := c.radarr.GetMovieByIDContext(ctx, movie.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get movie details for poster: %w", err)
+	}
+
+	return artwork.FetchPosterImage(ctx, full.Images, c.cfg.URL, c.cfg.APIKey)
 }
 
 // GetInfo implements medialib.ArrLibrary. It returns structured metadata for

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -3,12 +3,14 @@ package radarr_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golift.io/starr"
 	radarrlib "golift.io/starr/radarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
@@ -24,19 +26,47 @@ type parseResponse struct {
 	Movie *radarrlib.Movie `json:"movie"`
 }
 
+// testServerConfig holds configuration for test HTTP servers.
+type testServerConfig struct {
+	parseResp *parseResponse
+	movieByID *radarrlib.Movie // response for /api/v3/movie/{id}
+	imageBody []byte           // raw bytes served at image paths
+	imageType string           // Content-Type for image responses
+}
+
 func newTestServer(t *testing.T, parseResp *parseResponse) *httptest.Server {
+	t.Helper()
+	return newTestServerWithConfig(t, testServerConfig{parseResp: parseResp})
+}
+
+func newTestServerWithConfig(t *testing.T, cfg testServerConfig) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(parseResp))
+		require.NoError(t, json.NewEncoder(w).Encode(cfg.parseResp))
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(&radarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	mux.HandleFunc("/api/v3/movie/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(cfg.movieByID))
+	})
+
+	mux.HandleFunc("/MediaCover/", func(w http.ResponseWriter, r *http.Request) {
+		ct := cfg.imageType
+		if ct == "" {
+			ct = "image/jpeg"
+		}
+
+		w.Header().Set("Content-Type", ct)
+		_, _ = w.Write(cfg.imageBody)
 	})
 
 	return httptest.NewServer(mux)
@@ -216,6 +246,118 @@ func TestGetInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPosterImage(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	knownMovie := &radarrlib.Movie{ID: 42, Title: "The Matrix", Year: 1999}
+
+	tests := []struct {
+		name      string
+		movieByID *radarrlib.Movie
+		imageBody []byte
+		imageType string
+		wantBytes []byte
+		wantMime  string
+		errFunc   require.ErrorAssertionFunc
+	}{
+		{
+			name: "JPEG poster image returned",
+			movieByID: &radarrlib.Movie{
+				ID: 42,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/42/poster.jpg"},
+				},
+			},
+			imageBody: jpegBytes,
+			imageType: "image/jpeg",
+			wantBytes: jpegBytes,
+			wantMime:  "image/jpeg",
+		},
+		{
+			name: "PNG poster image returned",
+			movieByID: &radarrlib.Movie{
+				ID: 42,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".png", URL: "/MediaCover/42/poster.png"},
+				},
+			},
+			imageBody: pngBytes,
+			imageType: "image/png",
+			wantBytes: pngBytes,
+			wantMime:  "image/png",
+		},
+		{
+			name: "no poster image returns nil bytes",
+			movieByID: &radarrlib.Movie{
+				ID: 42,
+				Images: []*starr.Image{
+					{CoverType: "fanart", Extension: ".jpg", URL: "/MediaCover/42/fanart.jpg"},
+				},
+			},
+			imageBody: jpegBytes,
+			imageType: "image/jpeg",
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "unsupported image extension returns nil bytes",
+			movieByID: &radarrlib.Movie{
+				ID: 42,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".webp", URL: "/MediaCover/42/poster.webp"},
+				},
+			},
+			imageBody: []byte("webp"),
+			imageType: "image/webp",
+			wantBytes: nil,
+			wantMime:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServerWithConfig(t, testServerConfig{
+				parseResp: &parseResponse{Movie: knownMovie},
+				movieByID: tc.movieByID,
+				imageBody: tc.imageBody,
+				imageType: tc.imageType,
+			})
+			t.Cleanup(srv.Close)
+
+			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+			gotBytes, gotMime, err := client.GetPosterImage(t.Context(), "/movies/The.Matrix.1999.mkv")
+
+			errFunc := tc.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, err)
+			assert.Equal(t, tc.wantBytes, gotBytes)
+			assert.Equal(t, tc.wantMime, gotMime)
+		})
+	}
+}
+
+func TestGetPosterImage_MovieNotFound(t *testing.T) {
+	srv := newTestServer(t, &parseResponse{Movie: nil})
+	t.Cleanup(srv.Close)
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, _, err := client.GetPosterImage(t.Context(), "/movies/Unknown.mkv")
+	require.ErrorIs(t, err, medialib.ErrNotFound)
+}
+
+func TestGetPosterImage_UnreachableURL(t *testing.T) {
+	client := radarr.New(radarr.Config{URL: unreachableURL, APIKey: "test-key"})
+
+	_, _, err := client.GetPosterImage(t.Context(), fmt.Sprintf("%s/movies/file.mkv", unreachableURL))
+	require.Error(t, err)
 }
 
 func TestGetMovieByFilePath_ErrNotFoundSentinel(t *testing.T) {

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -11,6 +11,7 @@ import (
 	sonarrlib "golift.io/starr/sonarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/artwork"
 )
 
 // Compile-time assertions that *Client implements medialib.EpisodeLibrary and medialib.ArrLibrary.
@@ -88,6 +89,24 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 		SeasonNumber:  ep.SeasonNumber,
 		EpisodeNumber: ep.EpisodeNumber,
 	}, nil
+}
+
+// GetPosterImage implements medialib.ArrLibrary. It returns the raw poster
+// image bytes and MIME type for the series containing the episode at path.
+// Returns nil bytes (no error) when no JPEG or PNG poster is available.
+// Returns an error if the library is unreachable.
+func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
+	episode, err := c.GetEpisodeByFilePath(ctx, path)
+	if err != nil {
+		return nil, "", fmt.Errorf("get episode for poster: %w", err)
+	}
+
+	series, err := c.sonarr.GetSeriesByIDContext(ctx, episode.SeriesID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get series details for poster: %w", err)
+	}
+
+	return artwork.FetchPosterImage(ctx, series.Images, c.cfg.URL, c.cfg.APIKey)
 }
 
 // GetInfo implements medialib.ArrLibrary. It returns structured metadata for

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -94,7 +94,8 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 // GetPosterImage implements medialib.ArrLibrary. It returns the raw poster
 // image bytes and MIME type for the series containing the episode at path.
 // Returns nil bytes (no error) when no JPEG or PNG poster is available.
-// Returns an error if the library is unreachable.
+// Returns medialib.ErrNotFound if the path cannot be matched to an episode.
+// Returns other errors if the library is unreachable or a Sonarr API call fails.
 func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
 	episode, err := c.GetEpisodeByFilePath(ctx, path)
 	if err != nil {

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golift.io/starr"
 	sonarrlib "golift.io/starr/sonarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
@@ -19,19 +20,47 @@ import (
 // privileged port with no listener in any normal environment).
 const unreachableURL = "http://127.0.0.1:1"
 
+// sonarrTestServerConfig holds configuration for test HTTP servers.
+type sonarrTestServerConfig struct {
+	parseResp  *sonarrlib.ParseOutput
+	seriesByID *sonarrlib.Series // response for /api/v3/series/{id}
+	imageBody  []byte
+	imageType  string
+}
+
 func newSonarrTestServer(t *testing.T, parseResp *sonarrlib.ParseOutput) *httptest.Server {
+	t.Helper()
+	return newSonarrTestServerWithConfig(t, sonarrTestServerConfig{parseResp: parseResp})
+}
+
+func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(parseResp))
+		require.NoError(t, json.NewEncoder(w).Encode(cfg.parseResp))
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(&sonarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	mux.HandleFunc("/api/v3/series/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(cfg.seriesByID))
+	})
+
+	mux.HandleFunc("/MediaCover/", func(w http.ResponseWriter, r *http.Request) {
+		ct := cfg.imageType
+		if ct == "" {
+			ct = "image/jpeg"
+		}
+
+		w.Header().Set("Content-Type", ct)
+		_, _ = w.Write(cfg.imageBody)
 	})
 
 	return httptest.NewServer(mux)
@@ -254,6 +283,128 @@ func TestGetInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPosterImage(t *testing.T) {
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	knownParseOutput := &sonarrlib.ParseOutput{
+		Title: "Breaking Bad",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Breaking Bad",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
+		},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		seriesByID *sonarrlib.Series
+		imageBody  []byte
+		imageType  string
+		wantBytes  []byte
+		wantMime   string
+		errFunc    require.ErrorAssertionFunc
+	}{
+		{
+			name: "JPEG series poster returned",
+			seriesByID: &sonarrlib.Series{
+				ID: 10,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".jpg", URL: "/MediaCover/10/poster.jpg"},
+				},
+			},
+			imageBody: jpegBytes,
+			imageType: "image/jpeg",
+			wantBytes: jpegBytes,
+			wantMime:  "image/jpeg",
+		},
+		{
+			name: "PNG series poster returned",
+			seriesByID: &sonarrlib.Series{
+				ID: 10,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".png", URL: "/MediaCover/10/poster.png"},
+				},
+			},
+			imageBody: pngBytes,
+			imageType: "image/png",
+			wantBytes: pngBytes,
+			wantMime:  "image/png",
+		},
+		{
+			name: "no poster image returns nil bytes",
+			seriesByID: &sonarrlib.Series{
+				ID: 10,
+				Images: []*starr.Image{
+					{CoverType: "fanart", Extension: ".jpg", URL: "/MediaCover/10/fanart.jpg"},
+				},
+			},
+			imageBody: jpegBytes,
+			imageType: "image/jpeg",
+			wantBytes: nil,
+			wantMime:  "",
+		},
+		{
+			name: "unsupported image extension returns nil bytes",
+			seriesByID: &sonarrlib.Series{
+				ID: 10,
+				Images: []*starr.Image{
+					{CoverType: "poster", Extension: ".webp", URL: "/MediaCover/10/poster.webp"},
+				},
+			},
+			imageBody: []byte("webp"),
+			imageType: "image/webp",
+			wantBytes: nil,
+			wantMime:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+				parseResp:  knownParseOutput,
+				seriesByID: tc.seriesByID,
+				imageBody:  tc.imageBody,
+				imageType:  tc.imageType,
+			})
+			t.Cleanup(srv.Close)
+
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+			gotBytes, gotMime, err := client.GetPosterImage(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
+
+			errFunc := tc.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, err)
+			assert.Equal(t, tc.wantBytes, gotBytes)
+			assert.Equal(t, tc.wantMime, gotMime)
+		})
+	}
+}
+
+func TestGetPosterImage_EpisodeNotFound(t *testing.T) {
+	srv := newSonarrTestServer(t, &sonarrlib.ParseOutput{})
+	t.Cleanup(srv.Close)
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, _, err := client.GetPosterImage(t.Context(), "/tv/Unknown.S01E01.mkv")
+	require.ErrorIs(t, err, medialib.ErrNotFound)
+}
+
+func TestGetPosterImage_UnreachableURL(t *testing.T) {
+	client := sonarr.New(sonarr.Config{URL: unreachableURL, APIKey: "test-key"})
+
+	_, _, err := client.GetPosterImage(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
+	require.Error(t, err)
 }
 
 func TestGetEpisodeByFilePath_ErrNotFoundSentinel(t *testing.T) {

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -128,7 +128,17 @@ func NewMediaWorkflow(
 			return shared.TranscodeOutput{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		return shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir, cfg.HardwareDevicePath)
+		library, err := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
+		if err != nil {
+			return shared.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
+		}
+
+		out, err := shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir, cfg.HardwareDevicePath, library)
+		if err == nil && out.ArtworkFetchSkipped {
+			recorder.RecordArtworkFetchSkipped(ctx)
+		}
+
+		return out, err
 	}, hatchet.WithParents(probeTask), skipIfInvalid)
 
 	// notify: look up the media in Radarr (movie) or Sonarr (show) and trigger a library

--- a/workflows/media/recorder.go
+++ b/workflows/media/recorder.go
@@ -16,15 +16,16 @@ import (
 type Recorder struct {
 	highCardinality bool
 
-	audioTrackCount    otelmetric.Float64Histogram
-	subtitleTrackCount otelmetric.Float64Histogram
-	sourceDuration     otelmetric.Float64Histogram
-	sourceFileSize     otelmetric.Float64Histogram
-	destFileSize       otelmetric.Float64Histogram
-	transcodeDuration  otelmetric.Float64Histogram
-	totalDuration      otelmetric.Float64Histogram
-	invalidFilesTotal  otelmetric.Int64Counter
-	metricsErrorsTotal otelmetric.Int64Counter
+	audioTrackCount          otelmetric.Float64Histogram
+	subtitleTrackCount       otelmetric.Float64Histogram
+	sourceDuration           otelmetric.Float64Histogram
+	sourceFileSize           otelmetric.Float64Histogram
+	destFileSize             otelmetric.Float64Histogram
+	transcodeDuration        otelmetric.Float64Histogram
+	totalDuration            otelmetric.Float64Histogram
+	invalidFilesTotal        otelmetric.Int64Counter
+	metricsErrorsTotal       otelmetric.Int64Counter
+	artworkFetchSkippedTotal otelmetric.Int64Counter
 }
 
 // NewRecorder creates a Recorder that registers all media workflow instruments against mp.
@@ -94,17 +95,24 @@ func NewRecorder(mp otelmetric.MeterProvider, highCardinality bool) (*Recorder, 
 		return nil, fmt.Errorf("create metrics_errors_total counter: %w", err)
 	}
 
+	artworkFetchSkippedTotal, err := meter.Int64Counter("media_workflow_artwork_fetch_skipped_total",
+		otelmetric.WithDescription("Number of transcode runs where artwork fetch was attempted but yielded no embeddable image"))
+	if err != nil {
+		return nil, fmt.Errorf("create artwork_fetch_skipped_total counter: %w", err)
+	}
+
 	return &Recorder{
-		highCardinality:    highCardinality,
-		audioTrackCount:    audioTrackCount,
-		subtitleTrackCount: subtitleTrackCount,
-		sourceDuration:     sourceDuration,
-		sourceFileSize:     sourceFileSize,
-		destFileSize:       destFileSize,
-		transcodeDuration:  transcodeDuration,
-		totalDuration:      totalDuration,
-		invalidFilesTotal:  invalidFilesTotal,
-		metricsErrorsTotal: metricsErrorsTotal,
+		highCardinality:          highCardinality,
+		audioTrackCount:          audioTrackCount,
+		subtitleTrackCount:       subtitleTrackCount,
+		sourceDuration:           sourceDuration,
+		sourceFileSize:           sourceFileSize,
+		destFileSize:             destFileSize,
+		transcodeDuration:        transcodeDuration,
+		totalDuration:            totalDuration,
+		invalidFilesTotal:        invalidFilesTotal,
+		metricsErrorsTotal:       metricsErrorsTotal,
+		artworkFetchSkippedTotal: artworkFetchSkippedTotal,
 	}, nil
 }
 
@@ -146,6 +154,11 @@ func (r *Recorder) RecordInvalidFile(ctx context.Context, mediaType medialib.Med
 			mappingNameAttr(mappingName),
 		),
 	)
+}
+
+// RecordArtworkFetchSkipped increments the artwork_fetch_skipped_total counter.
+func (r *Recorder) RecordArtworkFetchSkipped(ctx context.Context) {
+	r.artworkFetchSkippedTotal.Add(ctx, 1)
 }
 
 // RecordMetricsError increments the metrics_errors_total counter and logs the error.

--- a/workflows/media/testhelpers_test.go
+++ b/workflows/media/testhelpers_test.go
@@ -34,6 +34,9 @@ type stubLibraryClient struct {
 	refreshCalls []string
 	infoResult   medialib.MediaInfo
 	infoErr      error
+	posterBytes  []byte
+	posterMime   string
+	posterErr    error
 }
 
 func (s *stubLibraryClient) RefreshByFilePath(_ context.Context, path string) error {
@@ -43,4 +46,8 @@ func (s *stubLibraryClient) RefreshByFilePath(_ context.Context, path string) er
 
 func (s *stubLibraryClient) GetInfo(_ context.Context, _ string) (medialib.MediaInfo, error) {
 	return s.infoResult, s.infoErr
+}
+
+func (s *stubLibraryClient) GetPosterImage(_ context.Context, _ string) ([]byte, string, error) {
+	return s.posterBytes, s.posterMime, s.posterErr
 }

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
 	"github.com/solidDoWant/media-processor/pkg/ffprobe"
+	"github.com/solidDoWant/media-processor/pkg/medialib"
 )
 
 // SelectVideoCodec returns CodecCopy when the video is already H.264 or H.265 in an
@@ -121,6 +123,9 @@ type TranscodeOutput struct {
 	// TranscodeDurationSeconds is the wall-clock time spent in RunTranscode (the ffmpeg call
 	// plus surrounding stat/rename operations), in seconds.
 	TranscodeDurationSeconds float64 `json:"transcode_duration_seconds"`
+	// ArtworkFetchSkipped is true when artwork fetch was attempted but yielded no
+	// embeddable image (library unreachable, no poster available, or unsupported type).
+	ArtworkFetchSkipped bool `json:"artwork_fetch_skipped,omitempty"`
 }
 
 // codecName returns a human-readable name for a codec, matching the names used
@@ -144,7 +149,10 @@ func codecName(c ffmpeg.Codec) string {
 // probe is the output of RunProbe for filePath.
 // hardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
 // an empty string uses the libav default (auto-select).
-func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string, hardwareDevicePath string) (TranscodeOutput, error) {
+// library is the arr library used to fetch poster artwork; when nil or when
+// artwork fetch fails, transcoding proceeds without an embedded attachment and
+// TranscodeOutput.ArtworkFetchSkipped is set to true.
+func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {
 	transcodeStart := time.Now()
 
 	srcInfo, err := os.Stat(filePath)
@@ -236,6 +244,27 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		}
 	}
 
+	var (
+		artworkSkipped bool
+		artBytes       []byte
+		artMime        string
+	)
+
+	if library != nil {
+		var artErr error
+
+		artBytes, artMime, artErr = library.GetPosterImage(ctx, filePath)
+		if artErr != nil || len(artBytes) == 0 {
+			if artErr != nil {
+				slog.WarnContext(ctx, "artwork fetch failed, proceeding without cover art", "error", artErr)
+			} else {
+				slog.WarnContext(ctx, "no poster image available, proceeding without cover art")
+			}
+
+			artworkSkipped = true
+		}
+	}
+
 	if err := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
@@ -248,6 +277,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		WithDownmixTitle(downmixLangName).
 		WithAutoDownmixTitle().
 		WithHardwareDevice(hardwareDevicePath).
+		WithCoverArt(artBytes, artMime).
 		Build().
 		Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
@@ -283,5 +313,6 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		SourceFileSizeBytes:      srcSize,
 		DestFileSizeBytes:        dstInfo.Size(),
 		TranscodeDurationSeconds: time.Since(transcodeStart).Seconds(),
+		ArtworkFetchSkipped:      artworkSkipped,
 	}, nil
 }

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -149,9 +149,11 @@ func codecName(c ffmpeg.Codec) string {
 // probe is the output of RunProbe for filePath.
 // hardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
 // an empty string uses the libav default (auto-select).
-// library is the arr library used to fetch poster artwork; when nil or when
-// artwork fetch fails, transcoding proceeds without an embedded attachment and
-// TranscodeOutput.ArtworkFetchSkipped is set to true.
+// library is the arr library used to fetch poster artwork. When nil, no fetch
+// is attempted and transcoding proceeds without an embedded attachment (
+// ArtworkFetchSkipped is not set). When non-nil and the fetch yields no
+// embeddable image, transcoding proceeds without an embedded attachment and
+// ArtworkFetchSkipped is set to true.
 func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {
 	transcodeStart := time.Now()
 

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -150,8 +150,8 @@ func codecName(c ffmpeg.Codec) string {
 // hardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
 // an empty string uses the libav default (auto-select).
 // library is the arr library used to fetch poster artwork. When nil, no fetch
-// is attempted and transcoding proceeds without an embedded attachment (
-// ArtworkFetchSkipped is not set). When non-nil and the fetch yields no
+// is attempted and transcoding proceeds without an embedded attachment, and
+// ArtworkFetchSkipped is not set. When non-nil and the fetch yields no
 // embeddable image, transcoding proceeds without an embedded attachment and
 // ArtworkFetchSkipped is set to true.
 func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -537,7 +537,7 @@ func TestRunTranscode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
 
-			out, err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir, "")
+			out, err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir, "", nil)
 
 			tt.errFunc(t, err)
 


### PR DESCRIPTION
## Summary

- Add `GetPosterImage` to the `ArrLibrary` interface, implemented for Radarr (movie poster) and Sonarr (series poster) via a shared `pkg/medialib/internal/artwork` package
- Artwork is validated twice: extension pre-check (`.jpg`/`.jpeg`/`.png` only before fetching) and `Content-Type` post-fetch validation
- Add `WithCoverArt` to `TranscodeBuilder`; strips existing attached-picture streams from the input (written as `MediaTypeAttachment`, read back by the matroska demuxer with `DispositionFlagAttachedPic`) and embeds the new poster as an MKV attachment stream
- `RunTranscode` accepts an optional `ArrLibrary` and falls back gracefully with a warning + `ArtworkFetchSkipped` flag when artwork is unavailable or cannot be fetched
- Increment `media_workflow_artwork_fetch_skipped_total` OTel counter when the fallback path is taken

## Test plan

- [x] `pkg/medialib/internal/artwork`: JPEG/PNG fetch, non-poster skip, unsupported extension, RemoteURL fallback, unsupported Content-Type, unreachable server
- [x] `pkg/medialib/radarr`: JPEG/PNG poster, no poster (fanart only), unsupported extension, episode not found, unreachable URL
- [x] `pkg/medialib/sonarr`: same coverage as radarr
- [x] `pkg/ffmpeg`: JPEG/PNG embedded correctly, existing attachments stripped on re-transcode, nil bytes is no-op
- [x] `workflows/shared`: existing RunTranscode tests pass with `nil` library (no regression)
- [x] All tests pass (`go test ./...`) and lint is clean (`make lint`)

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)