### PR TITLE
feat(ffmpeg): crop filter in TranscodeBuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,23 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 # Detect hardware encoders via ffmpeg CLI — independent of our DetectHardwareEncoders() logic.
-# This ensures hwtest/qsvtest runs even if our detection has bugs, allowing tests to catch them.
+# This ensures hardware-specific build tags are set even if our detection has bugs, allowing
+# tests to catch those bugs.
 HAS_HW_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
 	grep -qE '^\s+V..... (hevc|h264)_(qsv|nvenc|vaapi)' && echo "1" || echo "0")
 HAS_QSV_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
 	grep -qE '^\s+V..... (hevc|h264)_qsv' && echo "1" || echo "0")
+HAS_VAAPI_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
+	grep -qE '^\s+V..... (hevc|h264)_vaapi' && echo "1" || echo "0")
+HAS_NVENC_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
+	grep -qE '^\s+V..... (hevc|h264)_nvenc' && echo "1" || echo "0")
 
-# Build tags: hwtest when any HW encoder is present; qsvtest when QSV specifically is present.
+# Build tags: hwtest when any HW encoder is present; dedicated tags (qsvtest, vaapitest,
+# nvenctest) when the corresponding hardware encoder is specifically present.
 comma := ,
 empty :=
 space := $(empty) $(empty)
-_test_tags := $(strip $(if $(filter 1,$(HAS_HW_ENCODER)),hwtest )$(if $(filter 1,$(HAS_QSV_ENCODER)),qsvtest))
+_test_tags := $(strip $(if $(filter 1,$(HAS_HW_ENCODER)),hwtest )$(if $(filter 1,$(HAS_QSV_ENCODER)),qsvtest )$(if $(filter 1,$(HAS_VAAPI_ENCODER)),vaapitest )$(if $(filter 1,$(HAS_NVENC_ENCODER)),nvenctest))
 TEST_TAG_FLAGS := $(if $(_test_tags),-tags $(subst $(space),$(comma),$(_test_tags)))
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,17 @@ vet: ## Run go vet against code.
 # Detect hardware encoders via ffmpeg CLI — independent of our DetectHardwareEncoders() logic.
 # This ensures hardware-specific build tags are set even if our detection has bugs, allowing
 # tests to catch those bugs.
-HAS_HW_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
-	grep -qE '^\s+V..... (hevc|h264)_(qsv|nvenc|vaapi)' && echo "1" || echo "0")
-HAS_QSV_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
-	grep -qE '^\s+V..... (hevc|h264)_qsv' && echo "1" || echo "0")
-HAS_VAAPI_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
-	grep -qE '^\s+V..... (hevc|h264)_vaapi' && echo "1" || echo "0")
-HAS_NVENC_ENCODER := $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
-	grep -qE '^\s+V..... (hevc|h264)_nvenc' && echo "1" || echo "0")
+#
+# detect_encoder checks whether ffmpeg exposes an h264 or hevc encoder for the
+# given HW family (e.g. qsv, vaapi, nvenc). Outputs "1" if found, "0" otherwise.
+detect_encoder = $(shell ffmpeg -hide_banner -encoders 2>/dev/null | \
+	grep -qE '^\s+V..... (hevc|h264)_$(1)' && echo "1" || echo "0")
+
+HAS_QSV_ENCODER := $(call detect_encoder,qsv)
+HAS_VAAPI_ENCODER := $(call detect_encoder,vaapi)
+HAS_NVENC_ENCODER := $(call detect_encoder,nvenc)
+# HAS_HW_ENCODER is true when at least one of the per-family flags is set.
+HAS_HW_ENCODER := $(if $(filter 1,$(HAS_QSV_ENCODER) $(HAS_VAAPI_ENCODER) $(HAS_NVENC_ENCODER)),1,0)
 
 # Build tags: hwtest when any HW encoder is present; dedicated tags (qsvtest, vaapitest,
 # nvenctest) when the corresponding hardware encoder is specifically present.

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
@@ -90,6 +91,16 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("create Hatchet client: %w", err)
 	}
 
+	minCropX, err := parseCropThreshold("MEDIA_MIN_CROP_X", 10)
+	if err != nil {
+		return err
+	}
+
+	minCropY, err := parseCropThreshold("MEDIA_MIN_CROP_Y", 10)
+	if err != nil {
+		return err
+	}
+
 	mediaWorkflow := media.NewMediaWorkflow(client, media.MediaWorkflowConfig{
 		OutputDir:             mediaOutputDir,
 		WatcherRoot:           os.Getenv("MEDIA_WATCHER_ROOT"),
@@ -97,6 +108,8 @@ func run(ctx context.Context) error {
 		HardwareDevicePath:    os.Getenv("HARDWARE_DEVICE_PATH"),
 		MeterProvider:         metricsProvider.MeterProvider(),
 		HighCardinalityLabels: os.Getenv("METRICS_HIGH_CARDINALITY_LABELS") == "true",
+		MinCropX:              minCropX,
+		MinCropY:              minCropY,
 	}, radarrClient, sonarrClient, webhookClient)
 
 	worker, err := client.NewWorker(
@@ -114,4 +127,21 @@ func run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// parseCropThreshold reads an integer from the named environment variable.
+// If the variable is unset or empty, defaultVal is returned. A value of -1 is
+// accepted (disables the threshold). Any other non-integer value is a fatal error.
+func parseCropThreshold(envVar string, defaultVal int) (int, error) {
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		return defaultVal, nil
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer (got %q): %w", envVar, raw, err)
+	}
+
+	return v, nil
 }

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -242,7 +242,7 @@ func (vss *videoStreamState) tryCuvidCropOption(inStream *astiav.Stream, inputFm
 	defer cropDict.Free()
 
 	if setErr := cropDict.Set("crop", fmt.Sprintf("%dx%dx%dx%d", top, bottom, left, right), astiav.NewDictionaryFlags()); setErr != nil {
-		return false, nil
+		return false, fmt.Errorf("ffmpeg: setting cuvid crop dictionary option: %w", setErr)
 	}
 
 	if openErr := vss.decoder.codecContext.Open(vss.decoder.codec, cropDict); openErr == nil {

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -44,10 +44,14 @@ type videoStreamState struct {
 	copyStreamState
 
 	// Decoder state.
-	decoder            videoDecoderState
-	encoder            videoEncoderState
-	isHWDecode         bool
-	hardwareDevicePath string // device path for CreateHardwareDeviceContext; "" = auto-select
+	decoder videoDecoderState
+	encoder videoEncoderState
+	// encoderReceivesHWFrames is true when frames arriving at the encoder are
+	// already in GPU pixel format (HW decode without filter, cuvid crop dict, or
+	// a crop filter whose output is a HW surface such as VAAPI/QSV/CUDA).
+	// When true, setupVideoConversion skips CPU-side scaling and upload.
+	encoderReceivesHWFrames bool
+	hardwareDevicePath      string // device path for CreateHardwareDeviceContext; "" = auto-select
 
 	// Crop filter state. Non-nil when a crop region has been requested via
 	// WithCrop. The filter graph is set up in setupCropFilter after the
@@ -243,21 +247,84 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 	return nil
 }
 
+// cropFilterConfig describes the libavfilter graph used to apply a spatial crop.
+// The strategy is chosen per hardware accelerator by selectCropFilterConfig.
+type cropFilterConfig struct {
+	str         string             // avfilter graph string
+	srcPixFmt   astiav.PixelFormat // pixel format of frames entering buffersrc
+	useHWFrames bool               // initialise buffersrc with decoder's hw_frames_ctx
+	hwFilters   []string           // filter node names that require hw_device_ctx to be set
+	outPixFmt   astiav.PixelFormat // effective pixel format after the graph (PixelFormatNone = unchanged SW)
+}
+
+// selectCropFilterConfig returns the cropFilterConfig for the given hardware
+// accelerator and decoder state. It is a pure function — no FFmpeg state is
+// accessed — which makes all six filter paths unit-testable in isolation.
+//
+// For VAAPI with SW decode (hwDecodeActive=false) the returned config includes
+// scale_vaapi; the caller (setupCropFilter) is responsible for ensuring a VAAPI
+// device context exists before building the graph, and must fall back to the SW
+// config (HWAccelNone) if device creation fails.
+func selectCropFilterConfig(hwAccel HWAccel, hwDecodeActive bool, decoderPixFmt astiav.PixelFormat, cp CropParams) cropFilterConfig {
+	cropStr := fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y)
+
+	switch {
+	case hwAccel == HWAccelNVENC && hwDecodeActive:
+		// CUDA fallback: cuvid is active but its crop dict option was unsupported.
+		// Download frames to CPU, crop in software, re-upload to CUDA.
+		return cropFilterConfig{
+			str:         fmt.Sprintf("hwdownload,%s,hwupload", cropStr),
+			srcPixFmt:   astiav.PixelFormatCuda,
+			useHWFrames: true,
+			hwFilters:   []string{"hwupload"},
+			outPixFmt:   astiav.PixelFormatCuda,
+		}
+
+	case hwAccel == HWAccelVAAPI && hwDecodeActive:
+		// VAAPI HW decode: download to CPU, apply SW crop, re-upload via scale_vaapi.
+		return cropFilterConfig{
+			str:         fmt.Sprintf("hwdownload,%s,scale_vaapi", cropStr),
+			srcPixFmt:   astiav.PixelFormatVaapi,
+			useHWFrames: true,
+			hwFilters:   []string{"scale_vaapi"},
+			outPixFmt:   astiav.PixelFormatVaapi,
+		}
+
+	case hwAccel == HWAccelVAAPI && !hwDecodeActive:
+		// VAAPI SW decode: crop in software, upload via scale_vaapi.
+		return cropFilterConfig{
+			str:       fmt.Sprintf("%s,scale_vaapi", cropStr),
+			srcPixFmt: decoderPixFmt,
+			hwFilters: []string{"scale_vaapi"},
+			outPixFmt: astiav.PixelFormatVaapi,
+		}
+
+	case hwAccel == HWAccelQSV && hwDecodeActive:
+		// QSV: GPU-native crop and scale via vpp_qsv.
+		return cropFilterConfig{
+			str:         fmt.Sprintf("vpp_qsv=w=%d:h=%d:cx=%d:cy=%d", cp.W, cp.H, cp.X, cp.Y),
+			srcPixFmt:   astiav.PixelFormatQsv,
+			useHWFrames: true,
+			hwFilters:   []string{"vpp_qsv"},
+			outPixFmt:   astiav.PixelFormatQsv,
+		}
+
+	default:
+		// Software path (SW hwAccel, QSV/NVENC without HW decode, or explicit fallback).
+		return cropFilterConfig{
+			str:       cropStr,
+			srcPixFmt: decoderPixFmt,
+		}
+	}
+}
+
 // setupCropFilter builds the libavfilter graph that applies the crop region to
 // decoded video frames. It must be called after setupDecoder so that the
 // decoder's pixel format, dimensions, and hardware state are known.
 //
-// The filter strategy depends on the active hardware accelerator:
-//
-//   - SW:                crop=W:H:X:Y
-//   - VAAPI (SW decode): crop=W:H:X:Y,scale_vaapi  — uploads cropped frames to VAAPI
-//   - VAAPI (HW decode): hwdownload,crop=W:H:X:Y,scale_vaapi  — download, crop, re-upload
-//   - QSV (HW decode):   vpp_qsv=w=W:h=H:cx=X:cy=Y  — GPU-native crop
-//   - CUDA (cuvid dict): returns nil immediately (crop already applied by decoder)
-//   - CUDA (HW decode):  hwdownload,crop=W:H:X:Y,hwupload  — download, crop, re-upload
-//
-// For VAAPI with SW decode, a VAAPI device context is created here and stored
-// in vss.decoder.hwDevCtx so it can be reused by the encoder later.
+// The filter strategy is chosen by selectCropFilterConfig based on the active
+// hardware accelerator. For VAAPI with SW decode, a VAAPI device context is
+// created here and stored in vss.decoder.hwDevCtx so the encoder can reuse it.
 //
 // effectiveDecodedPixFmt is set to the output pixel format of the filter graph
 // (e.g. PixelFormatVaapi for VAAPI paths). configureEncoderPixelFormat uses
@@ -270,84 +337,26 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 		return nil
 	}
 
-	profile, hasHW := hwProfiles[hwAccel]
 	hwDecodeActive := vss.decoder.hwDevCtx != nil
 
-	// filterConfig describes the filter graph to build.
-	type filterConfig struct {
-		str         string             // avfilter graph string
-		srcPixFmt   astiav.PixelFormat // pixel format of frames entering buffersrc
-		useHWFrames bool               // init buffersrc with decoder's hw_frames_ctx
-		hwFilters   []string           // filter node names that need hw_device_ctx set
-		outPixFmt   astiav.PixelFormat // effective pixel format after the graph (PixelFormatNone = unchanged SW)
-	}
-
-	var cfg filterConfig
-
-	switch {
-	case hasHW && hwAccel == HWAccelNVENC && hwDecodeActive:
-		// CUDA fallback: cuvid is active but its crop dict option was unsupported.
-		// Download frames to CPU, crop in software, re-upload to CUDA.
-		cfg = filterConfig{
-			str:         fmt.Sprintf("hwdownload,crop=%d:%d:%d:%d,hwupload", cp.W, cp.H, cp.X, cp.Y),
-			srcPixFmt:   astiav.PixelFormatCuda,
-			useHWFrames: true,
-			hwFilters:   []string{"hwupload"},
-			outPixFmt:   astiav.PixelFormatCuda,
-		}
-
-	case hasHW && hwAccel == HWAccelVAAPI && hwDecodeActive:
-		// VAAPI HW decode: download to CPU, apply SW crop, re-upload via scale_vaapi.
-		cfg = filterConfig{
-			str:         fmt.Sprintf("hwdownload,crop=%d:%d:%d:%d,scale_vaapi", cp.W, cp.H, cp.X, cp.Y),
-			srcPixFmt:   astiav.PixelFormatVaapi,
-			useHWFrames: true,
-			hwFilters:   []string{"scale_vaapi"},
-			outPixFmt:   astiav.PixelFormatVaapi,
-		}
-
-	case hasHW && hwAccel == HWAccelVAAPI && !hwDecodeActive:
-		// VAAPI SW decode: crop in software, then upload to VAAPI via scale_vaapi.
-		// A VAAPI device context is needed for scale_vaapi. If one cannot be
-		// created, fall back to a pure software crop.
-		devCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
-		if err != nil {
-			slog.Debug("ffmpeg: VAAPI device context unavailable for crop filter, using SW-only crop", "error", err)
-
-			cfg = filterConfig{
-				str:       fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y),
-				srcPixFmt: vss.decoder.codecContext.PixelFormat(),
-			}
-		} else {
-			// Store the device context so the encoder (set up later) can reuse it.
-			vss.decoder.hwDevCtx = devCtx
-			vss.decoder.hwPixFmt = profile.hwPixFmt
-
-			cfg = filterConfig{
-				str:       fmt.Sprintf("crop=%d:%d:%d:%d,scale_vaapi", cp.W, cp.H, cp.X, cp.Y),
-				srcPixFmt: vss.decoder.codecContext.PixelFormat(),
-				hwFilters: []string{"scale_vaapi"},
-				outPixFmt: astiav.PixelFormatVaapi,
+	// VAAPI with SW decode: create a device context for scale_vaapi if possible.
+	// If creation fails, degrade to a pure software crop by clearing hwAccel so
+	// selectCropFilterConfig falls through to the default SW case.
+	if hwAccel == HWAccelVAAPI && !hwDecodeActive {
+		if profile, ok := hwProfiles[hwAccel]; ok {
+			devCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
+			if err != nil {
+				slog.Debug("ffmpeg: VAAPI device context unavailable for crop filter, using SW-only crop", "error", err)
+				hwAccel = HWAccelNone
+			} else {
+				// Store so the encoder (set up later in buildStreamStates) reuses it.
+				vss.decoder.hwDevCtx = devCtx
+				vss.decoder.hwPixFmt = profile.hwPixFmt
 			}
 		}
-
-	case hasHW && hwAccel == HWAccelQSV && hwDecodeActive:
-		// QSV: GPU-native crop and scale via vpp_qsv.
-		cfg = filterConfig{
-			str:         fmt.Sprintf("vpp_qsv=w=%d:h=%d:cx=%d:cy=%d", cp.W, cp.H, cp.X, cp.Y),
-			srcPixFmt:   astiav.PixelFormatQsv,
-			useHWFrames: true,
-			hwFilters:   []string{"vpp_qsv"},
-			outPixFmt:   astiav.PixelFormatQsv,
-		}
-
-	default:
-		// Software path (SW hwAccel, or HW decode unavailable).
-		cfg = filterConfig{
-			str:       fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y),
-			srcPixFmt: vss.decoder.codecContext.PixelFormat(),
-		}
 	}
+
+	cfg := selectCropFilterConfig(hwAccel, hwDecodeActive, vss.decoder.codecContext.PixelFormat(), *cp)
 
 	fg := astiav.AllocFilterGraph()
 	if fg == nil {
@@ -619,7 +628,7 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	// covers the CUDA cuvid crop-dict path where the crop is applied by the
 	// decoder itself (cuvidCropApplied=true, cropFilter=nil).
 	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt && vss.cropFilter == nil {
-		vss.isHWDecode = true
+		vss.encoderReceivesHWFrames = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 
 		return nil
@@ -629,7 +638,7 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	// (scale_vaapi, vpp_qsv, hwupload). The filter handles the CPU↔GPU transfer;
 	// frames arrive at the encoder ready for zero-copy encoding.
 	if vss.effectiveDecodedPixFmt != astiav.PixelFormatNone && vss.effectiveDecodedPixFmt == profile.hwPixFmt {
-		vss.isHWDecode = true
+		vss.encoderReceivesHWFrames = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 		// Provide the hardware device context so the encoder can initialise its
 		// hardware-specific state (e.g. create hw_frames_ctx from hw_device_ctx).
@@ -686,14 +695,14 @@ func (vss *videoStreamState) setupHWFramesContext(profile hwProfile) error {
 //
 // For the SW decode + HW encode path, decoded YUV frames are converted on the
 // CPU before being uploaded to GPU memory. A fully hardware-accelerated
-// decode→encode pipeline (isHWDecode=true) eliminates this CPU step by
+// decode→encode pipeline (encoderReceivesHWFrames=true) eliminates this CPU step by
 // sharing GPU surfaces between the decoder and encoder.
 //
 // Note: side-data formats such as Dolby Vision RPU are currently not
 // preserved across re-encoding. Copy streams (CodecCopy) always preserve all
 // side data since the bitstream is passed through unchanged.
 func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
-	if vss.isHWDecode {
+	if vss.encoderReceivesHWFrames {
 		// Decoded frames are already in the correct HW pixel format.
 		return nil
 	}
@@ -791,7 +800,7 @@ func (vss *videoStreamState) processPacket(packet *astiav.Packet, outputFmt *ast
 }
 
 // encodeVideoFrame converts and encodes a single decoded video frame.
-// On the fully hardware path (isHWDecode=true) the frame is already in GPU
+// On the fully hardware path (encoderReceivesHWFrames=true) the frame is already in GPU
 // memory and is passed directly to the encoder without any CPU conversion.
 // When a crop filter is active, the frame is first pushed through the filter
 // graph and the cropped output is used for the remainder of the pipeline.
@@ -804,6 +813,12 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 		}
 
 		if err := vss.cropFilter.sinkCtx.GetFrame(vss.cropFilter.frame, astiav.NewBuffersinkFlags()); err != nil {
+			if errors.Is(err, astiav.ErrEagain) {
+				// Filter needs more input before it can produce output (should not
+				// occur for a simple crop filter, but handled gracefully).
+				return nil
+			}
+
 			return fmt.Errorf("ffmpeg: getting frame from crop filter: %w", err)
 		}
 
@@ -812,7 +827,7 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 		encFrame = vss.cropFilter.frame
 	}
 
-	if !vss.isHWDecode {
+	if !vss.encoderReceivesHWFrames {
 		// Software decode path: convert pixel format if needed.
 		if vss.encoder.softwareFrameContext != nil {
 			if err := vss.encoder.softwareFrameContext.ScaleFrame(encFrame, vss.encoder.frame); err != nil {

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -9,6 +9,19 @@ import (
 	"github.com/asticode/go-astiav"
 )
 
+// videoCropFilterState holds the filter graph used to apply a spatial crop to
+// decoded video frames. For software-decoded streams the graph is simply
+// "crop=W:H:X:Y". For hardware-decoded streams "hwdownload" is prepended so
+// that the crop filter receives frames in system memory; the output pixel
+// format is the profile's software pixel format (e.g. NV12).
+type videoCropFilterState struct {
+	graph       *astiav.FilterGraph
+	srcCtx      *astiav.BuffersrcFilterContext
+	sinkCtx     *astiav.BuffersinkFilterContext
+	frame       *astiav.Frame
+	srcHWFrames *astiav.HardwareFramesContext // non-nil when source frames are in HW memory
+}
+
 type videoEncoderState struct {
 	codecID                 astiav.CodecID
 	codec                   *astiav.Codec
@@ -38,6 +51,14 @@ type videoStreamState struct {
 	encoder            videoEncoderState
 	isHWDecode         bool
 	hardwareDevicePath string // device path for CreateHardwareDeviceContext; "" = auto-select
+
+	// Crop filter state. Non-nil when a crop region has been requested via
+	// WithCrop. The filter graph is set up in setupCropFilter after the
+	// decoder is initialised so that source pixel format and dimensions are
+	// known.
+	cropParams             *CropParams           // crop region; nil = no crop
+	cropFilter             *videoCropFilterState // non-nil when crop filter graph is active
+	effectiveDecodedPixFmt astiav.PixelFormat    // pixel format of frames entering the encoder pipeline (post crop filter)
 }
 
 func (vds *videoDecoderState) free() {
@@ -71,6 +92,20 @@ func (vss *videoStreamState) free() {
 
 	if vss.encoder.hardwareFrameContext != nil {
 		vss.encoder.hardwareFrameContext.Free()
+	}
+
+	if vss.cropFilter != nil {
+		if vss.cropFilter.graph != nil {
+			vss.cropFilter.graph.Free()
+		}
+
+		if vss.cropFilter.frame != nil {
+			vss.cropFilter.frame.Free()
+		}
+
+		if vss.cropFilter.srcHWFrames != nil {
+			vss.cropFilter.srcHWFrames.Free()
+		}
 	}
 }
 
@@ -155,6 +190,228 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 	return nil
 }
 
+// setupCropFilter builds the libavfilter graph that applies the crop region to
+// decoded video frames. It must be called after setupDecoder so that the
+// decoder's pixel format and dimensions are known.
+//
+// For hardware-decoded streams the filter graph is "hwdownload,crop=W:H:X:Y"
+// so that frames are transferred to system memory before cropping. For
+// software-decoded streams the graph is simply "crop=W:H:X:Y".
+//
+// effectiveDecodedPixFmt is set to the pixel format of frames leaving the
+// filter (used by setupVideoConversion to configure the scaler correctly).
+func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HWAccel) error {
+	cp := vss.cropParams // guaranteed non-nil by caller
+
+	cropStr := fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y)
+
+	var (
+		filterStr   string
+		srcPixFmt   astiav.PixelFormat
+		srcHWFrames *astiav.HardwareFramesContext
+	)
+
+	if vss.decoder.hwDevCtx != nil {
+		// HW decode: prepend hwdownload so the crop filter receives frames in
+		// system memory. effectiveDecodedPixFmt becomes the profile's SW
+		// pixel format (e.g. NV12) — the format after the download step.
+		filterStr = "hwdownload," + cropStr
+		srcPixFmt = vss.decoder.hwPixFmt
+
+		profile := hwProfiles[hwAccel]
+		vss.effectiveDecodedPixFmt = profile.swPixFmt
+
+		// Allocate a hardware frames context describing the frames produced by
+		// the HW decoder so that the buffersrc filter knows their format.
+		hfc := astiav.AllocHardwareFramesContext(vss.decoder.hwDevCtx)
+		if hfc == nil {
+			return errors.New("ffmpeg: failed to allocate crop filter hardware frames context")
+		}
+
+		hfc.SetHardwarePixelFormat(vss.decoder.hwPixFmt)
+		hfc.SetSoftwarePixelFormat(profile.swPixFmt)
+		hfc.SetWidth(vss.decoder.codecContext.Width())
+		hfc.SetHeight(vss.decoder.codecContext.Height())
+		hfc.SetInitialPoolSize(0)
+
+		if err := hfc.Initialize(); err != nil {
+			hfc.Free()
+
+			return fmt.Errorf("ffmpeg: initializing crop filter hardware frames context: %w", err)
+		}
+
+		srcHWFrames = hfc
+	} else {
+		// SW decode: crop filter operates directly on the decoded frames.
+		filterStr = cropStr
+		srcPixFmt = vss.decoder.codecContext.PixelFormat()
+		vss.effectiveDecodedPixFmt = srcPixFmt
+	}
+
+	fg := astiav.AllocFilterGraph()
+	if fg == nil {
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: failed to allocate crop filter graph")
+	}
+
+	buffersrc := astiav.FindFilterByName("buffer")
+	if buffersrc == nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: buffer filter not found for crop")
+	}
+
+	buffersink := astiav.FindFilterByName("buffersink")
+	if buffersink == nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: buffersink filter not found for crop")
+	}
+
+	srcCtx, err := fg.NewBuffersrcFilterContext(buffersrc, "in")
+	if err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: creating crop buffersrc context: %w", err)
+	}
+
+	sinkCtx, err := fg.NewBuffersinkFilterContext(buffersink, "out")
+	if err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: creating crop buffersink context: %w", err)
+	}
+
+	srcParams := astiav.AllocBuffersrcFilterContextParameters()
+	defer srcParams.Free()
+
+	srcParams.SetPixelFormat(srcPixFmt)
+	srcParams.SetWidth(vss.decoder.codecContext.Width())
+	srcParams.SetHeight(vss.decoder.codecContext.Height())
+	srcParams.SetTimeBase(inStream.TimeBase())
+	srcParams.SetSampleAspectRatio(vss.decoder.codecContext.SampleAspectRatio())
+
+	if srcHWFrames != nil {
+		srcParams.SetHardwareFramesContext(srcHWFrames)
+	}
+
+	if err := srcCtx.SetParameters(srcParams); err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: setting crop buffersrc parameters: %w", err)
+	}
+
+	if err := srcCtx.Initialize(nil); err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: initializing crop buffersrc: %w", err)
+	}
+
+	outputs := astiav.AllocFilterInOut()
+	if outputs == nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: failed to allocate crop filter in/out (outputs)")
+	}
+
+	defer outputs.Free()
+
+	inputs := astiav.AllocFilterInOut()
+	if inputs == nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: failed to allocate crop filter in/out (inputs)")
+	}
+
+	defer inputs.Free()
+
+	outputs.SetName("in")
+	outputs.SetFilterContext(srcCtx.FilterContext())
+	outputs.SetPadIdx(0)
+	outputs.SetNext(nil)
+
+	inputs.SetName("out")
+	inputs.SetFilterContext(sinkCtx.FilterContext())
+	inputs.SetPadIdx(0)
+	inputs.SetNext(nil)
+
+	if err := fg.Parse(filterStr, inputs, outputs); err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: parsing crop filter graph %q: %w", filterStr, err)
+	}
+
+	if err := fg.Configure(); err != nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return fmt.Errorf("ffmpeg: configuring crop filter graph: %w", err)
+	}
+
+	filterFrame := astiav.AllocFrame()
+	if filterFrame == nil {
+		fg.Free()
+
+		if srcHWFrames != nil {
+			srcHWFrames.Free()
+		}
+
+		return errors.New("ffmpeg: failed to allocate crop filter output frame")
+	}
+
+	vss.cropFilter = &videoCropFilterState{
+		graph:       fg,
+		srcCtx:      srcCtx,
+		sinkCtx:     sinkCtx,
+		frame:       filterFrame,
+		srcHWFrames: srcHWFrames,
+	}
+
+	return nil
+}
+
 // setupEncoder implements the stream interface for video. If a hardware encoder
 // is requested but unavailable, it falls back to software encoding transparently.
 func (vss *videoStreamState) setupEncoder(hwAccel HWAccel, outputFmt *astiav.FormatContext) error {
@@ -233,8 +490,16 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 		return errors.New("failed to allocate encoder codec context")
 	}
 
-	vss.encoder.codecContext.SetWidth(vss.decoder.codecContext.Width())
-	vss.encoder.codecContext.SetHeight(vss.decoder.codecContext.Height())
+	encW := vss.decoder.codecContext.Width()
+	encH := vss.decoder.codecContext.Height()
+
+	if vss.cropParams != nil {
+		encW = vss.cropParams.W
+		encH = vss.cropParams.H
+	}
+
+	vss.encoder.codecContext.SetWidth(encW)
+	vss.encoder.codecContext.SetHeight(encH)
 	vss.encoder.codecContext.SetSampleAspectRatio(vss.decoder.codecContext.SampleAspectRatio())
 	vss.encoder.codecContext.SetTimeBase(vss.decoder.codecContext.TimeBase())
 	vss.encoder.codecContext.SetFramerate(vss.decoder.codecContext.Framerate())
@@ -279,8 +544,10 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	}
 
 	// HW encode with HW decode: decoded frames are already in GPU memory —
-	// share those surfaces directly with the encoder.
-	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt {
+	// share those surfaces directly with the encoder. The crop filter
+	// downloads frames to CPU memory, so the zero-copy path is unavailable
+	// when a crop filter is active.
+	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt && vss.cropFilter == nil {
 		vss.isHWDecode = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 
@@ -306,10 +573,18 @@ func (vss *videoStreamState) setupHWFramesContext(profile hwProfile) error {
 		return errors.New("failed to allocate hardware frames context")
 	}
 
+	hwFCW := vss.decoder.codecContext.Width()
+	hwFCH := vss.decoder.codecContext.Height()
+
+	if vss.cropParams != nil {
+		hwFCW = vss.cropParams.W
+		hwFCH = vss.cropParams.H
+	}
+
 	vss.encoder.hardwareFrameContext.SetHardwarePixelFormat(profile.hwPixFmt)
 	vss.encoder.hardwareFrameContext.SetSoftwarePixelFormat(profile.swPixFmt)
-	vss.encoder.hardwareFrameContext.SetWidth(vss.decoder.codecContext.Width())
-	vss.encoder.hardwareFrameContext.SetHeight(vss.decoder.codecContext.Height())
+	vss.encoder.hardwareFrameContext.SetWidth(hwFCW)
+	vss.encoder.hardwareFrameContext.SetHeight(hwFCH)
 	vss.encoder.hardwareFrameContext.SetInitialPoolSize(20)
 
 	if err := vss.encoder.hardwareFrameContext.Initialize(); err != nil {
@@ -337,7 +612,23 @@ func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
 		return nil
 	}
 
-	decoderPixelFormat := vss.decoder.codecContext.PixelFormat()
+	// When a crop filter is active, effectiveDecodedPixFmt holds the pixel
+	// format of the frames coming OUT of the filter graph (e.g. NV12 after
+	// hwdownload). Otherwise fall back to the decoder's native format.
+	decoderPixelFormat := vss.effectiveDecodedPixFmt
+	if decoderPixelFormat == astiav.PixelFormatNone {
+		decoderPixelFormat = vss.decoder.codecContext.PixelFormat()
+	}
+
+	// Source dimensions entering the scaler: crop output dimensions when a
+	// crop filter is active, decoder input dimensions otherwise.
+	srcW := vss.decoder.codecContext.Width()
+	srcH := vss.decoder.codecContext.Height()
+
+	if vss.cropParams != nil {
+		srcW = vss.cropParams.W
+		srcH = vss.cropParams.H
+	}
 
 	// For HW encode with SW decode, target the SW pixel format (e.g. NV12)
 	// before uploading; for pure SW encode, target the encoder pixel format.
@@ -348,8 +639,8 @@ func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
 
 	if decoderPixelFormat != encoderPixelFormat {
 		softwareFrameContext, err := astiav.CreateSoftwareScaleContext(
-			vss.decoder.codecContext.Width(), vss.decoder.codecContext.Height(), decoderPixelFormat,
-			vss.decoder.codecContext.Width(), vss.decoder.codecContext.Height(), encoderPixelFormat,
+			srcW, srcH, decoderPixelFormat,
+			srcW, srcH, encoderPixelFormat,
 			astiav.NewSoftwareScaleContextFlags(astiav.SoftwareScaleContextFlagBilinear),
 		)
 		if err != nil {
@@ -363,8 +654,8 @@ func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
 			return errors.New("failed to allocate scaled frame")
 		}
 
-		vss.encoder.frame.SetWidth(vss.decoder.codecContext.Width())
-		vss.encoder.frame.SetHeight(vss.decoder.codecContext.Height())
+		vss.encoder.frame.SetWidth(srcW)
+		vss.encoder.frame.SetHeight(srcH)
 		vss.encoder.frame.SetPixelFormat(encoderPixelFormat)
 
 		if err := vss.encoder.frame.AllocBuffer(0); err != nil {
@@ -416,17 +707,33 @@ func (vss *videoStreamState) processPacket(packet *astiav.Packet, outputFmt *ast
 // encodeVideoFrame converts and encodes a single decoded video frame.
 // On the fully hardware path (isHWDecode=true) the frame is already in GPU
 // memory and is passed directly to the encoder without any CPU conversion.
+// When a crop filter is active, the frame is first pushed through the filter
+// graph and the cropped output is used for the remainder of the pipeline.
 func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *astiav.FormatContext, progressCh chan<- Progress, totalDuration int64) error {
 	encFrame := frame
+
+	if vss.cropFilter != nil {
+		if err := vss.cropFilter.srcCtx.AddFrame(frame, astiav.NewBuffersrcFlags(astiav.BuffersrcFlagKeepRef)); err != nil {
+			return fmt.Errorf("ffmpeg: adding frame to crop filter: %w", err)
+		}
+
+		if err := vss.cropFilter.sinkCtx.GetFrame(vss.cropFilter.frame, astiav.NewBuffersinkFlags()); err != nil {
+			return fmt.Errorf("ffmpeg: getting frame from crop filter: %w", err)
+		}
+
+		defer vss.cropFilter.frame.Unref()
+
+		encFrame = vss.cropFilter.frame
+	}
 
 	if !vss.isHWDecode {
 		// Software decode path: convert pixel format if needed.
 		if vss.encoder.softwareFrameContext != nil {
-			if err := vss.encoder.softwareFrameContext.ScaleFrame(frame, vss.encoder.frame); err != nil {
+			if err := vss.encoder.softwareFrameContext.ScaleFrame(encFrame, vss.encoder.frame); err != nil {
 				return fmt.Errorf("ffmpeg: scaling video frame: %w", err)
 			}
 
-			vss.encoder.frame.SetPts(frame.Pts())
+			vss.encoder.frame.SetPts(encFrame.Pts())
 			vss.encoder.frame.SetPictureType(astiav.PictureTypeNone)
 			encFrame = vss.encoder.frame
 		}

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -40,14 +40,15 @@ type videoDecoderState struct {
 }
 
 // videoProcessingPlan captures the outputs of the decoder and crop-filter setup
-// phases. It is populated by setupDecoder and setupCropFilter, then consumed by
-// configureEncoderPixelFormat, setupVideoConversion, and encodeVideoFrame.
-// Grouping these inter-phase values makes the data flow between setup stages
-// explicit rather than relying on implicit field mutation order across
-// videoStreamState.
+// phases. It is populated by tryCuvidCropOption and setupCropFilter, then
+// consumed by configureEncoderPixelFormat, setupVideoConversion, and
+// encodeVideoFrame. Grouping these inter-phase values makes the data flow
+// between setup stages explicit rather than relying on implicit field mutation
+// order across videoStreamState.
 type videoProcessingPlan struct {
 	// cuvidCropApplied is true when NVDEC hardware applied the crop at decode
-	// time via the cuvid AVOption; setupCropFilter skips the filter graph.
+	// time via the cuvid AVOption (set by tryCuvidCropOption); setupCropFilter
+	// skips the filter graph when this is true.
 	cuvidCropApplied bool
 	// cropFilter is the active libavfilter graph, or nil when no spatial crop
 	// filter is needed (no crop requested, or cuvid handled it).
@@ -122,17 +123,14 @@ func (vss *videoStreamState) free() {
 	}
 }
 
-// setupDecoder initialises the decoder codec context for the video stream.
-// For non-None hwAccel it attempts hardware decoding so that decoded frames
-// remain in GPU memory, enabling a zero-copy decode→encode pipeline.
+// setupDecoder selects and configures the decoder codec context for the video
+// stream. For non-None hwAccel it attempts hardware decoding so that decoded
+// frames remain in GPU memory, enabling a zero-copy decode→encode pipeline.
 // Falls back silently to software decoding if HW decode is unavailable.
 //
-// For CUDA (NVENC) with a crop region, the cuvid decoder's built-in crop
-// dictionary option is tried first. If the option is accepted, the crop is
-// applied at decode time with no filter graph (plan.cuvidCropApplied = true).
-// If the option is rejected (unsupported codec or driver), the context is
-// rebuilt and opened without the option; setupCropFilter will then use
-// the hwdownload→crop→hwupload filter path instead.
+// setupDecoder allocates and configures the context but does not open it; the
+// caller (buildStreamStates) opens the context, either via tryCuvidCropOption
+// for NVENC with a crop region, or directly with Open(nil) otherwise.
 func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *astiav.FormatContext, hwAccel HWAccel) error {
 	var codec *astiav.Codec
 
@@ -162,104 +160,106 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 
 	vss.decoder.codec = codec
 
-	// allocAndConfigCodecContext allocates and configures a fresh decoder codec
-	// context. Extracted as a closure so it can be called a second time when the
-	// cuvid crop-dict Open attempt fails and the context must be rebuilt before
-	// retrying without the option.
-	allocAndConfigCodecContext := func() error {
-		if vss.decoder.codecContext != nil {
-			vss.decoder.codecContext.Free()
-		}
+	return vss.allocAndConfigDecoderContext(inStream, inputFmt)
+}
 
-		vss.decoder.codecContext = astiav.AllocCodecContext(codec)
-		if vss.decoder.codecContext == nil {
-			return errors.New("failed to allocate decoder codec context")
-		}
+// allocAndConfigDecoderContext allocates and configures a fresh decoder codec
+// context using vss.decoder.codec. Any previously allocated context is freed
+// first. Called by setupDecoder and tryCuvidCropOption (which needs a fresh
+// context when the cuvid Open attempt fails).
+func (vss *videoStreamState) allocAndConfigDecoderContext(inStream *astiav.Stream, inputFmt *astiav.FormatContext) error {
+	codec := vss.decoder.codec
 
-		if err := inStream.CodecParameters().ToCodecContext(vss.decoder.codecContext); err != nil {
-			return fmt.Errorf("copying codec parameters to context: %w", err)
-		}
-
-		vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
-
-		if vss.decoder.hwDevCtx != nil {
-			vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
-			vss.decoder.codecContext.SetPixelFormatCallback(func(pixelFormats []astiav.PixelFormat) astiav.PixelFormat {
-				for _, pixelFormat := range pixelFormats {
-					if pixelFormat == vss.decoder.hwPixFmt {
-						return pixelFormat
-					}
-				}
-				// HW pixel format not offered — fall back to the first available format.
-				// Update vss.decoder.hwPixFmt so configureEncoderPixelFormat correctly
-				// detects that the decoder is not outputting the HW format.
-				if len(pixelFormats) > 0 {
-					slog.Debug("ffmpeg: preferred hardware pixel format not offered by decoder, using fallback",
-						"preferred", vss.decoder.hwPixFmt, "fallback", pixelFormats[0])
-					vss.decoder.hwPixFmt = pixelFormats[0]
-
-					return pixelFormats[0]
-				}
-
-				return astiav.PixelFormatNone
-			})
-		}
-
-		return nil
+	if vss.decoder.codecContext != nil {
+		vss.decoder.codecContext.Free()
 	}
 
-	if err := allocAndConfigCodecContext(); err != nil {
-		return err
+	vss.decoder.codecContext = astiav.AllocCodecContext(codec)
+	if vss.decoder.codecContext == nil {
+		return errors.New("failed to allocate decoder codec context")
 	}
 
-	// For CUDA (NVENC) with a crop region, try the cuvid decoder's built-in crop
-	// dictionary option (crop=TxBxLxR). On success the crop is applied at decode
-	// time with zero CPU copies and no filter graph is needed. If the option is
-	// rejected, rebuild the context and open without it; setupCropFilter will use
-	// the hwdownload→crop→hwupload fallback path.
-	opened := false
+	if err := inStream.CodecParameters().ToCodecContext(vss.decoder.codecContext); err != nil {
+		return fmt.Errorf("copying codec parameters to context: %w", err)
+	}
 
-	if vss.decoder.hwDevCtx != nil && hwAccel == HWAccelNVENC && vss.cropParams != nil {
-		cp := vss.cropParams
-		inW := inStream.CodecParameters().Width()
-		inH := inStream.CodecParameters().Height()
-		top := cp.Y
-		bottom := inH - cp.Y - cp.H
-		left := cp.X
-		right := inW - cp.X - cp.W
+	vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
 
-		cropDict := astiav.NewDictionary()
-		defer cropDict.Free()
-
-		if setErr := cropDict.Set("crop", fmt.Sprintf("%dx%dx%dx%d", top, bottom, left, right), astiav.NewDictionaryFlags()); setErr == nil {
-			if openErr := vss.decoder.codecContext.Open(codec, cropDict); openErr == nil {
-				vss.plan.cuvidCropApplied = true
-				opened = true
-			} else {
-				slog.Debug("ffmpeg: cuvid crop dict option unsupported, will use hwdownload/crop/hwupload filter",
-					"error", openErr)
-
-				if err := allocAndConfigCodecContext(); err != nil {
-					return err
+	if vss.decoder.hwDevCtx != nil {
+		vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
+		vss.decoder.codecContext.SetPixelFormatCallback(func(pixelFormats []astiav.PixelFormat) astiav.PixelFormat {
+			for _, pixelFormat := range pixelFormats {
+				if pixelFormat == vss.decoder.hwPixFmt {
+					return pixelFormat
 				}
 			}
-		}
-	}
+			// HW pixel format not offered — fall back to the first available format.
+			// Update vss.decoder.hwPixFmt so configureEncoderPixelFormat correctly
+			// detects that the decoder is not outputting the HW format.
+			if len(pixelFormats) > 0 {
+				slog.Debug("ffmpeg: preferred hardware pixel format not offered by decoder, using fallback",
+					"preferred", vss.decoder.hwPixFmt, "fallback", pixelFormats[0])
+				vss.decoder.hwPixFmt = pixelFormats[0]
 
-	if !opened {
-		if err := vss.decoder.codecContext.Open(codec, nil); err != nil {
-			return fmt.Errorf("opening decoder: %w", err)
-		}
-	}
+				return pixelFormats[0]
+			}
 
-	vss.decoder.codecContext.SetTimeBase(inStream.TimeBase())
-
-	vss.decoder.frame = astiav.AllocFrame()
-	if vss.decoder.frame == nil {
-		return errors.New("failed to allocate decoder frame")
+			return astiav.PixelFormatNone
+		})
 	}
 
 	return nil
+}
+
+// tryCuvidCropOption attempts to apply the cuvid decoder's built-in crop
+// dictionary option (crop=TxBxLxR) for NVENC hardware acceleration with an
+// active crop region. It must be called after setupDecoder (so that
+// vss.decoder.codecContext is allocated and configured) and before
+// setupCropFilter.
+//
+// On success the context is opened with the crop dict, plan.cuvidCropApplied
+// is set to true, and (true, nil) is returned; the caller must NOT open the
+// context again. On failure (unsupported codec or driver), the context is
+// rebuilt into a freshly configured, unopened state so the caller can open it
+// normally; setupCropFilter will use the hwdownload→crop→hwupload path instead.
+//
+// Returns (false, nil) when the conditions for cuvid crop are not met (no HW
+// decode, not NVENC, or no crop region).
+func (vss *videoStreamState) tryCuvidCropOption(inStream *astiav.Stream, inputFmt *astiav.FormatContext, hwAccel HWAccel) (applied bool, err error) {
+	if vss.decoder.hwDevCtx == nil || hwAccel != HWAccelNVENC || vss.cropParams == nil {
+		return false, nil
+	}
+
+	cp := vss.cropParams
+	inW := inStream.CodecParameters().Width()
+	inH := inStream.CodecParameters().Height()
+	top := cp.Y
+	bottom := inH - cp.Y - cp.H
+	left := cp.X
+	right := inW - cp.X - cp.W
+
+	cropDict := astiav.NewDictionary()
+	defer cropDict.Free()
+
+	if setErr := cropDict.Set("crop", fmt.Sprintf("%dx%dx%dx%d", top, bottom, left, right), astiav.NewDictionaryFlags()); setErr != nil {
+		return false, nil
+	}
+
+	if openErr := vss.decoder.codecContext.Open(vss.decoder.codec, cropDict); openErr == nil {
+		vss.plan.cuvidCropApplied = true
+		return true, nil
+	} else {
+		slog.Debug("ffmpeg: cuvid crop dict option unsupported, will use hwdownload/crop/hwupload filter",
+			"error", openErr)
+	}
+
+	// Open() leaves the context in an undefined state on failure; rebuild it so
+	// the caller can perform a normal Open(nil).
+	if err := vss.allocAndConfigDecoderContext(inStream, inputFmt); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }
 
 // cropFilterConfig describes the libavfilter graph used to apply a spatial crop.

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -10,9 +10,8 @@ import (
 )
 
 // videoCropFilterState holds the filter graph used to apply a spatial crop to
-// decoded video frames. The graph is always "crop=W:H:X:Y" operating on
-// software (CPU) frames; hardware decode is disabled when crop is active so
-// that frames arrive in system memory without a separate hwdownload step.
+// decoded video frames. The exact graph depends on the active hardware
+// accelerator; see setupCropFilter for the per-path strategies.
 type videoCropFilterState struct {
 	graph   *astiav.FilterGraph
 	srcCtx  *astiav.BuffersrcFilterContext
@@ -55,6 +54,7 @@ type videoStreamState struct {
 	// decoder is initialised so that source pixel format and dimensions are
 	// known.
 	cropParams             *CropParams           // crop region; nil = no crop
+	cuvidCropApplied       bool                  // true when the cuvid decoder handled crop via its dict option (no filter needed)
 	cropFilter             *videoCropFilterState // non-nil when crop filter graph is active
 	effectiveDecodedPixFmt astiav.PixelFormat    // pixel format of frames entering the encoder pipeline (post crop filter)
 }
@@ -108,30 +108,27 @@ func (vss *videoStreamState) free() {
 // remain in GPU memory, enabling a zero-copy decode→encode pipeline.
 // Falls back silently to software decoding if HW decode is unavailable.
 //
-// When a crop filter is active (cropParams != nil), hardware decode is skipped
-// unconditionally. HW decode requires the crop filter's buffersrc to be
-// initialised with a hardware frames context that exactly matches the decoder's
-// internal pool — a setup that varies across CUDA, VAAPI, and QSV backends and
-// is fragile to get right. SW decode + crop filter + HW encode is still
-// hardware-accelerated on the encode side and is the supported path when
-// cropping is requested.
+// For CUDA (NVENC) with a crop region, the cuvid decoder's built-in crop
+// dictionary option is tried first. If the option is accepted, the crop is
+// applied at decode time with no filter graph (cuvidCropApplied = true).
+// If the option is rejected (unsupported codec or driver), the context is
+// rebuilt and opened without the option; setupCropFilter will then use
+// the hwdownload→crop→hwupload filter path instead.
 func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *astiav.FormatContext, hwAccel HWAccel) error {
 	var codec *astiav.Codec
 
-	if vss.cropParams == nil {
-		if profile, ok := hwProfiles[hwAccel]; ok {
-			hwDecName := hwDecoderNameForCodec(inStream.CodecParameters().CodecID(), profile)
-			if hwDecName != "" {
-				if hwDec := astiav.FindDecoderByName(hwDecName); hwDec != nil {
-					hwDevCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
-					if err == nil {
-						vss.decoder.hwDevCtx = hwDevCtx
-						vss.decoder.hwPixFmt = profile.hwPixFmt
-						codec = hwDec
-					} else {
-						slog.Debug("ffmpeg: hardware decoder setup failed, falling back to software",
-							"decoder", hwDecName, "error", err)
-					}
+	if profile, ok := hwProfiles[hwAccel]; ok {
+		hwDecName := hwDecoderNameForCodec(inStream.CodecParameters().CodecID(), profile)
+		if hwDecName != "" {
+			if hwDec := astiav.FindDecoderByName(hwDecName); hwDec != nil {
+				hwDevCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
+				if err == nil {
+					vss.decoder.hwDevCtx = hwDevCtx
+					vss.decoder.hwPixFmt = profile.hwPixFmt
+					codec = hwDec
+				} else {
+					slog.Debug("ffmpeg: hardware decoder setup failed, falling back to software",
+						"decoder", hwDecName, "error", err)
 				}
 			}
 		}
@@ -146,42 +143,94 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 
 	vss.decoder.codec = codec
 
-	vss.decoder.codecContext = astiav.AllocCodecContext(codec)
-	if vss.decoder.codecContext == nil {
-		return errors.New("failed to allocate decoder codec context")
+	// allocAndConfigCodecContext allocates and configures a fresh decoder codec
+	// context. Extracted as a closure so it can be called a second time when the
+	// cuvid crop-dict Open attempt fails and the context must be rebuilt before
+	// retrying without the option.
+	allocAndConfigCodecContext := func() error {
+		if vss.decoder.codecContext != nil {
+			vss.decoder.codecContext.Free()
+		}
+
+		vss.decoder.codecContext = astiav.AllocCodecContext(codec)
+		if vss.decoder.codecContext == nil {
+			return errors.New("failed to allocate decoder codec context")
+		}
+
+		if err := inStream.CodecParameters().ToCodecContext(vss.decoder.codecContext); err != nil {
+			return fmt.Errorf("copying codec parameters to context: %w", err)
+		}
+
+		vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
+
+		if vss.decoder.hwDevCtx != nil {
+			vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
+			vss.decoder.codecContext.SetPixelFormatCallback(func(pixelFormats []astiav.PixelFormat) astiav.PixelFormat {
+				for _, pixelFormat := range pixelFormats {
+					if pixelFormat == vss.decoder.hwPixFmt {
+						return pixelFormat
+					}
+				}
+				// HW pixel format not offered — fall back to the first available format.
+				// Update vss.decoder.hwPixFmt so configureEncoderPixelFormat correctly
+				// detects that the decoder is not outputting the HW format.
+				if len(pixelFormats) > 0 {
+					slog.Debug("ffmpeg: preferred hardware pixel format not offered by decoder, using fallback",
+						"preferred", vss.decoder.hwPixFmt, "fallback", pixelFormats[0])
+					vss.decoder.hwPixFmt = pixelFormats[0]
+
+					return pixelFormats[0]
+				}
+
+				return astiav.PixelFormatNone
+			})
+		}
+
+		return nil
 	}
 
-	if err := inStream.CodecParameters().ToCodecContext(vss.decoder.codecContext); err != nil {
-		return fmt.Errorf("copying codec parameters to context: %w", err)
+	if err := allocAndConfigCodecContext(); err != nil {
+		return err
 	}
 
-	vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
+	// For CUDA (NVENC) with a crop region, try the cuvid decoder's built-in crop
+	// dictionary option (crop=TxBxLxR). On success the crop is applied at decode
+	// time with zero CPU copies and no filter graph is needed. If the option is
+	// rejected, rebuild the context and open without it; setupCropFilter will use
+	// the hwdownload→crop→hwupload fallback path.
+	opened := false
 
-	if vss.decoder.hwDevCtx != nil {
-		vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
-		vss.decoder.codecContext.SetPixelFormatCallback(func(pixelFormats []astiav.PixelFormat) astiav.PixelFormat {
-			for _, pixelFormat := range pixelFormats {
-				if pixelFormat == vss.decoder.hwPixFmt {
-					return pixelFormat
+	if vss.decoder.hwDevCtx != nil && hwAccel == HWAccelNVENC && vss.cropParams != nil {
+		cp := vss.cropParams
+		inW := inStream.CodecParameters().Width()
+		inH := inStream.CodecParameters().Height()
+		top := cp.Y
+		bottom := inH - cp.Y - cp.H
+		left := cp.X
+		right := inW - cp.X - cp.W
+
+		cropDict := astiav.NewDictionary()
+		defer cropDict.Free()
+
+		if setErr := cropDict.Set("crop", fmt.Sprintf("%dx%dx%dx%d", top, bottom, left, right), astiav.NewDictionaryFlags()); setErr == nil {
+			if openErr := vss.decoder.codecContext.Open(codec, cropDict); openErr == nil {
+				vss.cuvidCropApplied = true
+				opened = true
+			} else {
+				slog.Debug("ffmpeg: cuvid crop dict option unsupported, will use hwdownload/crop/hwupload filter",
+					"error", openErr)
+
+				if err := allocAndConfigCodecContext(); err != nil {
+					return err
 				}
 			}
-			// HW pixel format not offered — fall back to the first available format.
-			// Update vss.decoder.hwPixFmt so configureEncoderPixelFormat correctly
-			// detects that the decoder is not outputting the HW format.
-			if len(pixelFormats) > 0 {
-				slog.Debug("ffmpeg: preferred hardware pixel format not offered by decoder, using fallback",
-					"preferred", vss.decoder.hwPixFmt, "fallback", pixelFormats[0])
-				vss.decoder.hwPixFmt = pixelFormats[0]
-
-				return pixelFormats[0]
-			}
-
-			return astiav.PixelFormatNone
-		})
+		}
 	}
 
-	if err := vss.decoder.codecContext.Open(codec, nil); err != nil {
-		return fmt.Errorf("opening decoder: %w", err)
+	if !opened {
+		if err := vss.decoder.codecContext.Open(codec, nil); err != nil {
+			return fmt.Errorf("opening decoder: %w", err)
+		}
 	}
 
 	vss.decoder.codecContext.SetTimeBase(inStream.TimeBase())
@@ -196,21 +245,109 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 
 // setupCropFilter builds the libavfilter graph that applies the crop region to
 // decoded video frames. It must be called after setupDecoder so that the
-// decoder's pixel format and dimensions are known.
+// decoder's pixel format, dimensions, and hardware state are known.
 //
-// The filter graph is always "crop=W:H:X:Y" operating on software (CPU) frames.
-// Hardware decode is disabled when crop is active (see setupDecoder), so frames
-// always arrive in system memory without a separate hwdownload step.
+// The filter strategy depends on the active hardware accelerator:
 //
-// effectiveDecodedPixFmt is set to the decoder's pixel format, so that
-// setupVideoConversion creates the right scaler/upload path after cropping.
-func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream) error {
+//   - SW:                crop=W:H:X:Y
+//   - VAAPI (SW decode): crop=W:H:X:Y,scale_vaapi  — uploads cropped frames to VAAPI
+//   - VAAPI (HW decode): hwdownload,crop=W:H:X:Y,scale_vaapi  — download, crop, re-upload
+//   - QSV (HW decode):   vpp_qsv=w=W:h=H:cx=X:cy=Y  — GPU-native crop
+//   - CUDA (cuvid dict): returns nil immediately (crop already applied by decoder)
+//   - CUDA (HW decode):  hwdownload,crop=W:H:X:Y,hwupload  — download, crop, re-upload
+//
+// For VAAPI with SW decode, a VAAPI device context is created here and stored
+// in vss.decoder.hwDevCtx so it can be reused by the encoder later.
+//
+// effectiveDecodedPixFmt is set to the output pixel format of the filter graph
+// (e.g. PixelFormatVaapi for VAAPI paths). configureEncoderPixelFormat uses
+// this to enable the zero-copy GPU path when the filter already outputs HW frames.
+func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HWAccel) error {
 	cp := vss.cropParams // guaranteed non-nil by caller
 
-	filterStr := fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y)
+	// CUDA: crop was already applied by the cuvid decoder's dict option.
+	if vss.cuvidCropApplied {
+		return nil
+	}
 
-	srcPixFmt := vss.decoder.codecContext.PixelFormat()
-	vss.effectiveDecodedPixFmt = srcPixFmt
+	profile, hasHW := hwProfiles[hwAccel]
+	hwDecodeActive := vss.decoder.hwDevCtx != nil
+
+	// filterConfig describes the filter graph to build.
+	type filterConfig struct {
+		str         string             // avfilter graph string
+		srcPixFmt   astiav.PixelFormat // pixel format of frames entering buffersrc
+		useHWFrames bool               // init buffersrc with decoder's hw_frames_ctx
+		hwFilters   []string           // filter node names that need hw_device_ctx set
+		outPixFmt   astiav.PixelFormat // effective pixel format after the graph (PixelFormatNone = unchanged SW)
+	}
+
+	var cfg filterConfig
+
+	switch {
+	case hasHW && hwAccel == HWAccelNVENC && hwDecodeActive:
+		// CUDA fallback: cuvid is active but its crop dict option was unsupported.
+		// Download frames to CPU, crop in software, re-upload to CUDA.
+		cfg = filterConfig{
+			str:         fmt.Sprintf("hwdownload,crop=%d:%d:%d:%d,hwupload", cp.W, cp.H, cp.X, cp.Y),
+			srcPixFmt:   astiav.PixelFormatCuda,
+			useHWFrames: true,
+			hwFilters:   []string{"hwupload"},
+			outPixFmt:   astiav.PixelFormatCuda,
+		}
+
+	case hasHW && hwAccel == HWAccelVAAPI && hwDecodeActive:
+		// VAAPI HW decode: download to CPU, apply SW crop, re-upload via scale_vaapi.
+		cfg = filterConfig{
+			str:         fmt.Sprintf("hwdownload,crop=%d:%d:%d:%d,scale_vaapi", cp.W, cp.H, cp.X, cp.Y),
+			srcPixFmt:   astiav.PixelFormatVaapi,
+			useHWFrames: true,
+			hwFilters:   []string{"scale_vaapi"},
+			outPixFmt:   astiav.PixelFormatVaapi,
+		}
+
+	case hasHW && hwAccel == HWAccelVAAPI && !hwDecodeActive:
+		// VAAPI SW decode: crop in software, then upload to VAAPI via scale_vaapi.
+		// A VAAPI device context is needed for scale_vaapi. If one cannot be
+		// created, fall back to a pure software crop.
+		devCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
+		if err != nil {
+			slog.Debug("ffmpeg: VAAPI device context unavailable for crop filter, using SW-only crop", "error", err)
+
+			cfg = filterConfig{
+				str:       fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y),
+				srcPixFmt: vss.decoder.codecContext.PixelFormat(),
+			}
+		} else {
+			// Store the device context so the encoder (set up later) can reuse it.
+			vss.decoder.hwDevCtx = devCtx
+			vss.decoder.hwPixFmt = profile.hwPixFmt
+
+			cfg = filterConfig{
+				str:       fmt.Sprintf("crop=%d:%d:%d:%d,scale_vaapi", cp.W, cp.H, cp.X, cp.Y),
+				srcPixFmt: vss.decoder.codecContext.PixelFormat(),
+				hwFilters: []string{"scale_vaapi"},
+				outPixFmt: astiav.PixelFormatVaapi,
+			}
+		}
+
+	case hasHW && hwAccel == HWAccelQSV && hwDecodeActive:
+		// QSV: GPU-native crop and scale via vpp_qsv.
+		cfg = filterConfig{
+			str:         fmt.Sprintf("vpp_qsv=w=%d:h=%d:cx=%d:cy=%d", cp.W, cp.H, cp.X, cp.Y),
+			srcPixFmt:   astiav.PixelFormatQsv,
+			useHWFrames: true,
+			hwFilters:   []string{"vpp_qsv"},
+			outPixFmt:   astiav.PixelFormatQsv,
+		}
+
+	default:
+		// Software path (SW hwAccel, or HW decode unavailable).
+		cfg = filterConfig{
+			str:       fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y),
+			srcPixFmt: vss.decoder.codecContext.PixelFormat(),
+		}
+	}
 
 	fg := astiav.AllocFilterGraph()
 	if fg == nil {
@@ -248,11 +385,15 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream) error {
 	srcParams := astiav.AllocBuffersrcFilterContextParameters()
 	defer srcParams.Free()
 
-	srcParams.SetPixelFormat(srcPixFmt)
+	srcParams.SetPixelFormat(cfg.srcPixFmt)
 	srcParams.SetWidth(vss.decoder.codecContext.Width())
 	srcParams.SetHeight(vss.decoder.codecContext.Height())
 	srcParams.SetTimeBase(inStream.TimeBase())
 	srcParams.SetSampleAspectRatio(vss.decoder.codecContext.SampleAspectRatio())
+
+	if cfg.useHWFrames {
+		srcParams.SetHardwareFramesContext(vss.decoder.codecContext.HardwareFramesContext())
+	}
 
 	if err := srcCtx.SetParameters(srcParams); err != nil {
 		fg.Free()
@@ -294,10 +435,25 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream) error {
 	inputs.SetPadIdx(0)
 	inputs.SetNext(nil)
 
-	if err := fg.Parse(filterStr, inputs, outputs); err != nil {
+	if err := fg.Parse(cfg.str, inputs, outputs); err != nil {
 		fg.Free()
 
-		return fmt.Errorf("ffmpeg: parsing crop filter graph %q: %w", filterStr, err)
+		return fmt.Errorf("ffmpeg: parsing crop filter graph %q: %w", cfg.str, err)
+	}
+
+	// Set the hardware device context on filters that require it (scale_vaapi,
+	// vpp_qsv, hwupload). Must be done after Parse() and before Configure().
+	if len(cfg.hwFilters) > 0 && vss.decoder.hwDevCtx != nil {
+		hwFilterSet := make(map[string]bool, len(cfg.hwFilters))
+		for _, name := range cfg.hwFilters {
+			hwFilterSet[name] = true
+		}
+
+		for _, fc := range fg.Filters() {
+			if hwFilterSet[fc.Filter().Name()] {
+				fc.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
+			}
+		}
 	}
 
 	if err := fg.Configure(); err != nil {
@@ -311,6 +467,10 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream) error {
 		fg.Free()
 
 		return errors.New("ffmpeg: failed to allocate crop filter output frame")
+	}
+
+	if cfg.outPixFmt != astiav.PixelFormatNone {
+		vss.effectiveDecodedPixFmt = cfg.outPixFmt
 	}
 
 	vss.cropFilter = &videoCropFilterState{
@@ -454,13 +614,28 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 		return nil
 	}
 
-	// HW encode with HW decode: decoded frames are already in GPU memory —
-	// share those surfaces directly with the encoder. The crop filter
-	// downloads frames to CPU memory, so the zero-copy path is unavailable
-	// when a crop filter is active.
+	// HW encode with HW decode and no crop filter: decoded frames are already
+	// in GPU memory — share those surfaces directly with the encoder. This also
+	// covers the CUDA cuvid crop-dict path where the crop is applied by the
+	// decoder itself (cuvidCropApplied=true, cropFilter=nil).
 	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt && vss.cropFilter == nil {
 		vss.isHWDecode = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
+
+		return nil
+	}
+
+	// HW encode with a crop filter whose output is already in HW pixel format
+	// (scale_vaapi, vpp_qsv, hwupload). The filter handles the CPU↔GPU transfer;
+	// frames arrive at the encoder ready for zero-copy encoding.
+	if vss.effectiveDecodedPixFmt != astiav.PixelFormatNone && vss.effectiveDecodedPixFmt == profile.hwPixFmt {
+		vss.isHWDecode = true
+		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
+		// Provide the hardware device context so the encoder can initialise its
+		// hardware-specific state (e.g. create hw_frames_ctx from hw_device_ctx).
+		if vss.decoder.hwDevCtx != nil {
+			vss.encoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
+		}
 
 		return nil
 	}

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -10,16 +10,14 @@ import (
 )
 
 // videoCropFilterState holds the filter graph used to apply a spatial crop to
-// decoded video frames. For software-decoded streams the graph is simply
-// "crop=W:H:X:Y". For hardware-decoded streams "hwdownload" is prepended so
-// that the crop filter receives frames in system memory; the output pixel
-// format is the profile's software pixel format (e.g. NV12).
+// decoded video frames. The graph is always "crop=W:H:X:Y" operating on
+// software (CPU) frames; hardware decode is disabled when crop is active so
+// that frames arrive in system memory without a separate hwdownload step.
 type videoCropFilterState struct {
-	graph       *astiav.FilterGraph
-	srcCtx      *astiav.BuffersrcFilterContext
-	sinkCtx     *astiav.BuffersinkFilterContext
-	frame       *astiav.Frame
-	srcHWFrames *astiav.HardwareFramesContext // non-nil when source frames are in HW memory
+	graph   *astiav.FilterGraph
+	srcCtx  *astiav.BuffersrcFilterContext
+	sinkCtx *astiav.BuffersinkFilterContext
+	frame   *astiav.Frame
 }
 
 type videoEncoderState struct {
@@ -102,10 +100,6 @@ func (vss *videoStreamState) free() {
 		if vss.cropFilter.frame != nil {
 			vss.cropFilter.frame.Free()
 		}
-
-		if vss.cropFilter.srcHWFrames != nil {
-			vss.cropFilter.srcHWFrames.Free()
-		}
 	}
 }
 
@@ -113,21 +107,31 @@ func (vss *videoStreamState) free() {
 // For non-None hwAccel it attempts hardware decoding so that decoded frames
 // remain in GPU memory, enabling a zero-copy decode→encode pipeline.
 // Falls back silently to software decoding if HW decode is unavailable.
+//
+// When a crop filter is active (cropParams != nil), hardware decode is skipped
+// unconditionally. HW decode requires the crop filter's buffersrc to be
+// initialised with a hardware frames context that exactly matches the decoder's
+// internal pool — a setup that varies across CUDA, VAAPI, and QSV backends and
+// is fragile to get right. SW decode + crop filter + HW encode is still
+// hardware-accelerated on the encode side and is the supported path when
+// cropping is requested.
 func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *astiav.FormatContext, hwAccel HWAccel) error {
 	var codec *astiav.Codec
 
-	if profile, ok := hwProfiles[hwAccel]; ok {
-		hwDecName := hwDecoderNameForCodec(inStream.CodecParameters().CodecID(), profile)
-		if hwDecName != "" {
-			if hwDec := astiav.FindDecoderByName(hwDecName); hwDec != nil {
-				hwDevCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
-				if err == nil {
-					vss.decoder.hwDevCtx = hwDevCtx
-					vss.decoder.hwPixFmt = profile.hwPixFmt
-					codec = hwDec
-				} else {
-					slog.Debug("ffmpeg: hardware decoder setup failed, falling back to software",
-						"decoder", hwDecName, "error", err)
+	if vss.cropParams == nil {
+		if profile, ok := hwProfiles[hwAccel]; ok {
+			hwDecName := hwDecoderNameForCodec(inStream.CodecParameters().CodecID(), profile)
+			if hwDecName != "" {
+				if hwDec := astiav.FindDecoderByName(hwDecName); hwDec != nil {
+					hwDevCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
+					if err == nil {
+						vss.decoder.hwDevCtx = hwDevCtx
+						vss.decoder.hwPixFmt = profile.hwPixFmt
+						codec = hwDec
+					} else {
+						slog.Debug("ffmpeg: hardware decoder setup failed, falling back to software",
+							"decoder", hwDecName, "error", err)
+					}
 				}
 			}
 		}
@@ -194,76 +198,28 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 // decoded video frames. It must be called after setupDecoder so that the
 // decoder's pixel format and dimensions are known.
 //
-// For hardware-decoded streams the filter graph is "hwdownload,crop=W:H:X:Y"
-// so that frames are transferred to system memory before cropping. For
-// software-decoded streams the graph is simply "crop=W:H:X:Y".
+// The filter graph is always "crop=W:H:X:Y" operating on software (CPU) frames.
+// Hardware decode is disabled when crop is active (see setupDecoder), so frames
+// always arrive in system memory without a separate hwdownload step.
 //
-// effectiveDecodedPixFmt is set to the pixel format of frames leaving the
-// filter (used by setupVideoConversion to configure the scaler correctly).
-func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HWAccel) error {
+// effectiveDecodedPixFmt is set to the decoder's pixel format, so that
+// setupVideoConversion creates the right scaler/upload path after cropping.
+func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream) error {
 	cp := vss.cropParams // guaranteed non-nil by caller
 
-	cropStr := fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y)
+	filterStr := fmt.Sprintf("crop=%d:%d:%d:%d", cp.W, cp.H, cp.X, cp.Y)
 
-	var (
-		filterStr   string
-		srcPixFmt   astiav.PixelFormat
-		srcHWFrames *astiav.HardwareFramesContext
-	)
-
-	if vss.decoder.hwDevCtx != nil {
-		// HW decode: prepend hwdownload so the crop filter receives frames in
-		// system memory. effectiveDecodedPixFmt becomes the profile's SW
-		// pixel format (e.g. NV12) — the format after the download step.
-		filterStr = "hwdownload," + cropStr
-		srcPixFmt = vss.decoder.hwPixFmt
-
-		profile := hwProfiles[hwAccel]
-		vss.effectiveDecodedPixFmt = profile.swPixFmt
-
-		// Allocate a hardware frames context describing the frames produced by
-		// the HW decoder so that the buffersrc filter knows their format.
-		hfc := astiav.AllocHardwareFramesContext(vss.decoder.hwDevCtx)
-		if hfc == nil {
-			return errors.New("ffmpeg: failed to allocate crop filter hardware frames context")
-		}
-
-		hfc.SetHardwarePixelFormat(vss.decoder.hwPixFmt)
-		hfc.SetSoftwarePixelFormat(profile.swPixFmt)
-		hfc.SetWidth(vss.decoder.codecContext.Width())
-		hfc.SetHeight(vss.decoder.codecContext.Height())
-		hfc.SetInitialPoolSize(0)
-
-		if err := hfc.Initialize(); err != nil {
-			hfc.Free()
-
-			return fmt.Errorf("ffmpeg: initializing crop filter hardware frames context: %w", err)
-		}
-
-		srcHWFrames = hfc
-	} else {
-		// SW decode: crop filter operates directly on the decoded frames.
-		filterStr = cropStr
-		srcPixFmt = vss.decoder.codecContext.PixelFormat()
-		vss.effectiveDecodedPixFmt = srcPixFmt
-	}
+	srcPixFmt := vss.decoder.codecContext.PixelFormat()
+	vss.effectiveDecodedPixFmt = srcPixFmt
 
 	fg := astiav.AllocFilterGraph()
 	if fg == nil {
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return errors.New("ffmpeg: failed to allocate crop filter graph")
 	}
 
 	buffersrc := astiav.FindFilterByName("buffer")
 	if buffersrc == nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return errors.New("ffmpeg: buffer filter not found for crop")
 	}
@@ -272,10 +228,6 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	if buffersink == nil {
 		fg.Free()
 
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return errors.New("ffmpeg: buffersink filter not found for crop")
 	}
 
@@ -283,20 +235,12 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	if err != nil {
 		fg.Free()
 
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return fmt.Errorf("ffmpeg: creating crop buffersrc context: %w", err)
 	}
 
 	sinkCtx, err := fg.NewBuffersinkFilterContext(buffersink, "out")
 	if err != nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return fmt.Errorf("ffmpeg: creating crop buffersink context: %w", err)
 	}
@@ -310,16 +254,8 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	srcParams.SetTimeBase(inStream.TimeBase())
 	srcParams.SetSampleAspectRatio(vss.decoder.codecContext.SampleAspectRatio())
 
-	if srcHWFrames != nil {
-		srcParams.SetHardwareFramesContext(srcHWFrames)
-	}
-
 	if err := srcCtx.SetParameters(srcParams); err != nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return fmt.Errorf("ffmpeg: setting crop buffersrc parameters: %w", err)
 	}
@@ -327,20 +263,12 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	if err := srcCtx.Initialize(nil); err != nil {
 		fg.Free()
 
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return fmt.Errorf("ffmpeg: initializing crop buffersrc: %w", err)
 	}
 
 	outputs := astiav.AllocFilterInOut()
 	if outputs == nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return errors.New("ffmpeg: failed to allocate crop filter in/out (outputs)")
 	}
@@ -350,10 +278,6 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	inputs := astiav.AllocFilterInOut()
 	if inputs == nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return errors.New("ffmpeg: failed to allocate crop filter in/out (inputs)")
 	}
@@ -373,19 +297,11 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	if err := fg.Parse(filterStr, inputs, outputs); err != nil {
 		fg.Free()
 
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return fmt.Errorf("ffmpeg: parsing crop filter graph %q: %w", filterStr, err)
 	}
 
 	if err := fg.Configure(); err != nil {
 		fg.Free()
-
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
 
 		return fmt.Errorf("ffmpeg: configuring crop filter graph: %w", err)
 	}
@@ -394,19 +310,14 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	if filterFrame == nil {
 		fg.Free()
 
-		if srcHWFrames != nil {
-			srcHWFrames.Free()
-		}
-
 		return errors.New("ffmpeg: failed to allocate crop filter output frame")
 	}
 
 	vss.cropFilter = &videoCropFilterState{
-		graph:       fg,
-		srcCtx:      srcCtx,
-		sinkCtx:     sinkCtx,
-		frame:       filterFrame,
-		srcHWFrames: srcHWFrames,
+		graph:   fg,
+		srcCtx:  srcCtx,
+		sinkCtx: sinkCtx,
+		frame:   filterFrame,
 	}
 
 	return nil

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -39,28 +39,43 @@ type videoDecoderState struct {
 	hwPixFmt astiav.PixelFormat // expected HW pixel format from the HW decoder
 }
 
+// videoProcessingPlan captures the outputs of the decoder and crop-filter setup
+// phases. It is populated by setupDecoder and setupCropFilter, then consumed by
+// configureEncoderPixelFormat, setupVideoConversion, and encodeVideoFrame.
+// Grouping these inter-phase values makes the data flow between setup stages
+// explicit rather than relying on implicit field mutation order across
+// videoStreamState.
+type videoProcessingPlan struct {
+	// cuvidCropApplied is true when NVDEC hardware applied the crop at decode
+	// time via the cuvid AVOption; setupCropFilter skips the filter graph.
+	cuvidCropApplied bool
+	// cropFilter is the active libavfilter graph, or nil when no spatial crop
+	// filter is needed (no crop requested, or cuvid handled it).
+	cropFilter *videoCropFilterState
+	// effectiveDecodedPixFmt is the pixel format of frames entering the encoder
+	// pipeline. Set by setupCropFilter to the filter output format (e.g.
+	// PixelFormatVaapi for VAAPI paths); zero value when no crop filter is active.
+	effectiveDecodedPixFmt astiav.PixelFormat
+	// encoderReceivesHWFrames is true when frames at the encoder input are
+	// already in GPU pixel format. Set by configureEncoderPixelFormat; read by
+	// setupVideoConversion and encodeVideoFrame.
+	encoderReceivesHWFrames bool
+}
+
 // videoStreamState decodes and re-encodes a video stream.
 type videoStreamState struct {
 	copyStreamState
 
 	// Decoder state.
-	decoder videoDecoderState
-	encoder videoEncoderState
-	// encoderReceivesHWFrames is true when frames arriving at the encoder are
-	// already in GPU pixel format (HW decode without filter, cuvid crop dict, or
-	// a crop filter whose output is a HW surface such as VAAPI/QSV/CUDA).
-	// When true, setupVideoConversion skips CPU-side scaling and upload.
-	encoderReceivesHWFrames bool
-	hardwareDevicePath      string // device path for CreateHardwareDeviceContext; "" = auto-select
+	decoder            videoDecoderState
+	encoder            videoEncoderState
+	hardwareDevicePath string // device path for CreateHardwareDeviceContext; "" = auto-select
 
-	// Crop filter state. Non-nil when a crop region has been requested via
-	// WithCrop. The filter graph is set up in setupCropFilter after the
-	// decoder is initialised so that source pixel format and dimensions are
-	// known.
-	cropParams             *CropParams           // crop region; nil = no crop
-	cuvidCropApplied       bool                  // true when the cuvid decoder handled crop via its dict option (no filter needed)
-	cropFilter             *videoCropFilterState // non-nil when crop filter graph is active
-	effectiveDecodedPixFmt astiav.PixelFormat    // pixel format of frames entering the encoder pipeline (post crop filter)
+	// cropParams is the requested spatial crop region, or nil when no crop is needed.
+	cropParams *CropParams
+	// plan captures the outputs of the decoder and crop-filter setup phases and
+	// is consumed by the encoder setup and per-frame processing. See videoProcessingPlan.
+	plan videoProcessingPlan
 }
 
 func (vds *videoDecoderState) free() {
@@ -96,13 +111,13 @@ func (vss *videoStreamState) free() {
 		vss.encoder.hardwareFrameContext.Free()
 	}
 
-	if vss.cropFilter != nil {
-		if vss.cropFilter.graph != nil {
-			vss.cropFilter.graph.Free()
+	if vss.plan.cropFilter != nil {
+		if vss.plan.cropFilter.graph != nil {
+			vss.plan.cropFilter.graph.Free()
 		}
 
-		if vss.cropFilter.frame != nil {
-			vss.cropFilter.frame.Free()
+		if vss.plan.cropFilter.frame != nil {
+			vss.plan.cropFilter.frame.Free()
 		}
 	}
 }
@@ -114,7 +129,7 @@ func (vss *videoStreamState) free() {
 //
 // For CUDA (NVENC) with a crop region, the cuvid decoder's built-in crop
 // dictionary option is tried first. If the option is accepted, the crop is
-// applied at decode time with no filter graph (cuvidCropApplied = true).
+// applied at decode time with no filter graph (plan.cuvidCropApplied = true).
 // If the option is rejected (unsupported codec or driver), the context is
 // rebuilt and opened without the option; setupCropFilter will then use
 // the hwdownload→crop→hwupload filter path instead.
@@ -218,7 +233,7 @@ func (vss *videoStreamState) setupDecoder(inStream *astiav.Stream, inputFmt *ast
 
 		if setErr := cropDict.Set("crop", fmt.Sprintf("%dx%dx%dx%d", top, bottom, left, right), astiav.NewDictionaryFlags()); setErr == nil {
 			if openErr := vss.decoder.codecContext.Open(codec, cropDict); openErr == nil {
-				vss.cuvidCropApplied = true
+				vss.plan.cuvidCropApplied = true
 				opened = true
 			} else {
 				slog.Debug("ffmpeg: cuvid crop dict option unsupported, will use hwdownload/crop/hwupload filter",
@@ -326,14 +341,14 @@ func selectCropFilterConfig(hwAccel HWAccel, hwDecodeActive bool, decoderPixFmt 
 // hardware accelerator. For VAAPI with SW decode, a VAAPI device context is
 // created here and stored in vss.decoder.hwDevCtx so the encoder can reuse it.
 //
-// effectiveDecodedPixFmt is set to the output pixel format of the filter graph
+// plan.effectiveDecodedPixFmt is set to the output pixel format of the filter graph
 // (e.g. PixelFormatVaapi for VAAPI paths). configureEncoderPixelFormat uses
 // this to enable the zero-copy GPU path when the filter already outputs HW frames.
 func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HWAccel) error {
 	cp := vss.cropParams // guaranteed non-nil by caller
 
 	// CUDA: crop was already applied by the cuvid decoder's dict option.
-	if vss.cuvidCropApplied {
+	if vss.plan.cuvidCropApplied {
 		return nil
 	}
 
@@ -479,10 +494,10 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 	}
 
 	if cfg.outPixFmt != astiav.PixelFormatNone {
-		vss.effectiveDecodedPixFmt = cfg.outPixFmt
+		vss.plan.effectiveDecodedPixFmt = cfg.outPixFmt
 	}
 
-	vss.cropFilter = &videoCropFilterState{
+	vss.plan.cropFilter = &videoCropFilterState{
 		graph:   fg,
 		srcCtx:  srcCtx,
 		sinkCtx: sinkCtx,
@@ -626,9 +641,9 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	// HW encode with HW decode and no crop filter: decoded frames are already
 	// in GPU memory — share those surfaces directly with the encoder. This also
 	// covers the CUDA cuvid crop-dict path where the crop is applied by the
-	// decoder itself (cuvidCropApplied=true, cropFilter=nil).
-	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt && vss.cropFilter == nil {
-		vss.encoderReceivesHWFrames = true
+	// decoder itself (plan.cuvidCropApplied=true, plan.cropFilter=nil).
+	if vss.decoder.hwDevCtx != nil && vss.decoder.hwPixFmt == profile.hwPixFmt && vss.plan.cropFilter == nil {
+		vss.plan.encoderReceivesHWFrames = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 
 		return nil
@@ -637,8 +652,8 @@ func (vss *videoStreamState) configureEncoderPixelFormat(enc *astiav.Codec, prof
 	// HW encode with a crop filter whose output is already in HW pixel format
 	// (scale_vaapi, vpp_qsv, hwupload). The filter handles the CPU↔GPU transfer;
 	// frames arrive at the encoder ready for zero-copy encoding.
-	if vss.effectiveDecodedPixFmt != astiav.PixelFormatNone && vss.effectiveDecodedPixFmt == profile.hwPixFmt {
-		vss.encoderReceivesHWFrames = true
+	if vss.plan.effectiveDecodedPixFmt != astiav.PixelFormatNone && vss.plan.effectiveDecodedPixFmt == profile.hwPixFmt {
+		vss.plan.encoderReceivesHWFrames = true
 		vss.encoder.codecContext.SetPixelFormat(profile.hwPixFmt)
 		// Provide the hardware device context so the encoder can initialise its
 		// hardware-specific state (e.g. create hw_frames_ctx from hw_device_ctx).
@@ -695,22 +710,22 @@ func (vss *videoStreamState) setupHWFramesContext(profile hwProfile) error {
 //
 // For the SW decode + HW encode path, decoded YUV frames are converted on the
 // CPU before being uploaded to GPU memory. A fully hardware-accelerated
-// decode→encode pipeline (encoderReceivesHWFrames=true) eliminates this CPU step by
+// decode→encode pipeline (plan.encoderReceivesHWFrames=true) eliminates this CPU step by
 // sharing GPU surfaces between the decoder and encoder.
 //
 // Note: side-data formats such as Dolby Vision RPU are currently not
 // preserved across re-encoding. Copy streams (CodecCopy) always preserve all
 // side data since the bitstream is passed through unchanged.
 func (vss *videoStreamState) setupVideoConversion(profile hwProfile) error {
-	if vss.encoderReceivesHWFrames {
+	if vss.plan.encoderReceivesHWFrames {
 		// Decoded frames are already in the correct HW pixel format.
 		return nil
 	}
 
-	// When a crop filter is active, effectiveDecodedPixFmt holds the pixel
+	// When a crop filter is active, plan.effectiveDecodedPixFmt holds the pixel
 	// format of the frames coming OUT of the filter graph (e.g. NV12 after
 	// hwdownload). Otherwise fall back to the decoder's native format.
-	decoderPixelFormat := vss.effectiveDecodedPixFmt
+	decoderPixelFormat := vss.plan.effectiveDecodedPixFmt
 	if decoderPixelFormat == astiav.PixelFormatNone {
 		decoderPixelFormat = vss.decoder.codecContext.PixelFormat()
 	}
@@ -800,19 +815,19 @@ func (vss *videoStreamState) processPacket(packet *astiav.Packet, outputFmt *ast
 }
 
 // encodeVideoFrame converts and encodes a single decoded video frame.
-// On the fully hardware path (encoderReceivesHWFrames=true) the frame is already in GPU
+// On the fully hardware path (plan.encoderReceivesHWFrames=true) the frame is already in GPU
 // memory and is passed directly to the encoder without any CPU conversion.
 // When a crop filter is active, the frame is first pushed through the filter
 // graph and the cropped output is used for the remainder of the pipeline.
 func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *astiav.FormatContext, progressCh chan<- Progress, totalDuration int64) error {
 	encFrame := frame
 
-	if vss.cropFilter != nil {
-		if err := vss.cropFilter.srcCtx.AddFrame(frame, astiav.NewBuffersrcFlags(astiav.BuffersrcFlagKeepRef)); err != nil {
+	if vss.plan.cropFilter != nil {
+		if err := vss.plan.cropFilter.srcCtx.AddFrame(frame, astiav.NewBuffersrcFlags(astiav.BuffersrcFlagKeepRef)); err != nil {
 			return fmt.Errorf("ffmpeg: adding frame to crop filter: %w", err)
 		}
 
-		if err := vss.cropFilter.sinkCtx.GetFrame(vss.cropFilter.frame, astiav.NewBuffersinkFlags()); err != nil {
+		if err := vss.plan.cropFilter.sinkCtx.GetFrame(vss.plan.cropFilter.frame, astiav.NewBuffersinkFlags()); err != nil {
 			if errors.Is(err, astiav.ErrEagain) {
 				// Filter needs more input before it can produce output (should not
 				// occur for a simple crop filter, but handled gracefully).
@@ -822,12 +837,12 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 			return fmt.Errorf("ffmpeg: getting frame from crop filter: %w", err)
 		}
 
-		defer vss.cropFilter.frame.Unref()
+		defer vss.plan.cropFilter.frame.Unref()
 
-		encFrame = vss.cropFilter.frame
+		encFrame = vss.plan.cropFilter.frame
 	}
 
-	if !vss.encoderReceivesHWFrames {
+	if !vss.plan.encoderReceivesHWFrames {
 		// Software decode path: convert pixel format if needed.
 		if vss.encoder.softwareFrameContext != nil {
 			if err := vss.encoder.softwareFrameContext.ScaleFrame(encFrame, vss.encoder.frame); err != nil {

--- a/pkg/ffmpeg/stream_video_test.go
+++ b/pkg/ffmpeg/stream_video_test.go
@@ -1,0 +1,109 @@
+package ffmpeg
+
+import (
+	"testing"
+
+	"github.com/asticode/go-astiav"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSelectCropFilterConfig verifies that selectCropFilterConfig returns the
+// correct filter graph string and buffersrc configuration for each of the six
+// hardware-accelerator crop paths. The function is pure (no FFmpeg state) so
+// all paths can be covered without real hardware.
+func TestSelectCropFilterConfig(t *testing.T) {
+	cp := CropParams{W: 1920, H: 800, X: 0, Y: 140}
+	swPixFmt := astiav.PixelFormatYuv420P
+
+	tests := []struct {
+		name            string
+		hwAccel         HWAccel
+		hwDecodeActive  bool
+		decoderPixFmt   astiav.PixelFormat
+		wantStr         string
+		wantSrcPixFmt   astiav.PixelFormat
+		wantUseHWFrames bool
+		wantHWFilters   []string
+		wantOutPixFmt   astiav.PixelFormat
+	}{
+		{
+			name:           "software path",
+			hwAccel:        HWAccelNone,
+			hwDecodeActive: false,
+			decoderPixFmt:  swPixFmt,
+			wantStr:        "crop=1920:800:0:140",
+			wantSrcPixFmt:  swPixFmt,
+		},
+		{
+			name:            "CUDA cuvid fallback (hwdownload/crop/hwupload)",
+			hwAccel:         HWAccelNVENC,
+			hwDecodeActive:  true,
+			decoderPixFmt:   astiav.PixelFormatCuda,
+			wantStr:         "hwdownload,crop=1920:800:0:140,hwupload",
+			wantSrcPixFmt:   astiav.PixelFormatCuda,
+			wantUseHWFrames: true,
+			wantHWFilters:   []string{"hwupload"},
+			wantOutPixFmt:   astiav.PixelFormatCuda,
+		},
+		{
+			name:           "CUDA without HW decode falls back to SW",
+			hwAccel:        HWAccelNVENC,
+			hwDecodeActive: false,
+			decoderPixFmt:  swPixFmt,
+			wantStr:        "crop=1920:800:0:140",
+			wantSrcPixFmt:  swPixFmt,
+		},
+		{
+			name:            "VAAPI HW decode (hwdownload/crop/scale_vaapi)",
+			hwAccel:         HWAccelVAAPI,
+			hwDecodeActive:  true,
+			decoderPixFmt:   astiav.PixelFormatVaapi,
+			wantStr:         "hwdownload,crop=1920:800:0:140,scale_vaapi",
+			wantSrcPixFmt:   astiav.PixelFormatVaapi,
+			wantUseHWFrames: true,
+			wantHWFilters:   []string{"scale_vaapi"},
+			wantOutPixFmt:   astiav.PixelFormatVaapi,
+		},
+		{
+			name:           "VAAPI SW decode (crop/scale_vaapi)",
+			hwAccel:        HWAccelVAAPI,
+			hwDecodeActive: false,
+			decoderPixFmt:  swPixFmt,
+			wantStr:        "crop=1920:800:0:140,scale_vaapi",
+			wantSrcPixFmt:  swPixFmt,
+			wantHWFilters:  []string{"scale_vaapi"},
+			wantOutPixFmt:  astiav.PixelFormatVaapi,
+		},
+		{
+			name:            "QSV HW decode (vpp_qsv)",
+			hwAccel:         HWAccelQSV,
+			hwDecodeActive:  true,
+			decoderPixFmt:   astiav.PixelFormatQsv,
+			wantStr:         "vpp_qsv=w=1920:h=800:cx=0:cy=140",
+			wantSrcPixFmt:   astiav.PixelFormatQsv,
+			wantUseHWFrames: true,
+			wantHWFilters:   []string{"vpp_qsv"},
+			wantOutPixFmt:   astiav.PixelFormatQsv,
+		},
+		{
+			name:           "QSV without HW decode falls back to SW",
+			hwAccel:        HWAccelQSV,
+			hwDecodeActive: false,
+			decoderPixFmt:  swPixFmt,
+			wantStr:        "crop=1920:800:0:140",
+			wantSrcPixFmt:  swPixFmt,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectCropFilterConfig(tc.hwAccel, tc.hwDecodeActive, tc.decoderPixFmt, cp)
+
+			assert.Equal(t, tc.wantStr, got.str, "filter string")
+			assert.Equal(t, tc.wantSrcPixFmt, got.srcPixFmt, "srcPixFmt")
+			assert.Equal(t, tc.wantUseHWFrames, got.useHWFrames, "useHWFrames")
+			assert.Equal(t, tc.wantHWFilters, got.hwFilters, "hwFilters")
+			assert.Equal(t, tc.wantOutPixFmt, got.outPixFmt, "outPixFmt")
+		})
+	}
+}

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -447,7 +447,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 			}
 
 			if t.cropParams != nil {
-				if err := videoState.setupCropFilter(inStream); err != nil {
+				if err := videoState.setupCropFilter(inStream, hwAccel); err != nil {
 					freeStreams(streams)
 					return nil, fmt.Errorf("ffmpeg: setting up crop filter for stream %d: %w", inStream.Index(), err)
 				}

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -448,6 +448,31 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 				return nil, fmt.Errorf("ffmpeg: setting up decoder for stream %d: %w", inStream.Index(), err)
 			}
 
+			// For NVENC with a crop region, try to apply the crop via the cuvid
+			// decoder's built-in dictionary option (zero CPU copies). If successful
+			// the context is already open; otherwise it is left in a configured but
+			// unopened state for the normal Open below.
+			cuvidApplied, err := videoState.tryCuvidCropOption(inStream, inputFmt, hwAccel)
+			if err != nil {
+				freeStreams(streams)
+				return nil, fmt.Errorf("ffmpeg: trying cuvid crop option for stream %d: %w", inStream.Index(), err)
+			}
+
+			if !cuvidApplied {
+				if err := videoState.decoder.codecContext.Open(videoState.decoder.codec, nil); err != nil {
+					freeStreams(streams)
+					return nil, fmt.Errorf("ffmpeg: opening decoder for stream %d: %w", inStream.Index(), err)
+				}
+			}
+
+			videoState.decoder.codecContext.SetTimeBase(inStream.TimeBase())
+
+			videoState.decoder.frame = astiav.AllocFrame()
+			if videoState.decoder.frame == nil {
+				freeStreams(streams)
+				return nil, errors.New("ffmpeg: failed to allocate decoder frame")
+			}
+
 			if t.cropParams != nil {
 				if err := videoState.setupCropFilter(inStream, hwAccel); err != nil {
 					freeStreams(streams)

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -205,10 +205,12 @@ func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *Tra
 // WithCrop applies a crop filter to the video stream during encoding. The crop
 // region is specified by params: W and H are the output dimensions in pixels,
 // and X and Y are the offsets from the top-left corner of the input frame.
-// WithCrop is a no-op when params is nil or when videoCodec is CodecCopy,
-// since a crop filter requires decoding and re-encoding the video stream.
+// WithCrop is a no-op when params is nil. Crop is silently skipped at build
+// time when videoCodec is CodecCopy, since copying a stream precludes any
+// filter. Storing cropParams unconditionally avoids a call-order dependency:
+// WithCrop and ToVideoCodec may be called in any order on the builder.
 func (b *TranscodeBuilder) WithCrop(params *CropParams) *TranscodeBuilder {
-	if params == nil || b.videoCodec == CodecCopy {
+	if params == nil {
 		return b
 	}
 

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -205,14 +205,14 @@ func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *Tra
 // WithCrop applies a crop filter to the video stream during encoding. The crop
 // region is specified by params: W and H are the output dimensions in pixels,
 // and X and Y are the offsets from the top-left corner of the input frame.
-// WithCrop is a no-op when videoCodec is CodecCopy, since a crop filter
-// requires decoding and re-encoding the video stream.
-func (b *TranscodeBuilder) WithCrop(params CropParams) *TranscodeBuilder {
-	if b.videoCodec == CodecCopy {
+// WithCrop is a no-op when params is nil or when videoCodec is CodecCopy,
+// since a crop filter requires decoding and re-encoding the video stream.
+func (b *TranscodeBuilder) WithCrop(params *CropParams) *TranscodeBuilder {
+	if params == nil || b.videoCodec == CodecCopy {
 		return b
 	}
 
-	b.cropParams = &params
+	b.cropParams = params
 
 	return b
 }
@@ -447,7 +447,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 			}
 
 			if t.cropParams != nil {
-				if err := videoState.setupCropFilter(inStream, hwAccel); err != nil {
+				if err := videoState.setupCropFilter(inStream); err != nil {
 					freeStreams(streams)
 					return nil, fmt.Errorf("ffmpeg: setting up crop filter for stream %d: %w", inStream.Index(), err)
 				}

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -29,6 +29,7 @@ type TranscodeBuilder struct {
 	downmixTitle          string         // title prefix prepended to the downmix channel layout label
 	coverArtBytes         []byte         // raw image bytes to embed as MKV attachment; nil = no cover art
 	coverArtMimeType      string         // MIME type of coverArtBytes ("image/jpeg" or "image/png")
+	cropParams            *CropParams    // crop region to apply during video encode; nil = no crop
 }
 
 // NewTranscode returns a builder for a transcode job from inputPath to outputPath.
@@ -197,6 +198,21 @@ func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *Tra
 
 	b.coverArtBytes = imageBytes
 	b.coverArtMimeType = mimeType
+
+	return b
+}
+
+// WithCrop applies a crop filter to the video stream during encoding. The crop
+// region is specified by params: W and H are the output dimensions in pixels,
+// and X and Y are the offsets from the top-left corner of the input frame.
+// WithCrop is a no-op when videoCodec is CodecCopy, since a crop filter
+// requires decoding and re-encoding the video stream.
+func (b *TranscodeBuilder) WithCrop(params CropParams) *TranscodeBuilder {
+	if b.videoCodec == CodecCopy {
+		return b
+	}
+
+	b.cropParams = &params
 
 	return b
 }
@@ -424,10 +440,17 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 
 		switch {
 		case mediaType == astiav.MediaTypeVideo && t.videoCodec != CodecCopy:
-			videoState := &videoStreamState{copyStreamState: base, encoder: videoEncoderState{codecID: t.videoCodec}, hardwareDevicePath: t.hardwareDevicePath}
+			videoState := &videoStreamState{copyStreamState: base, encoder: videoEncoderState{codecID: t.videoCodec}, hardwareDevicePath: t.hardwareDevicePath, cropParams: t.cropParams}
 			if err := videoState.setupDecoder(inStream, inputFmt, hwAccel); err != nil {
 				freeStreams(streams)
 				return nil, fmt.Errorf("ffmpeg: setting up decoder for stream %d: %w", inStream.Index(), err)
+			}
+
+			if t.cropParams != nil {
+				if err := videoState.setupCropFilter(inStream, hwAccel); err != nil {
+					freeStreams(streams)
+					return nil, fmt.Errorf("ffmpeg: setting up crop filter for stream %d: %w", inStream.Index(), err)
+				}
 			}
 
 			s = videoState

--- a/pkg/ffmpeg/transcode_hw_test.go
+++ b/pkg/ffmpeg/transcode_hw_test.go
@@ -3,14 +3,11 @@
 package ffmpeg_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
-	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
 
 // TestDetectHardwareEncoders_HardwarePresent verifies that DetectHardwareEncoders
@@ -27,66 +24,4 @@ func TestDetectHardwareEncoders_HardwarePresent(t *testing.T) {
 		}
 	}
 	assert.True(t, foundHW, "DetectHardwareEncoders must return a non-empty list for at least one codec when hardware is present")
-}
-
-// testCropOutputDimensions is a shared helper that runs a transcode with the
-// given CropParams and asserts the output video dimensions match the crop region.
-func testCropOutputDimensions(t *testing.T, output string, crop *ffmpeg.CropParams) {
-	t.Helper()
-
-	info, err := ffprobe.Probe(t.Context(), output)
-	require.NoError(t, err)
-
-	var videoStream *ffprobe.StreamInfo
-	for i := range info.Streams {
-		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
-			videoStream = &info.Streams[i]
-			break
-		}
-	}
-
-	require.NotNil(t, videoStream, "output must contain a video stream")
-	assert.Equal(t, crop.W, videoStream.WidthPixels, "output width must match crop width")
-	assert.Equal(t, crop.H, videoStream.HeightPixels, "output height must match crop height")
-}
-
-// TestTranscode_CropWithVAAPI_SWDecode verifies that the SW-decode VAAPI crop
-// path (crop=W:H:X:Y,scale_vaapi) produces output with the correct dimensions.
-// Requires VAAPI hardware (hwtest build tag).
-func TestTranscode_CropWithVAAPI_SWDecode(t *testing.T) {
-	output := filepath.Join(t.TempDir(), "out.mkv")
-	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
-
-	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
-		ToVideoCodec(ffmpeg.CodecH265).
-		ToContainer(ffmpeg.ContainerMKV).
-		HardwareAccel(ffmpeg.HWAccelVAAPI).
-		WithCrop(crop).
-		Build().
-		Run(t.Context())
-	require.NoError(t, err)
-
-	testCropOutputDimensions(t, output, crop)
-}
-
-// TestTranscode_CropWithNVENC_CuvidFallback verifies that the CUDA cuvid
-// fallback crop path (hwdownload,crop,hwupload) produces output with the
-// correct dimensions when the cuvid dict option is unavailable. The test
-// forces the fallback by using an input codec that cuvid does not accept the
-// crop dict option for, or by relying on the natural fallback logic.
-// Requires NVENC hardware (hwtest build tag).
-func TestTranscode_CropWithNVENC_CuvidFallback(t *testing.T) {
-	output := filepath.Join(t.TempDir(), "out.mkv")
-	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
-
-	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
-		ToVideoCodec(ffmpeg.CodecH265).
-		ToContainer(ffmpeg.ContainerMKV).
-		HardwareAccel(ffmpeg.HWAccelNVENC).
-		WithCrop(crop).
-		Build().
-		Run(t.Context())
-	require.NoError(t, err)
-
-	testCropOutputDimensions(t, output, crop)
 }

--- a/pkg/ffmpeg/transcode_hw_test.go
+++ b/pkg/ffmpeg/transcode_hw_test.go
@@ -3,11 +3,14 @@
 package ffmpeg_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
+	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
 
 // TestDetectHardwareEncoders_HardwarePresent verifies that DetectHardwareEncoders
@@ -24,4 +27,66 @@ func TestDetectHardwareEncoders_HardwarePresent(t *testing.T) {
 		}
 	}
 	assert.True(t, foundHW, "DetectHardwareEncoders must return a non-empty list for at least one codec when hardware is present")
+}
+
+// testCropOutputDimensions is a shared helper that runs a transcode with the
+// given CropParams and asserts the output video dimensions match the crop region.
+func testCropOutputDimensions(t *testing.T, output string, crop *ffmpeg.CropParams) {
+	t.Helper()
+
+	info, err := ffprobe.Probe(t.Context(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output must contain a video stream")
+	assert.Equal(t, crop.W, videoStream.WidthPixels, "output width must match crop width")
+	assert.Equal(t, crop.H, videoStream.HeightPixels, "output height must match crop height")
+}
+
+// TestTranscode_CropWithVAAPI_SWDecode verifies that the SW-decode VAAPI crop
+// path (crop=W:H:X:Y,scale_vaapi) produces output with the correct dimensions.
+// Requires VAAPI hardware (hwtest build tag).
+func TestTranscode_CropWithVAAPI_SWDecode(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelVAAPI).
+		WithCrop(crop).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	testCropOutputDimensions(t, output, crop)
+}
+
+// TestTranscode_CropWithNVENC_CuvidFallback verifies that the CUDA cuvid
+// fallback crop path (hwdownload,crop,hwupload) produces output with the
+// correct dimensions when the cuvid dict option is unavailable. The test
+// forces the fallback by using an input codec that cuvid does not accept the
+// crop dict option for, or by relying on the natural fallback logic.
+// Requires NVENC hardware (hwtest build tag).
+func TestTranscode_CropWithNVENC_CuvidFallback(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelNVENC).
+		WithCrop(crop).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	testCropOutputDimensions(t, output, crop)
 }

--- a/pkg/ffmpeg/transcode_nvenc_test.go
+++ b/pkg/ffmpeg/transcode_nvenc_test.go
@@ -1,0 +1,48 @@
+//go:build nvenctest
+
+package ffmpeg_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
+	"github.com/solidDoWant/media-processor/pkg/ffprobe"
+)
+
+// TestTranscode_CropWithNVENC_CuvidFallback verifies that the CUDA cuvid
+// fallback crop path (hwdownload,crop=W:H:X:Y,hwupload) produces output with
+// the correct dimensions when the cuvid dict option is unavailable or unsupported
+// for the input codec.
+// Requires NVENC hardware (nvenctest build tag).
+func TestTranscode_CropWithNVENC_CuvidFallback(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelNVENC).
+		WithCrop(crop).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	info, err := ffprobe.Probe(t.Context(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output must contain a video stream")
+	assert.Equal(t, crop.W, videoStream.WidthPixels, "output width must match crop width")
+	assert.Equal(t, crop.H, videoStream.HeightPixels, "output height must match crop height")
+}

--- a/pkg/ffmpeg/transcode_qsv_test.go
+++ b/pkg/ffmpeg/transcode_qsv_test.go
@@ -15,6 +15,38 @@ import (
 	"github.com/solidDoWant/media-processor/pkg/ffprobe"
 )
 
+// TestTranscode_CropWithQSV verifies that the vpp_qsv crop path produces output
+// with the correct dimensions when QSV hardware is available.
+// Requires QSV hardware (qsvtest build tag).
+func TestTranscode_CropWithQSV(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelQSV).
+		WithCrop(crop).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	info, err := ffprobe.Probe(t.Context(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output must contain a video stream")
+	assert.Equal(t, crop.W, videoStream.WidthPixels, "output width must match crop width")
+	assert.Equal(t, crop.H, videoStream.HeightPixels, "output height must match crop height")
+}
+
 // TestTranscode_QSVPerformanceMatchesFFmpegCLI verifies that our QSV transcode
 // implementation performs within 1.25× of the ffmpeg CLI with identical QSV
 // parameters. This guards against accidentally falling back to software

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -612,6 +612,71 @@ func TestTranscode_WithCoverArt_NilBytesIsNoop(t *testing.T) {
 	assert.Empty(t, probeAttachments(t, output), "no attachment expected when cover art bytes are nil")
 }
 
+// testBlackBarsVideoPath is a 320x220 H.264 video with 22-pixel black bars on the
+// top and bottom, producing a 320x176 active picture area (crop=320:176:0:22).
+const testBlackBarsVideoPath = "testdata/video_black_bars.mp4"
+
+// TestWithCrop_NarrowsOutputDimensions verifies that WithCrop reduces the output
+// video dimensions to the crop region (320x176 from the 320x220 source).
+func TestWithCrop_NarrowsOutputDimensions(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	crop := ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		WithCrop(crop).
+		Build().
+		Run(context.Background())
+	require.NoError(t, err)
+
+	info, err := ffprobe.Probe(context.Background(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output file should contain a video stream")
+	assert.Equal(t, 320, videoStream.WidthPixels, "output width should match crop width")
+	assert.Equal(t, 176, videoStream.HeightPixels, "output height should match crop height")
+}
+
+// TestWithoutCrop_DimensionsUnchanged verifies that omitting WithCrop preserves
+// the source video dimensions (320x220).
+func TestWithoutCrop_DimensionsUnchanged(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		Build().
+		Run(context.Background())
+	require.NoError(t, err)
+
+	info, err := ffprobe.Probe(context.Background(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output file should contain a video stream")
+	assert.Equal(t, 320, videoStream.WidthPixels, "width should be unchanged without crop")
+	assert.Equal(t, 220, videoStream.HeightPixels, "height should be unchanged without crop")
+}
+
 // TestDetectHardwareEncoders_ValidResult verifies that DetectHardwareEncoders
 // returns only valid HWAccel constants for each supported codec. The test is
 // self-adapting: it passes whether or not hardware is present.

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -621,7 +621,7 @@ const testBlackBarsVideoPath = "testdata/video_black_bars.mp4"
 func TestWithCrop_NarrowsOutputDimensions(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "out.mkv")
 
-	crop := ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
 
 	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
 		ToVideoCodec(ffmpeg.CodecH265).

--- a/pkg/ffmpeg/transcode_vaapi_test.go
+++ b/pkg/ffmpeg/transcode_vaapi_test.go
@@ -1,0 +1,46 @@
+//go:build vaapitest
+
+package ffmpeg_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
+	"github.com/solidDoWant/media-processor/pkg/ffprobe"
+)
+
+// TestTranscode_CropWithVAAPI_SWDecode verifies that the SW-decode VAAPI crop
+// path (crop=W:H:X:Y,scale_vaapi) produces output with the correct dimensions.
+// Requires VAAPI hardware (vaapitest build tag).
+func TestTranscode_CropWithVAAPI_SWDecode(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+	crop := &ffmpeg.CropParams{W: 320, H: 176, X: 0, Y: 22}
+
+	err := ffmpeg.NewTranscode(testBlackBarsVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelVAAPI).
+		WithCrop(crop).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	info, err := ffprobe.Probe(t.Context(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+	for i := range info.Streams {
+		if info.Streams[i].CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &info.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output must contain a video stream")
+	assert.Equal(t, crop.W, videoStream.WidthPixels, "output width must match crop width")
+	assert.Equal(t, crop.H, videoStream.HeightPixels, "output height must match crop height")
+}

--- a/workflows/media/attrs.go
+++ b/workflows/media/attrs.go
@@ -24,6 +24,11 @@ func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode sh
 		hw = "true"
 	}
 
+	cropApplied := "false"
+	if transcode.CropApplied {
+		cropApplied = "true"
+	}
+
 	return []attribute.KeyValue{
 		attribute.String("source_codec", probe.VideoCodec),
 		attribute.String("destination_codec", transcode.DestCodec),
@@ -32,6 +37,7 @@ func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode sh
 		mediaTypeAttr(input.MediaType),
 		mappingNameAttr(input.MappingName),
 		attribute.String("hardware_accelerated", hw),
+		attribute.String("crop_applied", cropApplied),
 	}
 }
 

--- a/workflows/media/attrs.go
+++ b/workflows/media/attrs.go
@@ -19,16 +19,6 @@ func mappingNameAttr(name string) attribute.KeyValue {
 
 // buildStandardAttrs returns the full standard label set for processing metrics.
 func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode shared.TranscodeOutput, hardwareAccelerated bool) []attribute.KeyValue {
-	hw := "false"
-	if hardwareAccelerated {
-		hw = "true"
-	}
-
-	cropApplied := "false"
-	if transcode.CropApplied {
-		cropApplied = "true"
-	}
-
 	return []attribute.KeyValue{
 		attribute.String("source_codec", probe.VideoCodec),
 		attribute.String("destination_codec", transcode.DestCodec),
@@ -36,8 +26,8 @@ func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode sh
 		attribute.String("destination_container", transcode.DestContainer),
 		mediaTypeAttr(input.MediaType),
 		mappingNameAttr(input.MappingName),
-		attribute.String("hardware_accelerated", hw),
-		attribute.String("crop_applied", cropApplied),
+		attribute.String("hardware_accelerated", strconv.FormatBool(hardwareAccelerated)),
+		attribute.String("crop_applied", strconv.FormatBool(transcode.CropApplied)),
 	}
 }
 

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -45,6 +45,14 @@ type MediaWorkflowConfig struct {
 	// HighCardinalityLabels controls whether per-item labels (id, title, year, etc.)
 	// are attached to metric observations. Corresponds to METRICS_HIGH_CARDINALITY_LABELS.
 	HighCardinalityLabels bool
+	// MinCropX is the minimum number of pixels that must be trimmed horizontally
+	// for a crop to be applied. -1 disables the threshold (any crop is accepted).
+	// Defaults to 10 when not set.
+	MinCropX int
+	// MinCropY is the minimum number of pixels that must be trimmed vertically
+	// for a crop to be applied. -1 disables the threshold (any crop is accepted).
+	// Defaults to 10 when not set.
+	MinCropY int
 }
 
 // MediaInput is the workflow's trigger payload.
@@ -125,6 +133,34 @@ func NewMediaWorkflow(
 	// not checked. Verified in hatchet/pkg/repository/trigger.go.
 	skipIfInvalid := hatchet.WithSkipIf(hatchet.ParentCondition(probeTask, "output.is_valid_media == false"))
 
+	// detectcrop: run the ffmpeg cropdetect filter to find black bars. Returns a nil
+	// Crop pointer when no crop is warranted (both axes disabled or trim below threshold).
+	// Uses MinCropX/MinCropY from config; a value of 0 in MediaWorkflowConfig means
+	// the field was not set — treat it as the default of 10.
+	minCropX := cfg.MinCropX
+	if minCropX == 0 {
+		minCropX = 10
+	}
+
+	minCropY := cfg.MinCropY
+	if minCropY == 0 {
+		minCropY = 10
+	}
+
+	detectcropTask := wf.NewTask("detectcrop", func(ctx hatchet.Context, input MediaInput) (shared.DetectCropOutput, error) {
+		var probe shared.ProbeOutput
+		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
+			return shared.DetectCropOutput{}, fmt.Errorf("get probe output: %w", err)
+		}
+
+		crop, err := shared.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, minCropX, minCropY)
+		if err != nil {
+			return shared.DetectCropOutput{}, err
+		}
+
+		return shared.DetectCropOutput{Crop: crop}, nil
+	}, hatchet.WithParents(probeTask), skipIfInvalid)
+
 	// transcode: re-encode or copy the video stream directly into cfg.OutputDir under a
 	// temp name, then atomically rename it to the final path. Writing to the output
 	// directory (rather than the system temp dir) means the rename is always within the
@@ -135,18 +171,23 @@ func NewMediaWorkflow(
 			return shared.TranscodeOutput{}, fmt.Errorf("get probe output: %w", err)
 		}
 
+		var detectcrop shared.DetectCropOutput
+		if err := ctx.ParentOutput(detectcropTask, &detectcrop); err != nil {
+			return shared.TranscodeOutput{}, fmt.Errorf("get detectcrop output: %w", err)
+		}
+
 		library, err := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
 		if err != nil {
 			return shared.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
 		}
 
-		out, err := shared.RunTranscode(ctx, input.FilePath, probe, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, library)
+		out, err := shared.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, library)
 		if err == nil && out.ArtworkFetchSkipped {
 			recorder.RecordArtworkFetchSkipped(ctx)
 		}
 
 		return out, err
-	}, hatchet.WithParents(probeTask), skipIfInvalid)
+	}, hatchet.WithParents(probeTask, detectcropTask), skipIfInvalid)
 
 	// notify: send a DownloadedMoviesScan/DownloadedEpisodesScan command to Radarr/Sonarr
 	// for the processed output file, triggering import into the library. The import path is

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -47,11 +47,13 @@ type MediaWorkflowConfig struct {
 	HighCardinalityLabels bool
 	// MinCropX is the minimum number of pixels that must be trimmed horizontally
 	// for a crop to be applied. -1 disables the threshold (any crop is accepted).
-	// Defaults to 10 when not set.
+	// 0 means no minimum (any detected crop is applied). Defaults are applied by
+	// the caller (e.g. cmd/worker via parseCropThreshold) before constructing this config.
 	MinCropX int
 	// MinCropY is the minimum number of pixels that must be trimmed vertically
 	// for a crop to be applied. -1 disables the threshold (any crop is accepted).
-	// Defaults to 10 when not set.
+	// 0 means no minimum (any detected crop is applied). Defaults are applied by
+	// the caller (e.g. cmd/worker via parseCropThreshold) before constructing this config.
 	MinCropY int
 }
 
@@ -135,25 +137,15 @@ func NewMediaWorkflow(
 
 	// detectcrop: run the ffmpeg cropdetect filter to find black bars. Returns a nil
 	// Crop pointer when no crop is warranted (both axes disabled or trim below threshold).
-	// Uses MinCropX/MinCropY from config; a value of 0 in MediaWorkflowConfig means
-	// the field was not set — treat it as the default of 10.
-	minCropX := cfg.MinCropX
-	if minCropX == 0 {
-		minCropX = 10
-	}
-
-	minCropY := cfg.MinCropY
-	if minCropY == 0 {
-		minCropY = 10
-	}
-
+	// cfg.MinCropX and cfg.MinCropY are passed directly; defaults are applied by the
+	// caller (cmd/worker) via parseCropThreshold before constructing MediaWorkflowConfig.
 	detectcropTask := wf.NewTask("detectcrop", func(ctx hatchet.Context, input MediaInput) (shared.DetectCropOutput, error) {
 		var probe shared.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			return shared.DetectCropOutput{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		crop, err := shared.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, minCropX, minCropY)
+		crop, err := shared.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, cfg.MinCropX, cfg.MinCropY)
 		if err != nil {
 			return shared.DetectCropOutput{}, err
 		}

--- a/workflows/media/recorder_test.go
+++ b/workflows/media/recorder_test.go
@@ -128,6 +128,47 @@ func TestRecorder_ValidRunRecordsAllProcessingHistograms(t *testing.T) {
 	}
 }
 
+func TestRecorder_CropAppliedLabel(t *testing.T) {
+	tests := []struct {
+		name            string
+		cropApplied     bool
+		wantCropApplied string
+	}{
+		{
+			name:            "crop not applied — label is false",
+			cropApplied:     false,
+			wantCropApplied: "false",
+		},
+		{
+			name:            "crop applied — label is true",
+			cropApplied:     true,
+			wantCropApplied: "true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, reader := newTestRecorder(t, false)
+
+			transcode := sampleTranscode()
+			transcode.CropApplied = tc.cropApplied
+
+			rec.RecordRun(t.Context(), sampleInput(medialib.MovieType), sampleProbe(), transcode, nil, false, 5*time.Second)
+
+			rm := collectMetrics(t, reader)
+
+			m := findMetric(rm, "media_workflow_audio_track_count")
+			require.NotNil(t, m)
+			dps := histogramDataPoints(t, m)
+			require.Len(t, dps, 1)
+
+			val, present := dps[0].Attributes.Value(attributeKey("crop_applied"))
+			assert.True(t, present, "crop_applied label should be present")
+			assert.Equal(t, tc.wantCropApplied, val.AsString())
+		})
+	}
+}
+
 func TestRecorder_InvalidFileRecordsOnlyCounter(t *testing.T) {
 	rec, reader := newTestRecorder(t, false)
 

--- a/workflows/shared/detectcrop.go
+++ b/workflows/shared/detectcrop.go
@@ -1,0 +1,82 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
+)
+
+// DetectCropOutput is the output of the detectcrop workflow task.
+type DetectCropOutput struct {
+	// Crop is the detected crop region, or nil when no crop should be applied.
+	Crop *ffmpeg.CropParams `json:"crop,omitempty"`
+}
+
+// RunDetectCrop runs the ffmpeg cropdetect filter over filePath and returns the
+// crop region to apply, or nil when no crop is needed.
+//
+// minCropX and minCropY are the minimum number of pixels that must be trimmed
+// on each horizontal/vertical axis for a crop to be applied. A value of -1
+// disables the threshold for that axis (any detected crop is accepted). When
+// both are -1 the crop detection step is skipped entirely and ffmpeg.DetectCrop
+// is never called.
+//
+// inputW and inputH are the pixel dimensions of the source video (from the
+// ProbeOutput). They are used to compute how many pixels would be trimmed on
+// each axis.
+func RunDetectCrop(ctx context.Context, filePath string, inputW, inputH, minCropX, minCropY int) (*ffmpeg.CropParams, error) {
+	if minCropX == -1 && minCropY == -1 {
+		return nil, nil
+	}
+
+	detected, err := ffmpeg.DetectCrop(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return applyCropThresholds(detected, inputW, inputH, minCropX, minCropY), nil
+}
+
+// applyCropThresholds returns a pointer to detected when the crop exceeds the
+// per-axis minimum thresholds, or nil when the crop is too small to be worth
+// applying.
+//
+// For each axis the "trim" is the total number of pixels removed:
+//   - Horizontal: inputW - detected.W
+//   - Vertical:   inputH - detected.H
+//
+// A threshold of -1 disables the check for that axis (any crop is accepted).
+// When neither axis crosses its threshold, nil is returned (no crop applied).
+func applyCropThresholds(detected ffmpeg.CropParams, inputW, inputH, minCropX, minCropY int) *ffmpeg.CropParams {
+	trimX := inputW - detected.W
+	trimY := inputH - detected.H
+
+	xOK := minCropX == -1 || trimX >= minCropX
+	yOK := minCropY == -1 || trimY >= minCropY
+
+	if !xOK && !yOK {
+		return nil
+	}
+
+	result := detected
+
+	// If only one axis meets its threshold, zero out the other axis so we
+	// don't introduce a partial crop that may skew the aspect ratio.
+	if !xOK {
+		result.W = inputW
+		result.X = 0
+	}
+
+	if !yOK {
+		result.H = inputH
+		result.Y = 0
+	}
+
+	// After zeroing out a failing axis the result may equal the input
+	// dimensions on both axes, meaning nothing is actually cropped.
+	if result.W == inputW && result.H == inputH {
+		return nil
+	}
+
+	return &result
+}

--- a/workflows/shared/detectcrop_test.go
+++ b/workflows/shared/detectcrop_test.go
@@ -1,0 +1,102 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
+)
+
+func TestApplyCropThresholds(t *testing.T) {
+	// Input video dimensions used across all cases.
+	const (
+		inputW = 1920
+		inputH = 1080
+	)
+
+	tests := []struct {
+		name     string
+		detected ffmpeg.CropParams
+		minCropX int
+		minCropY int
+		wantNil  bool
+		wantCrop ffmpeg.CropParams
+	}{
+		{
+			name:     "crop exceeds both thresholds — full crop applied",
+			detected: ffmpeg.CropParams{W: 1880, H: 1040, X: 20, Y: 20},
+			minCropX: 10,
+			minCropY: 10,
+			wantNil:  false,
+			wantCrop: ffmpeg.CropParams{W: 1880, H: 1040, X: 20, Y: 20},
+		},
+		{
+			name:     "horizontal trim below threshold — x axis zeroed, y kept",
+			detected: ffmpeg.CropParams{W: 1915, H: 1040, X: 2, Y: 20},
+			minCropX: 10,
+			minCropY: 10,
+			wantNil:  false,
+			wantCrop: ffmpeg.CropParams{W: inputW, H: 1040, X: 0, Y: 20},
+		},
+		{
+			name:     "vertical trim below threshold — y axis zeroed, x kept",
+			detected: ffmpeg.CropParams{W: 1880, H: 1075, X: 20, Y: 2},
+			minCropX: 10,
+			minCropY: 10,
+			wantNil:  false,
+			wantCrop: ffmpeg.CropParams{W: 1880, H: inputH, X: 20, Y: 0},
+		},
+		{
+			name:     "both axes below threshold — nil returned",
+			detected: ffmpeg.CropParams{W: 1918, H: 1078, X: 1, Y: 1},
+			minCropX: 10,
+			minCropY: 10,
+			wantNil:  true,
+		},
+		{
+			name:     "minCropX disabled (-1) — x always accepted",
+			detected: ffmpeg.CropParams{W: 1918, H: 1040, X: 1, Y: 20},
+			minCropX: -1,
+			minCropY: 10,
+			wantNil:  false,
+			wantCrop: ffmpeg.CropParams{W: 1918, H: 1040, X: 1, Y: 20},
+		},
+		{
+			name:     "minCropY disabled (-1) — y always accepted",
+			detected: ffmpeg.CropParams{W: 1880, H: 1078, X: 20, Y: 1},
+			minCropX: 10,
+			minCropY: -1,
+			wantNil:  false,
+			wantCrop: ffmpeg.CropParams{W: 1880, H: 1078, X: 20, Y: 1},
+		},
+		{
+			name:     "detected equals input dimensions — nil returned (no crop)",
+			detected: ffmpeg.CropParams{W: inputW, H: inputH, X: 0, Y: 0},
+			minCropX: 10,
+			minCropY: 10,
+			wantNil:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyCropThresholds(tc.detected, inputW, inputH, tc.minCropX, tc.minCropY)
+			if tc.wantNil {
+				assert.Nil(t, got)
+			} else {
+				if assert.NotNil(t, got) {
+					assert.Equal(t, tc.wantCrop, *got)
+				}
+			}
+		})
+	}
+}
+
+func TestRunDetectCrop_BothDisabled(t *testing.T) {
+	// When both minCropX and minCropY are -1, RunDetectCrop must return nil
+	// without calling ffmpeg.DetectCrop (no video file needed).
+	got, err := RunDetectCrop(t.Context(), "/nonexistent/file.mkv", 1920, 1080, -1, -1)
+	assert.NoError(t, err)
+	assert.Nil(t, got, "expected nil when both axes are disabled")
+}

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -53,6 +53,10 @@ type ProbeOutput struct {
 	// SubtitleStreams lists every subtitle stream found in the file, in stream order.
 	// Only meaningful when IsValidMedia is true.
 	SubtitleStreams []StreamInfo `json:"subtitle_streams,omitempty"`
+	// VideoWidth and VideoHeight are the pixel dimensions of the first video stream.
+	// Only meaningful when IsValidMedia is true; zero otherwise.
+	VideoWidth  int `json:"video_width,omitempty"`
+	VideoHeight int `json:"video_height,omitempty"`
 	// StartedAt is the wall-clock time at which the probe step began. It is NOT set
 	// by RunProbe; the workflow step closure sets it before calling RunProbe so that
 	// downstream steps can compute elapsed durations.
@@ -120,6 +124,8 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 				DurationSeconds: info.Duration.Seconds(),
 				AudioStreams:    audioStreams,
 				SubtitleStreams: subtitleStreams,
+				VideoWidth:      s.WidthPixels,
+				VideoHeight:     s.HeightPixels,
 			}, nil
 		}
 	}

--- a/workflows/shared/probe_test.go
+++ b/workflows/shared/probe_test.go
@@ -74,6 +74,8 @@ func TestRunProbe_ValidMediaFile(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{
 			{StreamInfo: StreamInfo{Index: 1, Language: "und"}, ReportedChannelCount: 2, EffectiveChannelCount: 2},
 		},
+		VideoWidth:  320,
+		VideoHeight: 180,
 	}, gotWithoutDuration)
 	// DurationSeconds is a float64 derived from ffprobe; use InDelta to tolerate minor rounding.
 	assert.InDelta(t, 5.013333, got.DurationSeconds, 0.001, "DurationSeconds should match actual file duration")

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -337,7 +337,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		}
 	}
 
-	builder := ffmpeg.NewTranscode(filePath, tempPath).
+	if err := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
 		HardwareAccel(ffmpeg.HWAccelAuto).
@@ -350,13 +350,10 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		WithDownmixTitle(downmixLangName).
 		WithAutoDownmixTitle().
 		WithHardwareDevice(hardwareDevicePath).
-		WithCoverArt(artBytes, artMime)
-
-	if cropParams != nil {
-		builder = builder.WithCrop(*cropParams)
-	}
-
-	if err := builder.Build().Run(ctx); err != nil {
+		WithCoverArt(artBytes, artMime).
+		WithCrop(cropParams).
+		Build().
+		Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return TranscodeOutput{}, errors.Join(
 				fmt.Errorf("transcode: %w", err),

--- a/workflows/shared/transcode.go
+++ b/workflows/shared/transcode.go
@@ -126,6 +126,8 @@ type TranscodeOutput struct {
 	// ArtworkFetchSkipped is true when artwork fetch was attempted but yielded no
 	// embeddable image (library unreachable, no poster available, or unsupported type).
 	ArtworkFetchSkipped bool `json:"artwork_fetch_skipped,omitempty"`
+	// CropApplied is true when a crop filter was applied during transcoding.
+	CropApplied bool `json:"crop_applied,omitempty"`
 }
 
 // codecName returns a human-readable name for a codec, matching the names used
@@ -147,6 +149,9 @@ func codecName(c ffmpeg.Codec) string {
 // Writing directly to the output directory avoids a cross-filesystem copy and
 // guarantees the rename is atomic on Linux (same directory).
 // probe is the output of RunProbe for filePath.
+// cropParams is the crop region to apply, or nil for no cropping.
+// When cropParams is non-nil and videoCodec would be CodecCopy, the codec is
+// promoted to CodecH265 so the crop filter can be applied.
 // watcherRoot is the root directory that the watcher monitors. When non-empty,
 // the subdirectory of filePath relative to watcherRoot is mirrored under outputDir,
 // preserving the download client's directory structure. When empty, the output is
@@ -158,7 +163,7 @@ func codecName(c ffmpeg.Codec) string {
 // ArtworkFetchSkipped is not set. When non-nil and the fetch yields no
 // embeddable image, transcoding proceeds without an embedded attachment and
 // ArtworkFetchSkipped is set to true.
-func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outputDir string, watcherRoot string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {
+func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropParams *ffmpeg.CropParams, outputDir string, watcherRoot string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {
 	transcodeStart := time.Now()
 
 	srcInfo, err := os.Stat(filePath)
@@ -169,6 +174,12 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 	srcSize := srcInfo.Size()
 
 	videoCodec := SelectVideoCodec(probe.VideoCodec, probe.Format)
+
+	// Crop requires re-encoding: promote CodecCopy to CodecH265 so the crop
+	// filter can be applied.
+	if cropParams != nil && videoCodec == ffmpeg.CodecCopy {
+		videoCodec = ffmpeg.CodecH265
+	}
 
 	audioExclude := nonEnglishAudioIndices(probe.AudioStreams)
 	excludeIndices := append(audioExclude, nonEnglishSubtitleIndices(probe.SubtitleStreams)...)
@@ -326,9 +337,10 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		}
 	}
 
-	if err := ffmpeg.NewTranscode(filePath, tempPath).
+	builder := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
+		HardwareAccel(ffmpeg.HWAccelAuto).
 		ExcludeStreams(excludeIndices...).
 		WithDefaultAudioStream(firstEnglishIndex(audioBaseStreams)).
 		WithDefaultSubtitleStream(firstEnglishIndex(probe.SubtitleStreams)).
@@ -338,9 +350,13 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		WithDownmixTitle(downmixLangName).
 		WithAutoDownmixTitle().
 		WithHardwareDevice(hardwareDevicePath).
-		WithCoverArt(artBytes, artMime).
-		Build().
-		Run(ctx); err != nil {
+		WithCoverArt(artBytes, artMime)
+
+	if cropParams != nil {
+		builder = builder.WithCrop(*cropParams)
+	}
+
+	if err := builder.Build().Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return TranscodeOutput{}, errors.Join(
 				fmt.Errorf("transcode: %w", err),
@@ -375,5 +391,6 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, outpu
 		DestFileSizeBytes:        dstInfo.Size(),
 		TranscodeDurationSeconds: time.Since(transcodeStart).Seconds(),
 		ArtworkFetchSkipped:      artworkSkipped,
+		CropApplied:              cropParams != nil,
 	}, nil
 }

--- a/workflows/shared/transcode_test.go
+++ b/workflows/shared/transcode_test.go
@@ -537,7 +537,7 @@ func TestRunTranscode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
 
-			out, err := RunTranscode(t.Context(), inputPath, tt.probe, outputDir, "", "", nil)
+			out, err := RunTranscode(t.Context(), inputPath, tt.probe, nil, outputDir, "", "", nil)
 
 			tt.errFunc(t, err)
 
@@ -572,7 +572,7 @@ func TestRunTranscode_WatcherRoot_SubdirIsPreservedInOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, outputDir, watcherRoot, "", nil)
+	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "my-media-item", "video.mkv")
@@ -603,7 +603,7 @@ func TestRunTranscode_WatcherRoot_FlatInputProducesFlatOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, outputDir, watcherRoot, "", nil)
+	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "video.mkv")
@@ -632,7 +632,7 @@ func TestRunTranscode_WatcherRoot_InputOutsideWatcherRootReturnsError(t *testing
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	_, err = RunTranscode(t.Context(), inputPath, probe, outputDir, watcherRoot, "", nil)
+	_, err = RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
 	require.Error(t, err, "input outside watcherRoot should return an error")
 
 	entries, readErr := os.ReadDir(outputDir)


### PR DESCRIPTION
## Summary

- Adds `WithCrop(CropParams)` to `TranscodeBuilder` in `pkg/ffmpeg` — inserts a `crop=W:H:X:Y` libavfilter graph into the decode→encode pipeline, with `hwdownload` prepended for hardware-decoded streams
- Adds `RunDetectCrop` / `applyCropThresholds` in `workflows/shared` — wraps `ffmpeg.DetectCrop` with per-axis minimum-trim thresholds (skip-if-both-disabled fast path)
- Adds a `detectcrop` Hatchet task between probe and transcode in `workflows/media`
- Adds `MEDIA_MIN_CROP_X` / `MEDIA_MIN_CROP_Y` env vars (default 10, -1 disables axis) in `cmd/worker`
- Adds `crop_applied` boolean label to all existing processing histograms via `buildStandardAttrs`

## Test plan

- [x] `TestWithCrop_NarrowsOutputDimensions` — WithCrop({320,176,0,22}) on 320x220 source produces 320x176 output (AC1)
- [x] `TestWithoutCrop_DimensionsUnchanged` — omitting WithCrop on 320x220 source preserves 320x220 (AC2)
- [x] `TestApplyCropThresholds` — threshold logic: both axes, x-only, y-only, neither, disabled axes (AC3/AC5)
- [x] `TestRunDetectCrop_BothDisabled` — both thresholds -1 returns nil without calling ffmpeg (AC4)
- [x] `TestRecorder_CropAppliedLabel` — crop_applied label is "true"/"false" on histograms (AC5 metrics)
- [x] All existing tests pass; lint clean

Fixes #74