### PR TITLE
test(e2e): add end-to-end tests for Radarr and Sonarr happy-path flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/tasks/
 .env.hatchet
 .direnv
+e2e/testdata/cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ media-processor/
 - Test: `make test`
 - Lint: `make lint`
 - Fmt: `make fmt`
+- E2E tests: `make test-e2e` (requires Docker; first run downloads ~700 MB BBB fixture)
 
 ## Dev Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ All required tools (`go`, `golangci-lint`, etc.) are provided by `flake.nix`. If
 - Separate test cases that require fundamentally different setup into their own test functions.
 - Integration tests that require external services (e.g. a running Hatchet server) belong in files with a `//go:build integration` build tag. Skip with `t.Skip(...)` if required env vars are absent. Run via `make test-integration`.
 - Always use `t.Context()` (not `context.Background()`) when a test needs a context. It is automatically cancelled when the test finishes, preventing resource leaks.
-- Loop iteration variable names must be the singular form of the collection name, not single-letter abbreviations. For example, use `service` when ranging over `services`, `entry` when ranging over `entries`. Single-letter names like `s`, `v`, `f`, `k` are not allowed.
+- Loop iteration variable names must be the full singular form of the collection name. For example, use `service` when ranging over `services`, `entry` when ranging over `entries`, `category` when ranging over `categories`. Single-letter names (`s`, `v`, `f`, `k`) and shortened names (`cat` for `category`, `svc` for `service`) are not allowed unless the collection itself uses that short name (e.g. `cat` is fine when ranging over `cats`).
 
 ## Quality Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ All required tools (`go`, `golangci-lint`, etc.) are provided by `flake.nix`. If
 - Separate test cases that require fundamentally different setup into their own test functions.
 - Integration tests that require external services (e.g. a running Hatchet server) belong in files with a `//go:build integration` build tag. Skip with `t.Skip(...)` if required env vars are absent. Run via `make test-integration`.
 - Always use `t.Context()` (not `context.Background()`) when a test needs a context. It is automatically cancelled when the test finishes, preventing resource leaks.
+- Loop iteration variable names must be the singular form of the collection name, not single-letter abbreviations. For example, use `service` when ranging over `services`, `entry` when ranging over `entries`. Single-letter names like `s`, `v`, `f`, `k` are not allowed.
 
 ## Quality Rules
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-integration: hatchet-up ## Run integration tests against a local Hatchet se
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests (requires Docker; downloads ~700 MB BBB fixture on first run).
-	go test -v -timeout 30m -tags=e2e -count=1 ./e2e/
+	go test -v -timeout 2h -tags=e2e -count=1 ./e2e/
 
 .PHONY: lint
 lint: ## Run golangci-lint.

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ test: fmt vet ## Run tests.
 test-integration: hatchet-up ## Run integration tests against a local Hatchet server (starts server, generates token).
 	env $$(cat $(HATCHET_ENV_FILE)) go test -v -race -count=1 -tags=integration ./...
 
+.PHONY: test-e2e
+test-e2e: ## Run end-to-end tests (requires Docker; downloads ~700 MB BBB fixture on first run).
+	go test -v -timeout 30m -tags=e2e -count=1 ./e2e/...
+
 .PHONY: lint
 lint: ## Run golangci-lint.
 	golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-integration: hatchet-up ## Run integration tests against a local Hatchet se
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests (requires Docker; downloads ~700 MB BBB fixture on first run).
-	go test -v -timeout 30m -tags=e2e -count=1 ./e2e/...
+	go test -v -timeout 30m -tags=e2e -count=1 ./e2e/
 
 .PHONY: lint
 lint: ## Run golangci-lint.

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogLevel; no new-SDK equivalent
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogger; no new-SDK equivalent
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
 	"github.com/solidDoWant/media-processor/pkg/logging"

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -68,7 +68,10 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("create scan workflow: %w", err)
 	}
 
+	watcherLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "worker")
+
 	worker, err := client.NewWorker("mediaprocessor-watcher",
+		hatchet.WithLogger(&watcherLogger),
 		hatchet.WithWorkflows(scanWorkflow),
 	)
 	if err != nil {

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -54,8 +54,10 @@ func run(ctx context.Context, configPath string) error {
 	}
 	defer shutdown()
 
+	clientLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "client")
+
 	client, err := hatchet.NewClient(
-		v0Client.WithLogLevel(logging.ZerologLevel(os.Getenv("LOG_LEVEL"))), //nolint:staticcheck // no non-deprecated API for client log level in SDK v0.83
+		v0Client.WithLogger(&clientLogger), //nolint:staticcheck // no new-SDK equivalent for WithLogger
 	)
 	if err != nil {
 		return fmt.Errorf("connect to Hatchet: %w", err)

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context, configPath string) error {
 	}
 	defer shutdown()
 
-	clientLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "client")
+	clientLogger := logging.NewZerologLogger("client")
 
 	client, err := hatchet.NewClient(
 		v0Client.WithLogger(&clientLogger), //nolint:staticcheck // no new-SDK equivalent for WithLogger
@@ -70,7 +70,7 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("create scan workflow: %w", err)
 	}
 
-	watcherLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "worker")
+	watcherLogger := logging.NewZerologLogger("worker")
 
 	worker, err := client.NewWorker("mediaprocessor-watcher",
 		hatchet.WithLogger(&watcherLogger),

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogLevel; no new-SDK equivalent
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
 	"github.com/solidDoWant/media-processor/pkg/logging"
@@ -53,7 +54,9 @@ func run(ctx context.Context, configPath string) error {
 	}
 	defer shutdown()
 
-	client, err := hatchet.NewClient()
+	client, err := hatchet.NewClient(
+		v0Client.WithLogLevel(logging.ZerologLevel(os.Getenv("LOG_LEVEL"))), //nolint:staticcheck // no non-deprecated API for client log level in SDK v0.83
+	)
 	if err != nil {
 		return fmt.Errorf("connect to Hatchet: %w", err)
 	}

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -70,7 +70,7 @@ func run(ctx context.Context, configPath string) error {
 		return fmt.Errorf("create scan workflow: %w", err)
 	}
 
-	watcherLogger := logging.NewZerologLogger("worker")
+	watcherLogger := logging.NewZerologLogger("watcher")
 
 	worker, err := client.NewWorker("mediaprocessor-watcher",
 		hatchet.WithLogger(&watcherLogger),

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -87,7 +87,7 @@ func run(ctx context.Context) error {
 		URL: os.Getenv("WEBHOOK_URL"),
 	}
 
-	clientLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "client")
+	clientLogger := logging.NewZerologLogger("client")
 
 	client, err := hatchet.NewClient(
 		v0Client.WithLogger(&clientLogger), //nolint:staticcheck // no new-SDK equivalent for WithLogger
@@ -117,7 +117,7 @@ func run(ctx context.Context) error {
 		MinCropY:              minCropY,
 	}, radarrClient, sonarrClient, webhookClient)
 
-	workerLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "worker")
+	workerLogger := logging.NewZerologLogger("worker")
 
 	worker, err := client.NewWorker(
 		"mediaprocessor-worker",

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"syscall"
 
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogLevel; no new-SDK equivalent
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
 	"github.com/solidDoWant/media-processor/pkg/logging"
@@ -86,7 +87,9 @@ func run(ctx context.Context) error {
 		URL: os.Getenv("WEBHOOK_URL"),
 	}
 
-	client, err := hatchet.NewClient()
+	client, err := hatchet.NewClient(
+		v0Client.WithLogLevel(logging.ZerologLevel(os.Getenv("LOG_LEVEL"))), //nolint:staticcheck // no non-deprecated API for client log level in SDK v0.83
+	)
 	if err != nil {
 		return fmt.Errorf("create Hatchet client: %w", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -87,8 +87,10 @@ func run(ctx context.Context) error {
 		URL: os.Getenv("WEBHOOK_URL"),
 	}
 
+	clientLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "client")
+
 	client, err := hatchet.NewClient(
-		v0Client.WithLogLevel(logging.ZerologLevel(os.Getenv("LOG_LEVEL"))), //nolint:staticcheck // no non-deprecated API for client log level in SDK v0.83
+		v0Client.WithLogger(&clientLogger), //nolint:staticcheck // no new-SDK equivalent for WithLogger
 	)
 	if err != nil {
 		return fmt.Errorf("create Hatchet client: %w", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -115,8 +115,11 @@ func run(ctx context.Context) error {
 		MinCropY:              minCropY,
 	}, radarrClient, sonarrClient, webhookClient)
 
+	workerLogger := logging.NewZerologLogger(os.Getenv("LOG_LEVEL"), "worker")
+
 	worker, err := client.NewWorker(
 		"mediaprocessor-worker",
+		hatchet.WithLogger(&workerLogger),
 		hatchet.WithWorkflows(workflows.NewPlaceholder(client), mediaWorkflow),
 	)
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"syscall"
 
-	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogLevel; no new-SDK equivalent
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck // needed for WithLogger; no new-SDK equivalent
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 
 	"github.com/solidDoWant/media-processor/pkg/logging"

--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -1,0 +1,292 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// ---- Radarr / Sonarr configuration -------------------------------------
+
+// arrClient is a minimal HTTP client for Radarr and Sonarr v3 APIs.
+type arrClient struct {
+	base       string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newArrClient(base, apiKey string) *arrClient {
+	return &arrClient{base: base, apiKey: apiKey, httpClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (c *arrClient) get(path string, out any) error {
+	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("GET %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(body))
+	}
+
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	return nil
+}
+
+func (c *arrClient) post(path string, body any, out any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.base+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-Api-Key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("POST %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(respBody))
+	}
+
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	return nil
+}
+
+// configureRadarr adds the root folder, download client, and Big Buck Bunny (TMDB 10378).
+// Returns the Radarr movie ID.
+func configureRadarr(qbtPort int) (int, error) {
+	c := newArrClient(radarrBase, radarrAPIKey)
+
+	// Root folder.
+	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/movies"}, nil); err != nil {
+		return 0, fmt.Errorf("add root folder: %w", err)
+	}
+
+	// Quality profile — use the first available.
+	var profiles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+		return 0, fmt.Errorf("get quality profiles: %w", err)
+	}
+
+	if len(profiles) == 0 {
+		return 0, fmt.Errorf("no quality profiles found in Radarr")
+	}
+
+	profileID := profiles[0].ID
+
+	// Download client (qBittorrent stub).
+	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr", "category")
+
+	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+		return 0, fmt.Errorf("add download client: %w", err)
+	}
+
+	// Look up Big Buck Bunny by TMDB ID.
+	var lookupResults []json.RawMessage
+
+	if err := c.get("/api/v3/movie/lookup?term=tmdb:10378", &lookupResults); err != nil {
+		return 0, fmt.Errorf("lookup movie tmdb:10378: %w", err)
+	}
+
+	if len(lookupResults) == 0 {
+		return 0, fmt.Errorf("no results for tmdb:10378")
+	}
+
+	var lookupMovie map[string]any
+
+	if err := json.Unmarshal(lookupResults[0], &lookupMovie); err != nil {
+		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
+	}
+
+	// Overlay mandatory add fields.
+	lookupMovie["qualityProfileId"] = profileID
+	lookupMovie["rootFolderPath"] = "/movies"
+	lookupMovie["monitored"] = true
+	lookupMovie["addOptions"] = map[string]any{"searchForMovie": false}
+
+	var addedMovie struct {
+		ID int `json:"id"`
+	}
+
+	if err := c.post("/api/v3/movie", lookupMovie, &addedMovie); err != nil {
+		return 0, fmt.Errorf("add movie: %w", err)
+	}
+
+	if addedMovie.ID == 0 {
+		return 0, fmt.Errorf("Radarr returned movie ID 0")
+	}
+
+	return addedMovie.ID, nil
+}
+
+// configureSonarr adds the root folder, download client, and Colonel Bleep (TVDB 254376).
+// Colonel Bleep (1957) is in the public domain (copyright lapsed without renewal in 1985)
+// and has 6-minute episodes — short enough that the BBB fixture (9:56) passes Sonarr's
+// EpisodeFileIsNotSampleSpecification (50% of episode runtime = 3 min).
+// Returns the Sonarr series ID.
+func configureSonarr(qbtPort int) (int, error) {
+	c := newArrClient(sonarrBase, sonarrAPIKey)
+
+	// Root folder.
+	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/tv"}, nil); err != nil {
+		return 0, fmt.Errorf("add root folder: %w", err)
+	}
+
+	// Quality profile — use the first available.
+	var profiles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+		return 0, fmt.Errorf("get quality profiles: %w", err)
+	}
+
+	if len(profiles) == 0 {
+		return 0, fmt.Errorf("no quality profiles found in Sonarr")
+	}
+
+	profileID := profiles[0].ID
+
+	// Download client (qBittorrent stub).
+	// Sonarr's qBittorrent integration uses "tvCategory" (not "category") as the
+	// field name for the TV download category.
+	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr", "tvCategory")
+
+	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+		return 0, fmt.Errorf("add download client: %w", err)
+	}
+
+	// Look up Colonel Bleep by TVDB ID.
+	var lookupResults []json.RawMessage
+
+	if err := c.get("/api/v3/series/lookup?term=tvdb:254376", &lookupResults); err != nil {
+		return 0, fmt.Errorf("lookup series tvdb:254376: %w", err)
+	}
+
+	if len(lookupResults) == 0 {
+		return 0, fmt.Errorf("no results for tvdb:254376")
+	}
+
+	var lookupSeries map[string]any
+
+	if err := json.Unmarshal(lookupResults[0], &lookupSeries); err != nil {
+		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
+	}
+
+	// Overlay mandatory add fields.
+	lookupSeries["qualityProfileId"] = profileID
+	lookupSeries["rootFolderPath"] = "/tv"
+	lookupSeries["monitored"] = true
+	lookupSeries["seasonFolder"] = true
+	lookupSeries["addOptions"] = map[string]any{
+		"searchForMissingEpisodes":     false,
+		"searchForCutoffUnmetEpisodes": false,
+		"monitor":                      "pilot",
+	}
+
+	var addedSeries struct {
+		ID    int    `json:"id"`
+		Title string `json:"title"`
+	}
+
+	if err := c.post("/api/v3/series", lookupSeries, &addedSeries); err != nil {
+		return 0, fmt.Errorf("add series: %w", err)
+	}
+
+	if addedSeries.ID == 0 {
+		return 0, fmt.Errorf("Sonarr returned series ID 0")
+	}
+
+	log.Printf("e2e: added Sonarr series %q (ID %d)", addedSeries.Title, addedSeries.ID)
+
+	return addedSeries.ID, nil
+}
+
+// fetchSonarrS01E01 returns the Sonarr episode ID for Season 1, Episode 1 of the given series.
+func fetchSonarrS01E01(seriesID int) (int, error) {
+	c := newArrClient(sonarrBase, sonarrAPIKey)
+
+	var episodes []struct {
+		ID            int `json:"id"`
+		SeasonNumber  int `json:"seasonNumber"`
+		EpisodeNumber int `json:"episodeNumber"`
+	}
+
+	if err := c.get(fmt.Sprintf("/api/v3/episode?seriesId=%d&seasonNumber=1", seriesID), &episodes); err != nil {
+		return 0, fmt.Errorf("fetch episodes for series %d: %w", seriesID, err)
+	}
+
+	for _, episode := range episodes {
+		if episode.SeasonNumber == 1 && episode.EpisodeNumber == 1 {
+			return episode.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("S01E01 not found for series %d (got %d episodes in season 1)", seriesID, len(episodes))
+}
+
+// qbtDownloadClientBody returns the JSON body for adding a qBittorrent download client
+// to Radarr or Sonarr. categoryField is the Arr-service-specific field name that holds
+// the qBittorrent category: Radarr uses "category"; Sonarr uses "tvCategory".
+func qbtDownloadClientBody(name string, port int, category, categoryField string) map[string]any {
+	return map[string]any{
+		"name":           name,
+		"enable":         true,
+		"protocol":       "torrent",
+		"priority":       1,
+		"implementation": "QBittorrent",
+		"configContract": "QBittorrentSettings",
+		"fields": []map[string]any{
+			{"name": "host", "value": "host.docker.internal"},
+			{"name": "port", "value": port},
+			{"name": "useSsl", "value": false},
+			{"name": "urlBase", "value": ""},
+			{"name": "username", "value": ""},
+			{"name": "password", "value": ""},
+			{"name": categoryField, "value": category},
+			{"name": "initialState", "value": 0},
+			{"name": "sequentialOrder", "value": false},
+			{"name": "firstAndLast", "value": false},
+		},
+	}
+}

--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -237,7 +237,7 @@ func configureSonarr(qbtPort int) (int, error) {
 		return 0, fmt.Errorf("Sonarr returned series ID 0")
 	}
 
-	log.Printf("e2e: added Sonarr series %q (ID %d)", addedSeries.Title, addedSeries.ID)
+	slog.Info("Sonarr series added", "title", addedSeries.Title, "id", addedSeries.ID)
 
 	return addedSeries.ID, nil
 }

--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"time"
 )
@@ -237,7 +236,7 @@ func configureSonarr(qbtPort int) (int, error) {
 		return 0, fmt.Errorf("Sonarr returned series ID 0")
 	}
 
-	slog.Info("Sonarr series added", "title", addedSeries.Title, "id", addedSeries.ID)
+	log.Info("Sonarr series added", "title", addedSeries.Title, "id", addedSeries.ID)
 
 	return addedSeries.ID, nil
 }

--- a/e2e/configure_test.go
+++ b/e2e/configure_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,8 +25,8 @@ func newArrClient(base, apiKey string) *arrClient {
 	return &arrClient{base: base, apiKey: apiKey, httpClient: &http.Client{Timeout: 30 * time.Second}}
 }
 
-func (c *arrClient) get(path string, out any) error {
-	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
+func (c *arrClient) get(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+path, nil)
 	if err != nil {
 		return err
 	}
@@ -52,13 +53,13 @@ func (c *arrClient) get(path string, out any) error {
 	return nil
 }
 
-func (c *arrClient) post(path string, body any, out any) error {
+func (c *arrClient) post(ctx context.Context, path string, body any, out any) error {
 	data, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.base+path, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+path, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -88,11 +89,11 @@ func (c *arrClient) post(path string, body any, out any) error {
 
 // configureRadarr adds the root folder, download client, and Big Buck Bunny (TMDB 10378).
 // Returns the Radarr movie ID.
-func configureRadarr(qbtPort int) (int, error) {
+func configureRadarr(ctx context.Context, qbtPort int) (int, error) {
 	c := newArrClient(radarrBase, radarrAPIKey)
 
 	// Root folder.
-	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/movies"}, nil); err != nil {
+	if err := c.post(ctx, "/api/v3/rootfolder", map[string]any{"path": "/movies"}, nil); err != nil {
 		return 0, fmt.Errorf("add root folder: %w", err)
 	}
 
@@ -102,7 +103,7 @@ func configureRadarr(qbtPort int) (int, error) {
 		Name string `json:"name"`
 	}
 
-	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+	if err := c.get(ctx, "/api/v3/qualityprofile", &profiles); err != nil {
 		return 0, fmt.Errorf("get quality profiles: %w", err)
 	}
 
@@ -115,14 +116,14 @@ func configureRadarr(qbtPort int) (int, error) {
 	// Download client (qBittorrent stub).
 	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr", "category")
 
-	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+	if err := c.post(ctx, "/api/v3/downloadclient", dcBody, nil); err != nil {
 		return 0, fmt.Errorf("add download client: %w", err)
 	}
 
 	// Look up Big Buck Bunny by TMDB ID.
 	var lookupResults []json.RawMessage
 
-	if err := c.get("/api/v3/movie/lookup?term=tmdb:10378", &lookupResults); err != nil {
+	if err := c.get(ctx, "/api/v3/movie/lookup?term=tmdb:10378", &lookupResults); err != nil {
 		return 0, fmt.Errorf("lookup movie tmdb:10378: %w", err)
 	}
 
@@ -146,7 +147,7 @@ func configureRadarr(qbtPort int) (int, error) {
 		ID int `json:"id"`
 	}
 
-	if err := c.post("/api/v3/movie", lookupMovie, &addedMovie); err != nil {
+	if err := c.post(ctx, "/api/v3/movie", lookupMovie, &addedMovie); err != nil {
 		return 0, fmt.Errorf("add movie: %w", err)
 	}
 
@@ -162,11 +163,11 @@ func configureRadarr(qbtPort int) (int, error) {
 // and has 6-minute episodes — short enough that the BBB fixture (9:56) passes Sonarr's
 // EpisodeFileIsNotSampleSpecification (50% of episode runtime = 3 min).
 // Returns the Sonarr series ID.
-func configureSonarr(qbtPort int) (int, error) {
+func configureSonarr(ctx context.Context, qbtPort int) (int, error) {
 	c := newArrClient(sonarrBase, sonarrAPIKey)
 
 	// Root folder.
-	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/tv"}, nil); err != nil {
+	if err := c.post(ctx, "/api/v3/rootfolder", map[string]any{"path": "/tv"}, nil); err != nil {
 		return 0, fmt.Errorf("add root folder: %w", err)
 	}
 
@@ -176,7 +177,7 @@ func configureSonarr(qbtPort int) (int, error) {
 		Name string `json:"name"`
 	}
 
-	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+	if err := c.get(ctx, "/api/v3/qualityprofile", &profiles); err != nil {
 		return 0, fmt.Errorf("get quality profiles: %w", err)
 	}
 
@@ -191,14 +192,14 @@ func configureSonarr(qbtPort int) (int, error) {
 	// field name for the TV download category.
 	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr", "tvCategory")
 
-	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+	if err := c.post(ctx, "/api/v3/downloadclient", dcBody, nil); err != nil {
 		return 0, fmt.Errorf("add download client: %w", err)
 	}
 
 	// Look up Colonel Bleep by TVDB ID.
 	var lookupResults []json.RawMessage
 
-	if err := c.get("/api/v3/series/lookup?term=tvdb:254376", &lookupResults); err != nil {
+	if err := c.get(ctx, "/api/v3/series/lookup?term=tvdb:254376", &lookupResults); err != nil {
 		return 0, fmt.Errorf("lookup series tvdb:254376: %w", err)
 	}
 
@@ -228,7 +229,7 @@ func configureSonarr(qbtPort int) (int, error) {
 		Title string `json:"title"`
 	}
 
-	if err := c.post("/api/v3/series", lookupSeries, &addedSeries); err != nil {
+	if err := c.post(ctx, "/api/v3/series", lookupSeries, &addedSeries); err != nil {
 		return 0, fmt.Errorf("add series: %w", err)
 	}
 
@@ -242,7 +243,7 @@ func configureSonarr(qbtPort int) (int, error) {
 }
 
 // fetchSonarrS01E01 returns the Sonarr episode ID for Season 1, Episode 1 of the given series.
-func fetchSonarrS01E01(seriesID int) (int, error) {
+func fetchSonarrS01E01(ctx context.Context, seriesID int) (int, error) {
 	c := newArrClient(sonarrBase, sonarrAPIKey)
 
 	var episodes []struct {
@@ -251,7 +252,7 @@ func fetchSonarrS01E01(seriesID int) (int, error) {
 		EpisodeNumber int `json:"episodeNumber"`
 	}
 
-	if err := c.get(fmt.Sprintf("/api/v3/episode?seriesId=%d&seasonNumber=1", seriesID), &episodes); err != nil {
+	if err := c.get(ctx, fmt.Sprintf("/api/v3/episode?seriesId=%d&seasonNumber=1", seriesID), &episodes); err != nil {
 		return 0, fmt.Errorf("fetch episodes for series %d: %w", seriesID, err)
 	}
 

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     image: ghcr.io/home-operations/radarr:6.1.2
     # Run as the host user so volume-mounted directories are owned by the
     # current user and can be cleaned up without requiring elevated privileges.
-    user: "1000:1000"
+    user: "${UID}:${GID}"
     environment:
       TZ: UTC
       Radarr__Auth__ApiKey: e2e-radarr-api-key-e2e
@@ -98,7 +98,7 @@ services:
     image: ghcr.io/home-operations/sonarr:4.0.17
     # Run as the host user so volume-mounted directories are owned by the
     # current user and can be cleaned up without requiring elevated privileges.
-    user: "1000:1000"
+    user: "${UID}:${GID}"
     environment:
       TZ: UTC
       Sonarr__Auth__ApiKey: e2e-sonarr-api-key-e2e

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -75,6 +75,7 @@ services:
 
   radarr:
     image: ghcr.io/home-operations/radarr:6.1.2
+    user: "0:0"
     environment:
       TZ: UTC
       Radarr__Auth__ApiKey: e2e-radarr-api-key
@@ -89,6 +90,7 @@ services:
 
   sonarr:
     image: ghcr.io/home-operations/sonarr:4.0.17
+    user: "0:0"
     environment:
       TZ: UTC
       Sonarr__Auth__ApiKey: e2e-sonarr-api-key

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     user: "1000:1000"
     environment:
       TZ: UTC
-      Radarr__Auth__ApiKey: e2e-radarr-api-key
+      Radarr__Auth__ApiKey: e2e-radarr-api-key-e2e
     ports:
       - "7878:7878"
     volumes:
@@ -101,7 +101,7 @@ services:
     user: "1000:1000"
     environment:
       TZ: UTC
-      Sonarr__Auth__ApiKey: e2e-sonarr-api-key
+      Sonarr__Auth__ApiKey: e2e-sonarr-api-key-e2e
     ports:
       - "8989:8989"
     volumes:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "5436:5432"
     volumes:
-      - e2e_hatchet_postgres_data:/var/lib/postgresql/data
+      - e2e_hatchet_postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
       interval: 10s

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
     image: postgres:18
+    # Hatchet's workflow engine opens many concurrent database connections; the
+    # default PostgreSQL limit (100) is too low and causes connection errors.
     command: postgres -c 'max_connections=1000'
     hostname: postgres
     environment:
@@ -75,7 +77,9 @@ services:
 
   radarr:
     image: ghcr.io/home-operations/radarr:6.1.2
-    user: "0:0"
+    # Run as the host user so volume-mounted directories are owned by the
+    # current user and can be cleaned up without requiring elevated privileges.
+    user: "1000:1000"
     environment:
       TZ: UTC
       Radarr__Auth__ApiKey: e2e-radarr-api-key
@@ -90,7 +94,9 @@ services:
 
   sonarr:
     image: ghcr.io/home-operations/sonarr:4.0.17
-    user: "0:0"
+    # Run as the host user so volume-mounted directories are owned by the
+    # current user and can be cleaned up without requiring elevated privileges.
+    user: "1000:1000"
     environment:
       TZ: UTC
       Sonarr__Auth__ApiKey: e2e-sonarr-api-key

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,9 +1,11 @@
 services:
   postgres:
     image: postgres:18
-    # Hatchet's workflow engine opens many concurrent database connections; the
-    # default PostgreSQL limit (100) is too low and causes connection errors.
-    command: postgres -c 'max_connections=1000'
+    # Hatchet uses PostgreSQL as its message queue (SERVER_MSGQUEUE_KIND=postgres),
+    # which requires many concurrent connections for its internal pollers and
+    # listeners regardless of active workflow count. The default limit of 100 is
+    # too low; 200 is sufficient for a single engine instance.
+    command: postgres -c 'max_connections=200'
     hostname: postgres
     environment:
       POSTGRES_USER: hatchet

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "5436:5432"
     volumes:
-      - e2e_hatchet_postgres_data:/var/lib/postgresql
+      - e2e_hatchet_postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
       interval: 10s

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,107 @@
+services:
+  postgres:
+    image: postgres:18
+    command: postgres -c 'max_connections=1000'
+    hostname: postgres
+    environment:
+      POSTGRES_USER: hatchet
+      POSTGRES_PASSWORD: hatchet
+      POSTGRES_DB: hatchet
+    ports:
+      - "5436:5432"
+    volumes:
+      - e2e_hatchet_postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
+  migration:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:v0.83.1
+    command: /hatchet/hatchet-migrate
+    environment:
+      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  setup-config:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:v0.83.1
+    command: >
+      /hatchet/hatchet-admin quickstart
+      --skip certs
+      --generated-config-dir /hatchet/config
+      --overwrite=false
+    environment:
+      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
+      SERVER_MSGQUEUE_KIND: postgres
+      SERVER_AUTH_COOKIE_DOMAIN: "localhost:8080"
+      SERVER_AUTH_COOKIE_INSECURE: "t"
+      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
+      SERVER_GRPC_INSECURE: "t"
+      SERVER_GRPC_BROADCAST_ADDRESS: "localhost:7079"
+      SERVER_DEFAULT_ENGINE_VERSION: "V1"
+      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: "hatchet-engine:7070"
+    volumes:
+      - e2e_hatchet_certs:/hatchet/certs
+      - e2e_hatchet_config:/hatchet/config
+    depends_on:
+      migration:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+
+  hatchet-engine:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:v0.83.1
+    command: /hatchet/hatchet-engine --config /hatchet/config
+    restart: on-failure
+    ports:
+      - "7079:7070"
+    environment:
+      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
+      SERVER_MSGQUEUE_KIND: postgres
+      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
+      SERVER_GRPC_INSECURE: "t"
+    volumes:
+      - e2e_hatchet_certs:/hatchet/certs
+      - e2e_hatchet_config:/hatchet/config
+    depends_on:
+      setup-config:
+        condition: service_completed_successfully
+      migration:
+        condition: service_completed_successfully
+
+  radarr:
+    image: ghcr.io/home-operations/radarr:6.1.2
+    environment:
+      TZ: UTC
+      Radarr__Auth__ApiKey: e2e-radarr-api-key
+    ports:
+      - "7878:7878"
+    volumes:
+      - /tmp/e2e-media-processor/config/radarr:/config
+      - /tmp/e2e-media-processor/processed-output/radarr:/downloads
+      - /tmp/e2e-media-processor/processed-output/radarr-library:/movies
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  sonarr:
+    image: ghcr.io/home-operations/sonarr:4.0.17
+    environment:
+      TZ: UTC
+      Sonarr__Auth__ApiKey: e2e-sonarr-api-key
+    ports:
+      - "8989:8989"
+    volumes:
+      - /tmp/e2e-media-processor/config/sonarr:/config
+      - /tmp/e2e-media-processor/processed-output/sonarr:/downloads
+      - /tmp/e2e-media-processor/processed-output/sonarr-library:/tv
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  e2e_hatchet_postgres_data:
+  e2e_hatchet_config:
+  e2e_hatchet_certs:

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -67,7 +67,12 @@ func run(m *testing.M) error {
 	}
 
 	// 2. Download and cache the Big Buck Bunny fixture.
-	fixturePath, err := ensureBBBFixture()
+	// A 30-minute timeout ensures the suite fails fast on a stalled download
+	// rather than hanging until the global test timeout fires.
+	downloadCtx, downloadCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer downloadCancel()
+
+	fixturePath, err := ensureBBBFixture(downloadCtx)
 	if err != nil {
 		return fmt.Errorf("ensureBBBFixture: %w", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,7 +11,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -26,8 +26,8 @@ const (
 	processedDir = "/tmp/e2e-media-processor/processed-output"
 	configDir    = "/tmp/e2e-media-processor/config"
 
-	radarrAPIKey = "e2e-radarr-api-key"
-	sonarrAPIKey = "e2e-sonarr-api-key"
+	radarrAPIKey = "e2e-radarr-api-key-e2e"
+	sonarrAPIKey = "e2e-sonarr-api-key-e2e"
 
 	radarrBase = "http://localhost:7878"
 	sonarrBase = "http://localhost:8989"
@@ -46,7 +46,7 @@ var (
 
 func TestMain(m *testing.M) {
 	if err := run(m); err != nil {
-		log.Printf("e2e: %v", err)
+		slog.Error("e2e run failed", "error", err)
 		os.Exit(1)
 	}
 }
@@ -77,7 +77,7 @@ func run(m *testing.M) error {
 
 	defer qbtStub.Close()
 
-	log.Printf("e2e: qBittorrent stub listening on port %d", qbtStub.Port())
+	slog.Info("qBittorrent stub listening", "port", qbtStub.Port())
 
 	// 4. Pull Docker images (may download several hundred MB on first run).
 	pullCtx, pullCancel := context.WithTimeout(context.Background(), 20*time.Minute)
@@ -119,7 +119,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("configureRadarr: %w", err)
 	}
 
-	log.Printf("e2e: Radarr movie ID %d", radarrMovieID)
+	slog.Info("Radarr configured", "movieID", radarrMovieID)
 
 	// 9. Configure Sonarr (root folder, quality profile, download client, series).
 	sonarrSeriesID, err = configureSonarr(qbtStub.Port())
@@ -127,7 +127,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("configureSonarr: %w", err)
 	}
 
-	log.Printf("e2e: Sonarr series ID %d", sonarrSeriesID)
+	slog.Info("Sonarr configured", "seriesID", sonarrSeriesID)
 
 	// Fetch S01E01 episode ID for use in the Sonarr release push.
 	sonarrEpisodeID, err = fetchSonarrS01E01(sonarrSeriesID)
@@ -135,7 +135,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("fetchSonarrS01E01: %w", err)
 	}
 
-	log.Printf("e2e: Sonarr S01E01 episode ID %d", sonarrEpisodeID)
+	slog.Info("Sonarr S01E01 fetched", "episodeID", sonarrEpisodeID)
 
 	// 10. Build watcher and worker binaries, write watcher config, start both.
 	if err = startProcesses(); err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -51,14 +51,15 @@ const (
 
 // Package-level state set during TestMain.
 var (
-	hatchetToken   string
-	qbtStub        *qbittorrent.Server
-	radarrMovieID  int
-	sonarrSeriesID int
-	fixturePath    string // path to BBB mp4 fixture
-	binDir         string // temp dir holding built binaries
-	watcherCmd     *exec.Cmd
-	workerCmd      *exec.Cmd
+	hatchetToken    string
+	qbtStub         *qbittorrent.Server
+	radarrMovieID   int
+	sonarrSeriesID  int
+	sonarrEpisodeID int    // Sonarr episode ID for S01E01 of the test series
+	fixturePath     string // path to BBB mp4 fixture
+	binDir          string // temp dir holding built binaries
+	watcherCmd      *exec.Cmd
+	workerCmd       *exec.Cmd
 )
 
 func TestMain(m *testing.M) {
@@ -66,6 +67,11 @@ func TestMain(m *testing.M) {
 }
 
 func run(m *testing.M) int {
+	// 0. Tear down any leftover services from a previous killed run.
+	// This ensures we always start from a clean Docker state even when the
+	// previous run's deferred composeDown did not execute (e.g. SIGKILL).
+	composeDown()
+
 	// 1. Clean and recreate all directories.
 	if err := resetDirs(); err != nil {
 		log.Printf("e2e: resetDirs: %v", err)
@@ -83,9 +89,19 @@ func run(m *testing.M) int {
 		return 1
 	}
 
+	// 2a. Derive a short MKV fixture from the BBB MP4 so the worker uses the
+	// CodecCopy path (matroska+H.264 → no re-encode) and the e2e round-trip
+	// completes well within the per-test 5-minute polling timeout.
+	qbtFixturePath, err := ensureShortMKVFixture(fixturePath)
+	if err != nil {
+		log.Printf("e2e: ensureShortMKVFixture: %v", err)
+
+		return 1
+	}
+
 	// 3. Start the in-process qBittorrent stub.
 	// It binds to 0.0.0.0 so Docker containers can reach it via host.docker.internal.
-	qbtStub, err = qbittorrent.New(fixturePath, downloadsDir)
+	qbtStub, err = qbittorrent.New(qbtFixturePath, downloadsDir)
 	if err != nil {
 		log.Printf("e2e: start qbt stub: %v", err)
 
@@ -107,7 +123,8 @@ func run(m *testing.M) int {
 	defer composeDown()
 
 	// 5. Wait for Radarr, Sonarr, and Hatchet to be healthy.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// 10-minute timeout to accommodate image pulls on first run.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 
 	if err = waitForServices(ctx); err != nil {
 		cancel()
@@ -146,6 +163,16 @@ func run(m *testing.M) int {
 
 	log.Printf("e2e: Sonarr series ID %d", sonarrSeriesID)
 
+	// Fetch S01E01 episode ID for use in the Sonarr release push.
+	sonarrEpisodeID, err = fetchSonarrS01E01(sonarrSeriesID)
+	if err != nil {
+		log.Printf("e2e: fetchSonarrS01E01: %v", err)
+
+		return 1
+	}
+
+	log.Printf("e2e: Sonarr S01E01 episode ID %d", sonarrEpisodeID)
+
 	// 9. Build watcher and worker binaries, write watcher config, start both.
 	if err = startProcesses(); err != nil {
 		log.Printf("e2e: startProcesses: %v", err)
@@ -161,7 +188,30 @@ func run(m *testing.M) int {
 
 // ---- directory management -----------------------------------------------
 
+// forceRemoveDir removes dir and all its contents using a Docker container
+// running as root to handle any files or directories owned by root (created by
+// containers running as root). It mounts the parent directory so the target
+// directory itself can also be removed. It is a no-op if dir does not exist.
+func forceRemoveDir(dir string) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return
+	}
+
+	parent := filepath.Dir(dir)
+	base := filepath.Base(dir)
+
+	cmd := exec.Command("docker", "run", "--rm",
+		"-v", parent+":/target-parent",
+		"alpine", "rm", "-rf", "/target-parent/"+base,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}
+
 func resetDirs() error {
+	forceRemoveDir(baseDir)
+
 	if err := os.RemoveAll(baseDir); err != nil {
 		return fmt.Errorf("remove base dir: %w", err)
 	}
@@ -224,6 +274,64 @@ func ensureBBBFixture() (string, error) {
 	log.Printf("e2e: BBB fixture cached at %s", mp4Path)
 
 	return mp4Path, nil
+}
+
+// ensureShortMKVFixture creates a 15-minute H.264-in-MKV clip from srcPath,
+// cached at testdata/cache/fixture_15min.mkv. Three properties are critical:
+//
+//  1. Matroska container: the worker's SelectVideoCodec function recognises the
+//     file as already-MKV and issues a stream-copy transcode (CodecCopy) instead
+//     of a full H.265 re-encode, keeping per-test runtime inside the 5-minute
+//     polling timeout.
+//
+//  2. No letterboxing: the video is scaled to fill the full 1280x720 frame so
+//     the worker's crop-detection step finds no crop, preserving CodecCopy (a
+//     detected crop would promote CodecCopy to CodecH265 and slow the transcode).
+//
+//  3. ≥ 13 minutes duration: both Radarr's and Sonarr's sample-rejection
+//     specifications must pass.
+//     - Radarr's SampleSpecification rejects files whose runtime is less than
+//       ~20% of the movie's TMDB runtime. Big Buck Bunny is listed as 8 minutes
+//       on TMDB, so ≥ 96 seconds is required; 15 minutes clears that easily.
+//     - Sonarr's EpisodeFileIsNotSampleSpecification rejects files whose runtime
+//       is less than 50% of the series' expected episode runtime. The Lone Ranger
+//       (TVDB 72059) has ~26-minute episodes, so ≥ 13 minutes is required;
+//       15 minutes (57.7% of 26 min) clears that threshold.
+func ensureShortMKVFixture(srcPath string) (string, error) {
+	const mkvName = "fixture_15min.mkv"
+
+	cacheDir := "testdata/cache"
+	mkvPath := filepath.Join(cacheDir, mkvName)
+
+	if _, err := os.Stat(mkvPath); err == nil {
+		log.Printf("e2e: MKV fixture already cached at %s", mkvPath)
+
+		return mkvPath, nil
+	}
+
+	log.Printf("e2e: creating 15-minute MKV fixture from %s (this takes ~2min)...", srcPath)
+
+	// Scale to 1280x720 (fills the 16:9 frame, no letterboxing) and re-encode
+	// with libx264 ultrafast at CRF 28 so the fixture is created quickly and
+	// the cached file stays under ~200 MB.
+	cmd := exec.Command("ffmpeg", "-y",
+		"-t", "900",
+		"-i", srcPath,
+		"-vf", "scale=1280:720",
+		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
+		"-c:a", "copy",
+		mkvPath,
+	)
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.Remove(mkvPath)
+
+		return "", fmt.Errorf("create MKV fixture: %w\n%s", err, out)
+	}
+
+	log.Printf("e2e: MKV fixture cached at %s", mkvPath)
+
+	return mkvPath, nil
 }
 
 func downloadFile(rawURL, dest string) error {
@@ -323,6 +431,9 @@ func composeDown() {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	_ = cmd.Run()
+
+	forceRemoveDir(baseDir)
+
 	_ = os.RemoveAll(baseDir)
 }
 
@@ -517,7 +628,7 @@ func configureRadarr(qbtPort int) (int, error) {
 	profileID := profiles[0].ID
 
 	// Download client (qBittorrent stub).
-	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr")
+	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr", "category")
 
 	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
 		return 0, fmt.Errorf("add download client: %w", err)
@@ -588,7 +699,9 @@ func configureSonarr(qbtPort int) (int, error) {
 	profileID := profiles[0].ID
 
 	// Download client (qBittorrent stub).
-	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr")
+	// Sonarr's qBittorrent integration uses "tvCategory" (not "category") as the
+	// field name for the TV download category.
+	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr", "tvCategory")
 
 	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
 		return 0, fmt.Errorf("add download client: %w", err)
@@ -614,12 +727,12 @@ func configureSonarr(qbtPort int) (int, error) {
 	// Overlay mandatory add fields.
 	lookupSeries["qualityProfileId"] = profileID
 	lookupSeries["rootFolderPath"] = "/tv"
-	lookupSeries["monitored"] = false
+	lookupSeries["monitored"] = true
 	lookupSeries["seasonFolder"] = true
 	lookupSeries["addOptions"] = map[string]any{
 		"searchForMissingEpisodes":     false,
 		"searchForCutoffUnmetEpisodes": false,
-		"monitor":                      "none",
+		"monitor":                      "pilot",
 	}
 
 	var addedSeries struct {
@@ -640,9 +753,33 @@ func configureSonarr(qbtPort int) (int, error) {
 	return addedSeries.ID, nil
 }
 
+// fetchSonarrS01E01 returns the Sonarr episode ID for Season 1, Episode 1 of the given series.
+func fetchSonarrS01E01(seriesID int) (int, error) {
+	c := newArrClient(sonarrBase, sonarrAPIKey)
+
+	var episodes []struct {
+		ID            int `json:"id"`
+		SeasonNumber  int `json:"seasonNumber"`
+		EpisodeNumber int `json:"episodeNumber"`
+	}
+
+	if err := c.get(fmt.Sprintf("/api/v3/episode?seriesId=%d&seasonNumber=1", seriesID), &episodes); err != nil {
+		return 0, fmt.Errorf("fetch episodes for series %d: %w", seriesID, err)
+	}
+
+	for _, ep := range episodes {
+		if ep.SeasonNumber == 1 && ep.EpisodeNumber == 1 {
+			return ep.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("S01E01 not found for series %d (got %d episodes in season 1)", seriesID, len(episodes))
+}
+
 // qbtDownloadClientBody returns the JSON body for adding a qBittorrent download client
-// to Radarr or Sonarr. category should be "radarr" or "sonarr".
-func qbtDownloadClientBody(name string, port int, category string) map[string]any {
+// to Radarr or Sonarr. categoryField is the Arr-service-specific field name that holds
+// the qBittorrent category: Radarr uses "category"; Sonarr uses "tvCategory".
+func qbtDownloadClientBody(name string, port int, category, categoryField string) map[string]any {
 	return map[string]any{
 		"name":           name,
 		"enable":         true,
@@ -657,7 +794,7 @@ func qbtDownloadClientBody(name string, port int, category string) map[string]an
 			{"name": "urlBase", "value": ""},
 			{"name": "username", "value": ""},
 			{"name": "password", "value": ""},
-			{"name": "category", "value": category},
+			{"name": categoryField, "value": category},
 			{"name": "initialState", "value": 0},
 			{"name": "sequentialOrder", "value": false},
 			{"name": "firstAndLast", "value": false},
@@ -816,6 +953,8 @@ func TestRadarrHappyPath(t *testing.T) {
 
 	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 1, releaseTitle)
 
+	var pushResp []json.RawMessage
+
 	require.NoError(t, radarr.post("/api/v3/release/push", map[string]any{
 		"title":       releaseTitle,
 		"downloadUrl": magnet,
@@ -823,7 +962,12 @@ func TestRadarrHappyPath(t *testing.T) {
 		"publishDate": time.Now().UTC().Format(time.RFC3339),
 		"indexer":     "e2e-test",
 		"size":        700_000_000,
-	}, nil), "push release to Radarr")
+		"movieId":     radarrMovieID,
+	}, &pushResp), "push release to Radarr")
+
+	if len(pushResp) > 0 {
+		t.Logf("Radarr push response: %s", pushResp)
+	}
 
 	// Poll until Radarr has imported the movie (hasFile=true).
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
@@ -864,18 +1008,29 @@ func TestRadarrHappyPath(t *testing.T) {
 func TestSonarrHappyPath(t *testing.T) {
 	sonarr := newArrClient(sonarrBase, sonarrAPIKey)
 
-	const releaseTitle = "The.Lone.Ranger.S01E01.1080p.WEB-DL"
+	// Include the year so Sonarr's title parser resolves "The Lone Ranger" with
+	// year 1949 and matches the library entry stored as "The Lone Ranger (1949)".
+	const releaseTitle = "The.Lone.Ranger.1949.S01E01.1080p.WEB-DL"
 
 	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 2, releaseTitle)
 
+	var sonarrPushResp []json.RawMessage
+
 	require.NoError(t, sonarr.post("/api/v3/release/push", map[string]any{
-		"title":       releaseTitle,
-		"downloadUrl": magnet,
-		"protocol":    "Torrent",
-		"publishDate": time.Now().UTC().Format(time.RFC3339),
-		"indexer":     "e2e-test",
-		"size":        700_000_000,
-	}, nil), "push release to Sonarr")
+		"title":              releaseTitle,
+		"downloadUrl":        magnet,
+		"protocol":           "Torrent",
+		"publishDate":        time.Now().UTC().Format(time.RFC3339),
+		"indexer":            "e2e-test",
+		"size":               700_000_000,
+		"mappedSeriesId":     sonarrSeriesID,
+		"mappedSeasonNumber": 1,
+		"mappedEpisodeIds":   []int{sonarrEpisodeID},
+	}, &sonarrPushResp), "push release to Sonarr")
+
+	if len(sonarrPushResp) > 0 {
+		t.Logf("Sonarr push response: %s", sonarrPushResp)
+	}
 
 	// Poll until Sonarr has at least one imported episode file.
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,7 +123,7 @@ func run(m *testing.M) error {
 	}
 
 	// 8. Configure Radarr (root folder, quality profile, download client, movie).
-	radarrMovieID, err = configureRadarr(qbtStub.Port())
+	radarrMovieID, err = configureRadarr(context.Background(), qbtStub.Port())
 	if err != nil {
 		return fmt.Errorf("configureRadarr: %w", err)
 	}
@@ -131,7 +131,7 @@ func run(m *testing.M) error {
 	log.Info("Radarr configured", "movieID", radarrMovieID)
 
 	// 9. Configure Sonarr (root folder, quality profile, download client, series).
-	sonarrSeriesID, err = configureSonarr(qbtStub.Port())
+	sonarrSeriesID, err = configureSonarr(context.Background(), qbtStub.Port())
 	if err != nil {
 		return fmt.Errorf("configureSonarr: %w", err)
 	}
@@ -139,7 +139,7 @@ func run(m *testing.M) error {
 	log.Info("Sonarr configured", "seriesID", sonarrSeriesID)
 
 	// Fetch S01E01 episode ID for use in the Sonarr release push.
-	sonarrEpisodeID, err = fetchSonarrS01E01(sonarrSeriesID)
+	sonarrEpisodeID, err = fetchSonarrS01E01(context.Background(), sonarrSeriesID)
 	if err != nil {
 		return fmt.Errorf("fetchSonarrS01E01: %w", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,25 +9,12 @@
 package e2e_test
 
 import (
-	"archive/zip"
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"io/fs"
 	"log"
-	"net"
-	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/solidDoWant/media-processor/e2e/stub/qbittorrent"
 )
@@ -49,24 +36,22 @@ const (
 	bbbMP4Name = "bbb_sunflower_1080p_30fps_normal.mp4"
 )
 
-// Package-level state set during TestMain.
+// Package-level state set during TestMain and shared across test functions.
 var (
 	hatchetToken    string
-	qbtStub         *qbittorrent.Server
 	radarrMovieID   int
 	sonarrSeriesID  int
-	sonarrEpisodeID int    // Sonarr episode ID for S01E01 of the test series
-	fixturePath     string // path to BBB mp4 fixture
-	binDir          string // temp dir holding built binaries
-	watcherCmd      *exec.Cmd
-	workerCmd       *exec.Cmd
+	sonarrEpisodeID int
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(run(m))
+	if err := run(m); err != nil {
+		log.Printf("e2e: %v", err)
+		os.Exit(1)
+	}
 }
 
-func run(m *testing.M) int {
+func run(m *testing.M) error {
 	// 0. Tear down any leftover services from a previous killed run.
 	// This ensures we always start from a clean Docker state even when the
 	// previous run's deferred composeDown did not execute (e.g. SIGKILL).
@@ -74,91 +59,72 @@ func run(m *testing.M) int {
 
 	// 1. Clean and recreate all directories.
 	if err := resetDirs(); err != nil {
-		log.Printf("e2e: resetDirs: %v", err)
-
-		return 1
+		return fmt.Errorf("resetDirs: %w", err)
 	}
 
 	// 2. Download and cache the Big Buck Bunny fixture.
-	var err error
-
-	fixturePath, err = ensureBBBFixture()
+	fixturePath, err := ensureBBBFixture()
 	if err != nil {
-		log.Printf("e2e: ensureBBBFixture: %v", err)
-
-		return 1
-	}
-
-	// 2a. Derive a short MKV fixture from the BBB MP4 so the worker uses the
-	// CodecCopy path (matroska+H.264 → no re-encode) and the e2e round-trip
-	// completes well within the per-test 5-minute polling timeout.
-	qbtFixturePath, err := ensureShortMKVFixture(fixturePath)
-	if err != nil {
-		log.Printf("e2e: ensureShortMKVFixture: %v", err)
-
-		return 1
+		return fmt.Errorf("ensureBBBFixture: %w", err)
 	}
 
 	// 3. Start the in-process qBittorrent stub.
 	// It binds to 0.0.0.0 so Docker containers can reach it via host.docker.internal.
-	qbtStub, err = qbittorrent.New(qbtFixturePath, downloadsDir)
+	qbtStub, err := qbittorrent.New(fixturePath, downloadsDir)
 	if err != nil {
-		log.Printf("e2e: start qbt stub: %v", err)
-
-		return 1
+		return fmt.Errorf("start qbt stub: %w", err)
 	}
 
 	defer qbtStub.Close()
 
 	log.Printf("e2e: qBittorrent stub listening on port %d", qbtStub.Port())
 
-	// 4. Docker Compose up.
+	// 4. Pull Docker images (may download several hundred MB on first run).
+	pullCtx, pullCancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer pullCancel()
+
+	if err = composePull(pullCtx); err != nil {
+		return fmt.Errorf("compose pull: %w", err)
+	}
+
+	// 5. Docker Compose up.
 	if err = composeUp(); err != nil {
-		log.Printf("e2e: compose up: %v", err)
 		composeDown()
 
-		return 1
+		return fmt.Errorf("compose up: %w", err)
 	}
 
 	defer composeDown()
 
-	// 5. Wait for Radarr, Sonarr, and Hatchet to be healthy.
-	// 10-minute timeout to accommodate image pulls on first run.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	// 6. Wait for Radarr, Sonarr, and Hatchet to be healthy.
+	healthCtx, healthCancel := context.WithTimeout(context.Background(), 5*time.Minute)
 
-	if err = waitForServices(ctx); err != nil {
-		cancel()
-		log.Printf("e2e: waitForServices: %v", err)
+	if err = waitForServices(healthCtx); err != nil {
+		healthCancel()
 
-		return 1
+		return fmt.Errorf("waitForServices: %w", err)
 	}
 
-	cancel()
+	healthCancel()
 
-	// 6. Generate Hatchet client token.
+	// 7. Generate Hatchet client token.
 	hatchetToken, err = generateHatchetToken()
 	if err != nil {
-		log.Printf("e2e: generateHatchetToken: %v", err)
-
-		return 1
+		return fmt.Errorf("generateHatchetToken: %w", err)
 	}
 
-	// 7. Configure Radarr (root folder, quality profile, download client, movie).
+	// 8. Configure Radarr (root folder, quality profile, download client, movie).
 	radarrMovieID, err = configureRadarr(qbtStub.Port())
 	if err != nil {
-		log.Printf("e2e: configureRadarr: %v", err)
-
-		return 1
+		return fmt.Errorf("configureRadarr: %w", err)
 	}
 
 	log.Printf("e2e: Radarr movie ID %d", radarrMovieID)
 
-	// 8. Configure Sonarr (root folder, quality profile, download client, series).
+	// 9. Configure Sonarr (root folder, quality profile, download client, series).
 	sonarrSeriesID, err = configureSonarr(qbtStub.Port())
 	if err != nil {
-		log.Printf("e2e: configureSonarr: %v", err)
-
-		return 1
+		return fmt.Errorf("configureSonarr: %w", err)
 	}
 
 	log.Printf("e2e: Sonarr series ID %d", sonarrSeriesID)
@@ -166,924 +132,23 @@ func run(m *testing.M) int {
 	// Fetch S01E01 episode ID for use in the Sonarr release push.
 	sonarrEpisodeID, err = fetchSonarrS01E01(sonarrSeriesID)
 	if err != nil {
-		log.Printf("e2e: fetchSonarrS01E01: %v", err)
-
-		return 1
+		return fmt.Errorf("fetchSonarrS01E01: %w", err)
 	}
 
 	log.Printf("e2e: Sonarr S01E01 episode ID %d", sonarrEpisodeID)
 
-	// 9. Build watcher and worker binaries, write watcher config, start both.
+	// 10. Build watcher and worker binaries, write watcher config, start both.
 	if err = startProcesses(); err != nil {
-		log.Printf("e2e: startProcesses: %v", err)
 		stopProcesses()
 
-		return 1
+		return fmt.Errorf("startProcesses: %w", err)
 	}
 
 	defer stopProcesses()
 
-	return m.Run()
-}
-
-// ---- directory management -----------------------------------------------
-
-// forceRemoveDir removes dir and all its contents using a Docker container
-// running as root to handle any files or directories owned by root (created by
-// containers running as root). It mounts the parent directory so the target
-// directory itself can also be removed. It is a no-op if dir does not exist.
-func forceRemoveDir(dir string) {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return
-	}
-
-	parent := filepath.Dir(dir)
-	base := filepath.Base(dir)
-
-	cmd := exec.Command("docker", "run", "--rm",
-		"-v", parent+":/target-parent",
-		"alpine", "rm", "-rf", "/target-parent/"+base,
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	_ = cmd.Run()
-}
-
-func resetDirs() error {
-	forceRemoveDir(baseDir)
-
-	if err := os.RemoveAll(baseDir); err != nil {
-		return fmt.Errorf("remove base dir: %w", err)
-	}
-
-	for _, d := range []string{
-		filepath.Join(downloadsDir, "radarr"),
-		filepath.Join(downloadsDir, "sonarr"),
-		filepath.Join(processedDir, "radarr"),
-		filepath.Join(processedDir, "radarr-library"),
-		filepath.Join(processedDir, "sonarr"),
-		filepath.Join(processedDir, "sonarr-library"),
-		filepath.Join(configDir, "radarr"),
-		filepath.Join(configDir, "sonarr"),
-	} {
-		if err := os.MkdirAll(d, 0o755); err != nil {
-			return fmt.Errorf("mkdir %s: %w", d, err)
-		}
+	if code := m.Run(); code != 0 {
+		return fmt.Errorf("test suite failed (exit code %d)", code)
 	}
 
 	return nil
-}
-
-// ---- BBB fixture --------------------------------------------------------
-
-func ensureBBBFixture() (string, error) {
-	// testdata/cache/ is relative to the e2e package directory.
-	cacheDir := "testdata/cache"
-
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return "", fmt.Errorf("mkdir cache: %w", err)
-	}
-
-	mp4Path := filepath.Join(cacheDir, bbbMP4Name)
-
-	if _, err := os.Stat(mp4Path); err == nil {
-		log.Printf("e2e: BBB fixture already cached at %s", mp4Path)
-
-		return mp4Path, nil
-	}
-
-	log.Printf("e2e: downloading BBB fixture from %s (this may take a while)...", bbbZipURL)
-
-	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
-
-	if err := downloadFile(bbbZipURL, zipPath); err != nil {
-		return "", fmt.Errorf("download BBB zip: %w", err)
-	}
-
-	log.Printf("e2e: extracting BBB mp4 from zip...")
-
-	if err := extractFromZip(zipPath, bbbMP4Name, mp4Path); err != nil {
-		_ = os.Remove(zipPath)
-
-		return "", fmt.Errorf("extract BBB mp4: %w", err)
-	}
-
-	// Remove the zip; only the mp4 needs to be cached.
-	_ = os.Remove(zipPath)
-
-	log.Printf("e2e: BBB fixture cached at %s", mp4Path)
-
-	return mp4Path, nil
-}
-
-// ensureShortMKVFixture creates a 15-minute H.264-in-MKV clip from srcPath,
-// cached at testdata/cache/fixture_15min.mkv. Three properties are critical:
-//
-//  1. Matroska container: the worker's SelectVideoCodec function recognises the
-//     file as already-MKV and issues a stream-copy transcode (CodecCopy) instead
-//     of a full H.265 re-encode, keeping per-test runtime inside the 5-minute
-//     polling timeout.
-//
-//  2. No letterboxing: the video is scaled to fill the full 1280x720 frame so
-//     the worker's crop-detection step finds no crop, preserving CodecCopy (a
-//     detected crop would promote CodecCopy to CodecH265 and slow the transcode).
-//
-//  3. ≥ 13 minutes duration: both Radarr's and Sonarr's sample-rejection
-//     specifications must pass.
-//     - Radarr's SampleSpecification rejects files whose runtime is less than
-//       ~20% of the movie's TMDB runtime. Big Buck Bunny is listed as 8 minutes
-//       on TMDB, so ≥ 96 seconds is required; 15 minutes clears that easily.
-//     - Sonarr's EpisodeFileIsNotSampleSpecification rejects files whose runtime
-//       is less than 50% of the series' expected episode runtime. The Lone Ranger
-//       (TVDB 72059) has ~26-minute episodes, so ≥ 13 minutes is required;
-//       15 minutes (57.7% of 26 min) clears that threshold.
-func ensureShortMKVFixture(srcPath string) (string, error) {
-	const mkvName = "fixture_15min.mkv"
-
-	cacheDir := "testdata/cache"
-	mkvPath := filepath.Join(cacheDir, mkvName)
-
-	if _, err := os.Stat(mkvPath); err == nil {
-		log.Printf("e2e: MKV fixture already cached at %s", mkvPath)
-
-		return mkvPath, nil
-	}
-
-	log.Printf("e2e: creating 15-minute MKV fixture from %s (this takes ~2min)...", srcPath)
-
-	// Scale to 1280x720 (fills the 16:9 frame, no letterboxing) and re-encode
-	// with libx264 ultrafast at CRF 28 so the fixture is created quickly and
-	// the cached file stays under ~200 MB.
-	cmd := exec.Command("ffmpeg", "-y",
-		"-t", "900",
-		"-i", srcPath,
-		"-vf", "scale=1280:720",
-		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
-		"-c:a", "copy",
-		mkvPath,
-	)
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		_ = os.Remove(mkvPath)
-
-		return "", fmt.Errorf("create MKV fixture: %w\n%s", err, out)
-	}
-
-	log.Printf("e2e: MKV fixture cached at %s", mkvPath)
-
-	return mkvPath, nil
-}
-
-func downloadFile(rawURL, dest string) error {
-	resp, err := http.Get(rawURL) //nolint:noctx // setup code, no request context needed
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d", resp.StatusCode)
-	}
-
-	f, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = f.Close() }()
-
-	_, err = io.Copy(f, resp.Body)
-
-	return err
-}
-
-// extractFromZip extracts the first file named targetName (basename match) from
-// the zip at zipPath into destPath. It writes to a .tmp file first and renames
-// on success to ensure the cached file is always complete.
-func extractFromZip(zipPath, targetName, destPath string) error {
-	r, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = r.Close() }()
-
-	for _, f := range r.File {
-		if filepath.Base(f.Name) != targetName {
-			continue
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			return fmt.Errorf("open zip entry %s: %w", f.Name, err)
-		}
-
-		tmpPath := destPath + ".tmp"
-
-		out, err := os.Create(tmpPath)
-		if err != nil {
-			_ = rc.Close()
-
-			return err
-		}
-
-		if _, err = io.Copy(out, rc); err != nil {
-			_ = rc.Close()
-			_ = out.Close()
-			_ = os.Remove(tmpPath)
-
-			return fmt.Errorf("copy entry: %w", err)
-		}
-
-		_ = rc.Close()
-
-		if err = out.Close(); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return err
-		}
-
-		return os.Rename(tmpPath, destPath)
-	}
-
-	return fmt.Errorf("entry %q not found in zip", targetName)
-}
-
-// ---- Docker Compose -----------------------------------------------------
-
-func composeArgs(subcmd ...string) []string {
-	args := []string{"compose", "-p", "e2e-media-processor", "-f", "docker-compose.yml"}
-
-	return append(args, subcmd...)
-}
-
-func composeUp() error {
-	cmd := exec.Command("docker", composeArgs("up", "-d")...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
-func composeDown() {
-	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	_ = cmd.Run()
-
-	forceRemoveDir(baseDir)
-
-	_ = os.RemoveAll(baseDir)
-}
-
-// waitForServices polls until Radarr, Sonarr, and the Hatchet gRPC port are up.
-func waitForServices(ctx context.Context) error {
-	type svc struct {
-		name string
-		fn   func() error
-	}
-
-	services := []svc{
-		{"radarr", func() error { return checkHTTP(radarrBase + "/ping") }},
-		{"sonarr", func() error { return checkHTTP(sonarrBase + "/ping") }},
-		{"hatchet-grpc", func() error { return checkTCP("localhost:7079") }},
-	}
-
-	for _, s := range services {
-		log.Printf("e2e: waiting for %s...", s.name)
-
-		if err := pollUntil(ctx, 5*time.Second, s.fn); err != nil {
-			return fmt.Errorf("%s not ready: %w", s.name, err)
-		}
-
-		log.Printf("e2e: %s ready", s.name)
-	}
-
-	return nil
-}
-
-func checkHTTP(url string) error {
-	resp, err := http.Get(url) //nolint:noctx // health poll, no caller context
-	if err != nil {
-		return err
-	}
-
-	_ = resp.Body.Close()
-
-	return nil
-}
-
-func checkTCP(addr string) error {
-	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-	if err != nil {
-		return err
-	}
-
-	return conn.Close()
-}
-
-// ---- Hatchet token ------------------------------------------------------
-
-func generateHatchetToken() (string, error) {
-	// Query the tenant ID from the e2e postgres container.
-	tenantCmd := exec.Command("docker", composeArgs(
-		"exec", "-T", "postgres",
-		"psql", "-U", "hatchet", "-d", "hatchet", "-t", "-c",
-		`SELECT id FROM "Tenant" WHERE slug = 'default' LIMIT 1`,
-	)...)
-
-	tenantOut, err := tenantCmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("query tenant ID: %w", err)
-	}
-
-	tenantID := strings.TrimSpace(string(tenantOut))
-
-	if tenantID == "" {
-		return "", fmt.Errorf("empty tenant ID from postgres")
-	}
-
-	// Generate the token using the setup-config container.
-	tokenCmd := exec.Command("docker", composeArgs(
-		"run", "--no-deps", "--rm", "-T", "setup-config",
-		"/hatchet/hatchet-admin", "token", "create",
-		"--config", "/hatchet/config",
-		"--tenant-id", tenantID,
-	)...)
-
-	tokenOut, err := tokenCmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("generate token: %w", err)
-	}
-
-	token := strings.TrimSpace(string(tokenOut))
-
-	if token == "" {
-		return "", fmt.Errorf("empty token from hatchet-admin")
-	}
-
-	return token, nil
-}
-
-// ---- Radarr / Sonarr configuration -------------------------------------
-
-// arrClient is a minimal HTTP client for Radarr and Sonarr v3 APIs.
-type arrClient struct {
-	base       string
-	apiKey     string
-	httpClient *http.Client
-}
-
-func newArrClient(base, apiKey string) *arrClient {
-	return &arrClient{base: base, apiKey: apiKey, httpClient: &http.Client{Timeout: 30 * time.Second}}
-}
-
-func (c *arrClient) get(path string, out any) error {
-	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("X-Api-Key", c.apiKey)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-
-		return fmt.Errorf("GET %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(body))
-	}
-
-	if out != nil {
-		return json.NewDecoder(resp.Body).Decode(out)
-	}
-
-	return nil
-}
-
-func (c *arrClient) post(path string, body any, out any) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, c.base+path, bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("X-Api-Key", c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-
-		return fmt.Errorf("POST %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(respBody))
-	}
-
-	if out != nil {
-		return json.NewDecoder(resp.Body).Decode(out)
-	}
-
-	return nil
-}
-
-// configureRadarr adds the root folder, download client, and Big Buck Bunny (TMDB 10378).
-// Returns the Radarr movie ID.
-func configureRadarr(qbtPort int) (int, error) {
-	c := newArrClient(radarrBase, radarrAPIKey)
-
-	// Root folder.
-	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/movies"}, nil); err != nil {
-		return 0, fmt.Errorf("add root folder: %w", err)
-	}
-
-	// Quality profile — use the first available.
-	var profiles []struct {
-		ID   int    `json:"id"`
-		Name string `json:"name"`
-	}
-
-	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
-		return 0, fmt.Errorf("get quality profiles: %w", err)
-	}
-
-	if len(profiles) == 0 {
-		return 0, fmt.Errorf("no quality profiles found in Radarr")
-	}
-
-	profileID := profiles[0].ID
-
-	// Download client (qBittorrent stub).
-	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr", "category")
-
-	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
-		return 0, fmt.Errorf("add download client: %w", err)
-	}
-
-	// Look up Big Buck Bunny by TMDB ID.
-	var lookupResults []json.RawMessage
-
-	if err := c.get("/api/v3/movie/lookup?term=tmdb:10378", &lookupResults); err != nil {
-		return 0, fmt.Errorf("lookup movie tmdb:10378: %w", err)
-	}
-
-	if len(lookupResults) == 0 {
-		return 0, fmt.Errorf("no results for tmdb:10378")
-	}
-
-	var lookupMovie map[string]any
-
-	if err := json.Unmarshal(lookupResults[0], &lookupMovie); err != nil {
-		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
-	}
-
-	// Overlay mandatory add fields.
-	lookupMovie["qualityProfileId"] = profileID
-	lookupMovie["rootFolderPath"] = "/movies"
-	lookupMovie["monitored"] = true
-	lookupMovie["addOptions"] = map[string]any{"searchForMovie": false}
-
-	var addedMovie struct {
-		ID int `json:"id"`
-	}
-
-	if err := c.post("/api/v3/movie", lookupMovie, &addedMovie); err != nil {
-		return 0, fmt.Errorf("add movie: %w", err)
-	}
-
-	if addedMovie.ID == 0 {
-		return 0, fmt.Errorf("Radarr returned movie ID 0")
-	}
-
-	return addedMovie.ID, nil
-}
-
-// configureSonarr adds the root folder, download client, and The Lone Ranger (TVDB 72059).
-// Returns the Sonarr series ID.
-func configureSonarr(qbtPort int) (int, error) {
-	c := newArrClient(sonarrBase, sonarrAPIKey)
-
-	// Root folder.
-	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/tv"}, nil); err != nil {
-		return 0, fmt.Errorf("add root folder: %w", err)
-	}
-
-	// Quality profile — use the first available.
-	var profiles []struct {
-		ID   int    `json:"id"`
-		Name string `json:"name"`
-	}
-
-	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
-		return 0, fmt.Errorf("get quality profiles: %w", err)
-	}
-
-	if len(profiles) == 0 {
-		return 0, fmt.Errorf("no quality profiles found in Sonarr")
-	}
-
-	profileID := profiles[0].ID
-
-	// Download client (qBittorrent stub).
-	// Sonarr's qBittorrent integration uses "tvCategory" (not "category") as the
-	// field name for the TV download category.
-	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr", "tvCategory")
-
-	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
-		return 0, fmt.Errorf("add download client: %w", err)
-	}
-
-	// Look up The Lone Ranger by TVDB ID.
-	var lookupResults []json.RawMessage
-
-	if err := c.get("/api/v3/series/lookup?term=tvdb:72059", &lookupResults); err != nil {
-		return 0, fmt.Errorf("lookup series tvdb:72059: %w", err)
-	}
-
-	if len(lookupResults) == 0 {
-		return 0, fmt.Errorf("no results for tvdb:72059")
-	}
-
-	var lookupSeries map[string]any
-
-	if err := json.Unmarshal(lookupResults[0], &lookupSeries); err != nil {
-		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
-	}
-
-	// Overlay mandatory add fields.
-	lookupSeries["qualityProfileId"] = profileID
-	lookupSeries["rootFolderPath"] = "/tv"
-	lookupSeries["monitored"] = true
-	lookupSeries["seasonFolder"] = true
-	lookupSeries["addOptions"] = map[string]any{
-		"searchForMissingEpisodes":     false,
-		"searchForCutoffUnmetEpisodes": false,
-		"monitor":                      "pilot",
-	}
-
-	var addedSeries struct {
-		ID    int    `json:"id"`
-		Title string `json:"title"`
-	}
-
-	if err := c.post("/api/v3/series", lookupSeries, &addedSeries); err != nil {
-		return 0, fmt.Errorf("add series: %w", err)
-	}
-
-	if addedSeries.ID == 0 {
-		return 0, fmt.Errorf("Sonarr returned series ID 0")
-	}
-
-	log.Printf("e2e: added Sonarr series %q (ID %d)", addedSeries.Title, addedSeries.ID)
-
-	return addedSeries.ID, nil
-}
-
-// fetchSonarrS01E01 returns the Sonarr episode ID for Season 1, Episode 1 of the given series.
-func fetchSonarrS01E01(seriesID int) (int, error) {
-	c := newArrClient(sonarrBase, sonarrAPIKey)
-
-	var episodes []struct {
-		ID            int `json:"id"`
-		SeasonNumber  int `json:"seasonNumber"`
-		EpisodeNumber int `json:"episodeNumber"`
-	}
-
-	if err := c.get(fmt.Sprintf("/api/v3/episode?seriesId=%d&seasonNumber=1", seriesID), &episodes); err != nil {
-		return 0, fmt.Errorf("fetch episodes for series %d: %w", seriesID, err)
-	}
-
-	for _, ep := range episodes {
-		if ep.SeasonNumber == 1 && ep.EpisodeNumber == 1 {
-			return ep.ID, nil
-		}
-	}
-
-	return 0, fmt.Errorf("S01E01 not found for series %d (got %d episodes in season 1)", seriesID, len(episodes))
-}
-
-// qbtDownloadClientBody returns the JSON body for adding a qBittorrent download client
-// to Radarr or Sonarr. categoryField is the Arr-service-specific field name that holds
-// the qBittorrent category: Radarr uses "category"; Sonarr uses "tvCategory".
-func qbtDownloadClientBody(name string, port int, category, categoryField string) map[string]any {
-	return map[string]any{
-		"name":           name,
-		"enable":         true,
-		"protocol":       "torrent",
-		"priority":       1,
-		"implementation": "QBittorrent",
-		"configContract": "QBittorrentSettings",
-		"fields": []map[string]any{
-			{"name": "host", "value": "host.docker.internal"},
-			{"name": "port", "value": port},
-			{"name": "useSsl", "value": false},
-			{"name": "urlBase", "value": ""},
-			{"name": "username", "value": ""},
-			{"name": "password", "value": ""},
-			{"name": categoryField, "value": category},
-			{"name": "initialState", "value": 0},
-			{"name": "sequentialOrder", "value": false},
-			{"name": "firstAndLast", "value": false},
-		},
-	}
-}
-
-// ---- watcher + worker subprocesses --------------------------------------
-
-func startProcesses() error {
-	var err error
-
-	binDir, err = os.MkdirTemp("", "e2e-bins-*")
-	if err != nil {
-		return fmt.Errorf("create bin dir: %w", err)
-	}
-
-	root := moduleRoot()
-
-	// Build watcher.
-	watcherBin := filepath.Join(binDir, "watcher")
-
-	if out, err := buildBinary(root, "./cmd/watcher", watcherBin); err != nil {
-		return fmt.Errorf("build watcher: %w\n%s", err, out)
-	}
-
-	// Build worker.
-	workerBin := filepath.Join(binDir, "worker")
-
-	if out, err := buildBinary(root, "./cmd/worker", workerBin); err != nil {
-		return fmt.Errorf("build worker: %w\n%s", err, out)
-	}
-
-	// Write watcher YAML config.
-	watcherCfg := filepath.Join(binDir, "watcher.yaml")
-	cfgContent := fmt.Sprintf("watches:\n"+
-		"  - name: radarr\n    path: %s\n    media_type: movie\n"+
-		"  - name: sonarr\n    path: %s\n    media_type: show\n",
-		filepath.Join(downloadsDir, "radarr"),
-		filepath.Join(downloadsDir, "sonarr"),
-	)
-
-	if err := os.WriteFile(watcherCfg, []byte(cfgContent), 0o644); err != nil {
-		return fmt.Errorf("write watcher config: %w", err)
-	}
-
-	baseEnv := append(os.Environ(),
-		"HATCHET_CLIENT_TOKEN="+hatchetToken,
-		"HATCHET_CLIENT_TLS_STRATEGY=none",
-	)
-
-	// Start watcher subprocess.
-	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
-	watcherCmd.Env = baseEnv
-	watcherCmd.Stdout = os.Stdout
-	watcherCmd.Stderr = os.Stderr
-
-	if err := watcherCmd.Start(); err != nil {
-		return fmt.Errorf("start watcher: %w", err)
-	}
-
-	log.Printf("e2e: watcher started (PID %d)", watcherCmd.Process.Pid)
-
-	// Start worker subprocess with path-translation env vars.
-	workerEnv := append(baseEnv,
-		"MEDIA_OUTPUT_DIR="+processedDir,
-		"MEDIA_WATCHER_ROOT="+downloadsDir,
-		"RADARR_URL="+radarrBase,
-		"RADARR_API_KEY="+radarrAPIKey,
-		"SONARR_URL="+sonarrBase,
-		"SONARR_API_KEY="+sonarrAPIKey,
-		"RADARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "radarr"),
-		"RADARR_REMOTE_PATH_PREFIX=/downloads",
-		"SONARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "sonarr"),
-		"SONARR_REMOTE_PATH_PREFIX=/downloads",
-	)
-
-	workerCmd = exec.Command(workerBin)
-	workerCmd.Env = workerEnv
-	workerCmd.Stdout = os.Stdout
-	workerCmd.Stderr = os.Stderr
-
-	if err := workerCmd.Start(); err != nil {
-		return fmt.Errorf("start worker: %w", err)
-	}
-
-	log.Printf("e2e: worker started (PID %d)", workerCmd.Process.Pid)
-
-	return nil
-}
-
-func stopProcesses() {
-	for _, cmd := range []*exec.Cmd{watcherCmd, workerCmd} {
-		if cmd != nil && cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
-	}
-
-	if binDir != "" {
-		_ = os.RemoveAll(binDir)
-	}
-}
-
-func buildBinary(moduleRoot, pkg, out string) ([]byte, error) {
-	cmd := exec.Command("go", "build", "-o", out, pkg)
-	cmd.Dir = moduleRoot
-
-	return cmd.CombinedOutput()
-}
-
-// moduleRoot returns the absolute path of the Go module root by invoking
-// `go env GOMOD`.
-func moduleRoot() string {
-	out, err := exec.Command("go", "env", "GOMOD").Output()
-	if err == nil {
-		mod := strings.TrimSpace(string(out))
-		if mod != "" && mod != os.DevNull {
-			return filepath.Dir(mod)
-		}
-	}
-
-	// Fallback: test runs from e2e/, so module root is one level up.
-	abs, _ := filepath.Abs("..")
-
-	return abs
-}
-
-// ---- polling helpers ----------------------------------------------------
-
-// pollUntil calls cond repeatedly with interval spacing until it returns nil or
-// ctx is done. It calls cond immediately on the first iteration.
-func pollUntil(ctx context.Context, interval time.Duration, cond func() error) error {
-	for {
-		if err := cond(); err == nil {
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(interval):
-		}
-	}
-}
-
-// ---- Tests --------------------------------------------------------------
-
-// TestRadarrHappyPath pushes a Big Buck Bunny release to Radarr, waits for the
-// pipeline to transcode it and notify Radarr, then verifies the movie is
-// imported and the original .mp4 source file has been deleted.
-func TestRadarrHappyPath(t *testing.T) {
-	radarr := newArrClient(radarrBase, radarrAPIKey)
-
-	const releaseTitle = "Big.Buck.Bunny.2008.1080p.WEB-DL"
-
-	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 1, releaseTitle)
-
-	var pushResp []json.RawMessage
-
-	require.NoError(t, radarr.post("/api/v3/release/push", map[string]any{
-		"title":       releaseTitle,
-		"downloadUrl": magnet,
-		"protocol":    "Torrent",
-		"publishDate": time.Now().UTC().Format(time.RFC3339),
-		"indexer":     "e2e-test",
-		"size":        700_000_000,
-		"movieId":     radarrMovieID,
-	}, &pushResp), "push release to Radarr")
-
-	if len(pushResp) > 0 {
-		t.Logf("Radarr push response: %s", pushResp)
-	}
-
-	// Poll until Radarr has imported the movie (hasFile=true).
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
-	defer cancel()
-
-	err := pollUntil(ctx, 10*time.Second, func() error {
-		var movie struct {
-			HasFile bool `json:"hasFile"`
-		}
-
-		if err := radarr.get(fmt.Sprintf("/api/v3/movie/%d", radarrMovieID), &movie); err != nil {
-			return err
-		}
-
-		if !movie.HasFile {
-			return fmt.Errorf("movie not yet imported")
-		}
-
-		return nil
-	})
-	require.NoError(t, err, "Radarr did not import the movie within the timeout")
-
-	// Source .mp4 must be deleted by the worker's cleanup step.
-	sourceMp4 := filepath.Join(downloadsDir, "radarr", releaseTitle+".mp4")
-	_, statErr := os.Stat(sourceMp4)
-
-	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
-
-	// .mkv must exist somewhere under the Radarr library directory.
-	foundMKV := findMKV(t, filepath.Join(processedDir, "radarr-library"))
-
-	assert.True(t, foundMKV, "expected .mkv in radarr-library after import")
-}
-
-// TestSonarrHappyPath pushes an S01E01 release to Sonarr, waits for the
-// pipeline to transcode it and notify Sonarr, then verifies an episode file
-// was imported and the original .mp4 source file has been deleted.
-func TestSonarrHappyPath(t *testing.T) {
-	sonarr := newArrClient(sonarrBase, sonarrAPIKey)
-
-	// Include the year so Sonarr's title parser resolves "The Lone Ranger" with
-	// year 1949 and matches the library entry stored as "The Lone Ranger (1949)".
-	const releaseTitle = "The.Lone.Ranger.1949.S01E01.1080p.WEB-DL"
-
-	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 2, releaseTitle)
-
-	var sonarrPushResp []json.RawMessage
-
-	require.NoError(t, sonarr.post("/api/v3/release/push", map[string]any{
-		"title":              releaseTitle,
-		"downloadUrl":        magnet,
-		"protocol":           "Torrent",
-		"publishDate":        time.Now().UTC().Format(time.RFC3339),
-		"indexer":            "e2e-test",
-		"size":               700_000_000,
-		"mappedSeriesId":     sonarrSeriesID,
-		"mappedSeasonNumber": 1,
-		"mappedEpisodeIds":   []int{sonarrEpisodeID},
-	}, &sonarrPushResp), "push release to Sonarr")
-
-	if len(sonarrPushResp) > 0 {
-		t.Logf("Sonarr push response: %s", sonarrPushResp)
-	}
-
-	// Poll until Sonarr has at least one imported episode file.
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
-	defer cancel()
-
-	err := pollUntil(ctx, 10*time.Second, func() error {
-		var files []struct {
-			ID int `json:"id"`
-		}
-
-		if err := sonarr.get(fmt.Sprintf("/api/v3/episodefile?seriesId=%d", sonarrSeriesID), &files); err != nil {
-			return err
-		}
-
-		if len(files) == 0 {
-			return fmt.Errorf("no episode files imported yet")
-		}
-
-		return nil
-	})
-	require.NoError(t, err, "Sonarr did not import any episode file within the timeout")
-
-	// Source .mp4 must be deleted by the worker's cleanup step.
-	sourceMp4 := filepath.Join(downloadsDir, "sonarr", releaseTitle+".mp4")
-	_, statErr := os.Stat(sourceMp4)
-
-	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
-
-	// .mkv must exist somewhere under the Sonarr library directory.
-	foundMKV := findMKV(t, filepath.Join(processedDir, "sonarr-library"))
-
-	assert.True(t, foundMKV, "expected .mkv in sonarr-library after import")
-}
-
-// findMKV returns true if any .mkv file exists under dir.
-func findMKV(t *testing.T, dir string) bool {
-	t.Helper()
-
-	var found bool
-
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if !d.IsDir() && strings.HasSuffix(strings.ToLower(path), ".mkv") {
-			found = true
-		}
-
-		return nil
-	})
-
-	require.NoError(t, err)
-
-	return found
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,934 @@
+//go:build e2e
+
+// Package e2e_test contains end-to-end tests for the media-processor pipeline.
+// It spins up Radarr, Sonarr, and Hatchet via Docker Compose, starts the
+// watcher and worker subprocesses, and verifies the full happy-path flow.
+//
+// Run with: make test-e2e
+// Prerequisites: Docker, internet access (first run downloads the BBB fixture).
+package e2e_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/e2e/stub/qbittorrent"
+)
+
+// Fixed base paths under which all e2e state lives.
+const (
+	baseDir      = "/tmp/e2e-media-processor"
+	downloadsDir = "/tmp/e2e-media-processor/downloads"
+	processedDir = "/tmp/e2e-media-processor/processed-output"
+	configDir    = "/tmp/e2e-media-processor/config"
+
+	radarrAPIKey = "e2e-radarr-api-key"
+	sonarrAPIKey = "e2e-sonarr-api-key"
+
+	radarrBase = "http://localhost:7878"
+	sonarrBase = "http://localhost:8989"
+
+	bbbZipURL  = "https://download.blender.org/demo/movies/BBB/bbb_sunflower_1080p_30fps_normal.mp4.zip"
+	bbbMP4Name = "bbb_sunflower_1080p_30fps_normal.mp4"
+)
+
+// Package-level state set during TestMain.
+var (
+	hatchetToken   string
+	qbtStub        *qbittorrent.Server
+	radarrMovieID  int
+	sonarrSeriesID int
+	fixturePath    string // path to BBB mp4 fixture
+	binDir         string // temp dir holding built binaries
+	watcherCmd     *exec.Cmd
+	workerCmd      *exec.Cmd
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	// 1. Clean and recreate all directories.
+	if err := resetDirs(); err != nil {
+		log.Printf("e2e: resetDirs: %v", err)
+
+		return 1
+	}
+
+	// 2. Download and cache the Big Buck Bunny fixture.
+	var err error
+
+	fixturePath, err = ensureBBBFixture()
+	if err != nil {
+		log.Printf("e2e: ensureBBBFixture: %v", err)
+
+		return 1
+	}
+
+	// 3. Start the in-process qBittorrent stub.
+	// It binds to 0.0.0.0 so Docker containers can reach it via host.docker.internal.
+	qbtStub, err = qbittorrent.New(fixturePath, downloadsDir)
+	if err != nil {
+		log.Printf("e2e: start qbt stub: %v", err)
+
+		return 1
+	}
+
+	defer qbtStub.Close()
+
+	log.Printf("e2e: qBittorrent stub listening on port %d", qbtStub.Port())
+
+	// 4. Docker Compose up.
+	if err = composeUp(); err != nil {
+		log.Printf("e2e: compose up: %v", err)
+		composeDown()
+
+		return 1
+	}
+
+	defer composeDown()
+
+	// 5. Wait for Radarr, Sonarr, and Hatchet to be healthy.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+
+	if err = waitForServices(ctx); err != nil {
+		cancel()
+		log.Printf("e2e: waitForServices: %v", err)
+
+		return 1
+	}
+
+	cancel()
+
+	// 6. Generate Hatchet client token.
+	hatchetToken, err = generateHatchetToken()
+	if err != nil {
+		log.Printf("e2e: generateHatchetToken: %v", err)
+
+		return 1
+	}
+
+	// 7. Configure Radarr (root folder, quality profile, download client, movie).
+	radarrMovieID, err = configureRadarr(qbtStub.Port())
+	if err != nil {
+		log.Printf("e2e: configureRadarr: %v", err)
+
+		return 1
+	}
+
+	log.Printf("e2e: Radarr movie ID %d", radarrMovieID)
+
+	// 8. Configure Sonarr (root folder, quality profile, download client, series).
+	sonarrSeriesID, err = configureSonarr(qbtStub.Port())
+	if err != nil {
+		log.Printf("e2e: configureSonarr: %v", err)
+
+		return 1
+	}
+
+	log.Printf("e2e: Sonarr series ID %d", sonarrSeriesID)
+
+	// 9. Build watcher and worker binaries, write watcher config, start both.
+	if err = startProcesses(); err != nil {
+		log.Printf("e2e: startProcesses: %v", err)
+		stopProcesses()
+
+		return 1
+	}
+
+	defer stopProcesses()
+
+	return m.Run()
+}
+
+// ---- directory management -----------------------------------------------
+
+func resetDirs() error {
+	if err := os.RemoveAll(baseDir); err != nil {
+		return fmt.Errorf("remove base dir: %w", err)
+	}
+
+	for _, d := range []string{
+		filepath.Join(downloadsDir, "radarr"),
+		filepath.Join(downloadsDir, "sonarr"),
+		filepath.Join(processedDir, "radarr"),
+		filepath.Join(processedDir, "radarr-library"),
+		filepath.Join(processedDir, "sonarr"),
+		filepath.Join(processedDir, "sonarr-library"),
+		filepath.Join(configDir, "radarr"),
+		filepath.Join(configDir, "sonarr"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", d, err)
+		}
+	}
+
+	return nil
+}
+
+// ---- BBB fixture --------------------------------------------------------
+
+func ensureBBBFixture() (string, error) {
+	// testdata/cache/ is relative to the e2e package directory.
+	cacheDir := "testdata/cache"
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir cache: %w", err)
+	}
+
+	mp4Path := filepath.Join(cacheDir, bbbMP4Name)
+
+	if _, err := os.Stat(mp4Path); err == nil {
+		log.Printf("e2e: BBB fixture already cached at %s", mp4Path)
+
+		return mp4Path, nil
+	}
+
+	log.Printf("e2e: downloading BBB fixture from %s (this may take a while)...", bbbZipURL)
+
+	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
+
+	if err := downloadFile(bbbZipURL, zipPath); err != nil {
+		return "", fmt.Errorf("download BBB zip: %w", err)
+	}
+
+	log.Printf("e2e: extracting BBB mp4 from zip...")
+
+	if err := extractFromZip(zipPath, bbbMP4Name, mp4Path); err != nil {
+		_ = os.Remove(zipPath)
+
+		return "", fmt.Errorf("extract BBB mp4: %w", err)
+	}
+
+	// Remove the zip; only the mp4 needs to be cached.
+	_ = os.Remove(zipPath)
+
+	log.Printf("e2e: BBB fixture cached at %s", mp4Path)
+
+	return mp4Path, nil
+}
+
+func downloadFile(rawURL, dest string) error {
+	resp, err := http.Get(rawURL) //nolint:noctx // setup code, no request context needed
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = f.Close() }()
+
+	_, err = io.Copy(f, resp.Body)
+
+	return err
+}
+
+// extractFromZip extracts the first file named targetName (basename match) from
+// the zip at zipPath into destPath. It writes to a .tmp file first and renames
+// on success to ensure the cached file is always complete.
+func extractFromZip(zipPath, targetName, destPath string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = r.Close() }()
+
+	for _, f := range r.File {
+		if filepath.Base(f.Name) != targetName {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("open zip entry %s: %w", f.Name, err)
+		}
+
+		tmpPath := destPath + ".tmp"
+
+		out, err := os.Create(tmpPath)
+		if err != nil {
+			_ = rc.Close()
+
+			return err
+		}
+
+		if _, err = io.Copy(out, rc); err != nil {
+			_ = rc.Close()
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
+
+			return fmt.Errorf("copy entry: %w", err)
+		}
+
+		_ = rc.Close()
+
+		if err = out.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return err
+		}
+
+		return os.Rename(tmpPath, destPath)
+	}
+
+	return fmt.Errorf("entry %q not found in zip", targetName)
+}
+
+// ---- Docker Compose -----------------------------------------------------
+
+func composeArgs(subcmd ...string) []string {
+	args := []string{"compose", "-p", "e2e-media-processor", "-f", "docker-compose.yml"}
+
+	return append(args, subcmd...)
+}
+
+func composeUp() error {
+	cmd := exec.Command("docker", composeArgs("up", "-d")...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func composeDown() {
+	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+	_ = os.RemoveAll(baseDir)
+}
+
+// waitForServices polls until Radarr, Sonarr, and the Hatchet gRPC port are up.
+func waitForServices(ctx context.Context) error {
+	type svc struct {
+		name string
+		fn   func() error
+	}
+
+	services := []svc{
+		{"radarr", func() error { return checkHTTP(radarrBase + "/ping") }},
+		{"sonarr", func() error { return checkHTTP(sonarrBase + "/ping") }},
+		{"hatchet-grpc", func() error { return checkTCP("localhost:7079") }},
+	}
+
+	for _, s := range services {
+		log.Printf("e2e: waiting for %s...", s.name)
+
+		if err := pollUntil(ctx, 5*time.Second, s.fn); err != nil {
+			return fmt.Errorf("%s not ready: %w", s.name, err)
+		}
+
+		log.Printf("e2e: %s ready", s.name)
+	}
+
+	return nil
+}
+
+func checkHTTP(url string) error {
+	resp, err := http.Get(url) //nolint:noctx // health poll, no caller context
+	if err != nil {
+		return err
+	}
+
+	_ = resp.Body.Close()
+
+	return nil
+}
+
+func checkTCP(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return err
+	}
+
+	return conn.Close()
+}
+
+// ---- Hatchet token ------------------------------------------------------
+
+func generateHatchetToken() (string, error) {
+	// Query the tenant ID from the e2e postgres container.
+	tenantCmd := exec.Command("docker", composeArgs(
+		"exec", "-T", "postgres",
+		"psql", "-U", "hatchet", "-d", "hatchet", "-t", "-c",
+		`SELECT id FROM "Tenant" WHERE slug = 'default' LIMIT 1`,
+	)...)
+
+	tenantOut, err := tenantCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("query tenant ID: %w", err)
+	}
+
+	tenantID := strings.TrimSpace(string(tenantOut))
+
+	if tenantID == "" {
+		return "", fmt.Errorf("empty tenant ID from postgres")
+	}
+
+	// Generate the token using the setup-config container.
+	tokenCmd := exec.Command("docker", composeArgs(
+		"run", "--no-deps", "--rm", "-T", "setup-config",
+		"/hatchet/hatchet-admin", "token", "create",
+		"--config", "/hatchet/config",
+		"--tenant-id", tenantID,
+	)...)
+
+	tokenOut, err := tokenCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+
+	token := strings.TrimSpace(string(tokenOut))
+
+	if token == "" {
+		return "", fmt.Errorf("empty token from hatchet-admin")
+	}
+
+	return token, nil
+}
+
+// ---- Radarr / Sonarr configuration -------------------------------------
+
+// arrClient is a minimal HTTP client for Radarr and Sonarr v3 APIs.
+type arrClient struct {
+	base       string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newArrClient(base, apiKey string) *arrClient {
+	return &arrClient{base: base, apiKey: apiKey, httpClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (c *arrClient) get(path string, out any) error {
+	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("GET %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(body))
+	}
+
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	return nil
+}
+
+func (c *arrClient) post(path string, body any, out any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.base+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-Api-Key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("POST %s: HTTP %d: %s", path, resp.StatusCode, bytes.TrimSpace(respBody))
+	}
+
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	return nil
+}
+
+// configureRadarr adds the root folder, download client, and Big Buck Bunny (TMDB 10378).
+// Returns the Radarr movie ID.
+func configureRadarr(qbtPort int) (int, error) {
+	c := newArrClient(radarrBase, radarrAPIKey)
+
+	// Root folder.
+	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/movies"}, nil); err != nil {
+		return 0, fmt.Errorf("add root folder: %w", err)
+	}
+
+	// Quality profile — use the first available.
+	var profiles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+		return 0, fmt.Errorf("get quality profiles: %w", err)
+	}
+
+	if len(profiles) == 0 {
+		return 0, fmt.Errorf("no quality profiles found in Radarr")
+	}
+
+	profileID := profiles[0].ID
+
+	// Download client (qBittorrent stub).
+	dcBody := qbtDownloadClientBody("e2e-radarr-qbt", qbtPort, "radarr")
+
+	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+		return 0, fmt.Errorf("add download client: %w", err)
+	}
+
+	// Look up Big Buck Bunny by TMDB ID.
+	var lookupResults []json.RawMessage
+
+	if err := c.get("/api/v3/movie/lookup?term=tmdb:10378", &lookupResults); err != nil {
+		return 0, fmt.Errorf("lookup movie tmdb:10378: %w", err)
+	}
+
+	if len(lookupResults) == 0 {
+		return 0, fmt.Errorf("no results for tmdb:10378")
+	}
+
+	var lookupMovie map[string]any
+
+	if err := json.Unmarshal(lookupResults[0], &lookupMovie); err != nil {
+		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
+	}
+
+	// Overlay mandatory add fields.
+	lookupMovie["qualityProfileId"] = profileID
+	lookupMovie["rootFolderPath"] = "/movies"
+	lookupMovie["monitored"] = true
+	lookupMovie["addOptions"] = map[string]any{"searchForMovie": false}
+
+	var addedMovie struct {
+		ID int `json:"id"`
+	}
+
+	if err := c.post("/api/v3/movie", lookupMovie, &addedMovie); err != nil {
+		return 0, fmt.Errorf("add movie: %w", err)
+	}
+
+	if addedMovie.ID == 0 {
+		return 0, fmt.Errorf("Radarr returned movie ID 0")
+	}
+
+	return addedMovie.ID, nil
+}
+
+// configureSonarr adds the root folder, download client, and The Lone Ranger (TVDB 72059).
+// Returns the Sonarr series ID.
+func configureSonarr(qbtPort int) (int, error) {
+	c := newArrClient(sonarrBase, sonarrAPIKey)
+
+	// Root folder.
+	if err := c.post("/api/v3/rootfolder", map[string]any{"path": "/tv"}, nil); err != nil {
+		return 0, fmt.Errorf("add root folder: %w", err)
+	}
+
+	// Quality profile — use the first available.
+	var profiles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	if err := c.get("/api/v3/qualityprofile", &profiles); err != nil {
+		return 0, fmt.Errorf("get quality profiles: %w", err)
+	}
+
+	if len(profiles) == 0 {
+		return 0, fmt.Errorf("no quality profiles found in Sonarr")
+	}
+
+	profileID := profiles[0].ID
+
+	// Download client (qBittorrent stub).
+	dcBody := qbtDownloadClientBody("e2e-sonarr-qbt", qbtPort, "sonarr")
+
+	if err := c.post("/api/v3/downloadclient", dcBody, nil); err != nil {
+		return 0, fmt.Errorf("add download client: %w", err)
+	}
+
+	// Look up The Lone Ranger by TVDB ID.
+	var lookupResults []json.RawMessage
+
+	if err := c.get("/api/v3/series/lookup?term=tvdb:72059", &lookupResults); err != nil {
+		return 0, fmt.Errorf("lookup series tvdb:72059: %w", err)
+	}
+
+	if len(lookupResults) == 0 {
+		return 0, fmt.Errorf("no results for tvdb:72059")
+	}
+
+	var lookupSeries map[string]any
+
+	if err := json.Unmarshal(lookupResults[0], &lookupSeries); err != nil {
+		return 0, fmt.Errorf("unmarshal lookup result: %w", err)
+	}
+
+	// Overlay mandatory add fields.
+	lookupSeries["qualityProfileId"] = profileID
+	lookupSeries["rootFolderPath"] = "/tv"
+	lookupSeries["monitored"] = false
+	lookupSeries["seasonFolder"] = true
+	lookupSeries["addOptions"] = map[string]any{
+		"searchForMissingEpisodes":     false,
+		"searchForCutoffUnmetEpisodes": false,
+		"monitor":                      "none",
+	}
+
+	var addedSeries struct {
+		ID    int    `json:"id"`
+		Title string `json:"title"`
+	}
+
+	if err := c.post("/api/v3/series", lookupSeries, &addedSeries); err != nil {
+		return 0, fmt.Errorf("add series: %w", err)
+	}
+
+	if addedSeries.ID == 0 {
+		return 0, fmt.Errorf("Sonarr returned series ID 0")
+	}
+
+	log.Printf("e2e: added Sonarr series %q (ID %d)", addedSeries.Title, addedSeries.ID)
+
+	return addedSeries.ID, nil
+}
+
+// qbtDownloadClientBody returns the JSON body for adding a qBittorrent download client
+// to Radarr or Sonarr. category should be "radarr" or "sonarr".
+func qbtDownloadClientBody(name string, port int, category string) map[string]any {
+	return map[string]any{
+		"name":           name,
+		"enable":         true,
+		"protocol":       "torrent",
+		"priority":       1,
+		"implementation": "QBittorrent",
+		"configContract": "QBittorrentSettings",
+		"fields": []map[string]any{
+			{"name": "host", "value": "host.docker.internal"},
+			{"name": "port", "value": port},
+			{"name": "useSsl", "value": false},
+			{"name": "urlBase", "value": ""},
+			{"name": "username", "value": ""},
+			{"name": "password", "value": ""},
+			{"name": "category", "value": category},
+			{"name": "initialState", "value": 0},
+			{"name": "sequentialOrder", "value": false},
+			{"name": "firstAndLast", "value": false},
+		},
+	}
+}
+
+// ---- watcher + worker subprocesses --------------------------------------
+
+func startProcesses() error {
+	var err error
+
+	binDir, err = os.MkdirTemp("", "e2e-bins-*")
+	if err != nil {
+		return fmt.Errorf("create bin dir: %w", err)
+	}
+
+	root := moduleRoot()
+
+	// Build watcher.
+	watcherBin := filepath.Join(binDir, "watcher")
+
+	if out, err := buildBinary(root, "./cmd/watcher", watcherBin); err != nil {
+		return fmt.Errorf("build watcher: %w\n%s", err, out)
+	}
+
+	// Build worker.
+	workerBin := filepath.Join(binDir, "worker")
+
+	if out, err := buildBinary(root, "./cmd/worker", workerBin); err != nil {
+		return fmt.Errorf("build worker: %w\n%s", err, out)
+	}
+
+	// Write watcher YAML config.
+	watcherCfg := filepath.Join(binDir, "watcher.yaml")
+	cfgContent := fmt.Sprintf("watches:\n"+
+		"  - name: radarr\n    path: %s\n    media_type: movie\n"+
+		"  - name: sonarr\n    path: %s\n    media_type: show\n",
+		filepath.Join(downloadsDir, "radarr"),
+		filepath.Join(downloadsDir, "sonarr"),
+	)
+
+	if err := os.WriteFile(watcherCfg, []byte(cfgContent), 0o644); err != nil {
+		return fmt.Errorf("write watcher config: %w", err)
+	}
+
+	baseEnv := append(os.Environ(),
+		"HATCHET_CLIENT_TOKEN="+hatchetToken,
+		"HATCHET_CLIENT_TLS_STRATEGY=none",
+	)
+
+	// Start watcher subprocess.
+	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
+	watcherCmd.Env = baseEnv
+	watcherCmd.Stdout = os.Stdout
+	watcherCmd.Stderr = os.Stderr
+
+	if err := watcherCmd.Start(); err != nil {
+		return fmt.Errorf("start watcher: %w", err)
+	}
+
+	log.Printf("e2e: watcher started (PID %d)", watcherCmd.Process.Pid)
+
+	// Start worker subprocess with path-translation env vars.
+	workerEnv := append(baseEnv,
+		"MEDIA_OUTPUT_DIR="+processedDir,
+		"MEDIA_WATCHER_ROOT="+downloadsDir,
+		"RADARR_URL="+radarrBase,
+		"RADARR_API_KEY="+radarrAPIKey,
+		"SONARR_URL="+sonarrBase,
+		"SONARR_API_KEY="+sonarrAPIKey,
+		"RADARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "radarr"),
+		"RADARR_REMOTE_PATH_PREFIX=/downloads",
+		"SONARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "sonarr"),
+		"SONARR_REMOTE_PATH_PREFIX=/downloads",
+	)
+
+	workerCmd = exec.Command(workerBin)
+	workerCmd.Env = workerEnv
+	workerCmd.Stdout = os.Stdout
+	workerCmd.Stderr = os.Stderr
+
+	if err := workerCmd.Start(); err != nil {
+		return fmt.Errorf("start worker: %w", err)
+	}
+
+	log.Printf("e2e: worker started (PID %d)", workerCmd.Process.Pid)
+
+	return nil
+}
+
+func stopProcesses() {
+	for _, cmd := range []*exec.Cmd{watcherCmd, workerCmd} {
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}
+
+	if binDir != "" {
+		_ = os.RemoveAll(binDir)
+	}
+}
+
+func buildBinary(moduleRoot, pkg, out string) ([]byte, error) {
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Dir = moduleRoot
+
+	return cmd.CombinedOutput()
+}
+
+// moduleRoot returns the absolute path of the Go module root by invoking
+// `go env GOMOD`.
+func moduleRoot() string {
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	if err == nil {
+		mod := strings.TrimSpace(string(out))
+		if mod != "" && mod != os.DevNull {
+			return filepath.Dir(mod)
+		}
+	}
+
+	// Fallback: test runs from e2e/, so module root is one level up.
+	abs, _ := filepath.Abs("..")
+
+	return abs
+}
+
+// ---- polling helpers ----------------------------------------------------
+
+// pollUntil calls cond repeatedly with interval spacing until it returns nil or
+// ctx is done. It calls cond immediately on the first iteration.
+func pollUntil(ctx context.Context, interval time.Duration, cond func() error) error {
+	for {
+		if err := cond(); err == nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// ---- Tests --------------------------------------------------------------
+
+// TestRadarrHappyPath pushes a Big Buck Bunny release to Radarr, waits for the
+// pipeline to transcode it and notify Radarr, then verifies the movie is
+// imported and the original .mp4 source file has been deleted.
+func TestRadarrHappyPath(t *testing.T) {
+	radarr := newArrClient(radarrBase, radarrAPIKey)
+
+	const releaseTitle = "Big.Buck.Bunny.2008.1080p.WEB-DL"
+
+	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 1, releaseTitle)
+
+	require.NoError(t, radarr.post("/api/v3/release/push", map[string]any{
+		"title":       releaseTitle,
+		"downloadUrl": magnet,
+		"protocol":    "Torrent",
+		"publishDate": time.Now().UTC().Format(time.RFC3339),
+		"indexer":     "e2e-test",
+		"size":        700_000_000,
+	}, nil), "push release to Radarr")
+
+	// Poll until Radarr has imported the movie (hasFile=true).
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	err := pollUntil(ctx, 10*time.Second, func() error {
+		var movie struct {
+			HasFile bool `json:"hasFile"`
+		}
+
+		if err := radarr.get(fmt.Sprintf("/api/v3/movie/%d", radarrMovieID), &movie); err != nil {
+			return err
+		}
+
+		if !movie.HasFile {
+			return fmt.Errorf("movie not yet imported")
+		}
+
+		return nil
+	})
+	require.NoError(t, err, "Radarr did not import the movie within the timeout")
+
+	// Source .mp4 must be deleted by the worker's cleanup step.
+	sourceMp4 := filepath.Join(downloadsDir, "radarr", releaseTitle+".mp4")
+	_, statErr := os.Stat(sourceMp4)
+
+	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+
+	// .mkv must exist somewhere under the Radarr library directory.
+	foundMKV := findMKV(t, filepath.Join(processedDir, "radarr-library"))
+
+	assert.True(t, foundMKV, "expected .mkv in radarr-library after import")
+}
+
+// TestSonarrHappyPath pushes an S01E01 release to Sonarr, waits for the
+// pipeline to transcode it and notify Sonarr, then verifies an episode file
+// was imported and the original .mp4 source file has been deleted.
+func TestSonarrHappyPath(t *testing.T) {
+	sonarr := newArrClient(sonarrBase, sonarrAPIKey)
+
+	const releaseTitle = "The.Lone.Ranger.S01E01.1080p.WEB-DL"
+
+	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 2, releaseTitle)
+
+	require.NoError(t, sonarr.post("/api/v3/release/push", map[string]any{
+		"title":       releaseTitle,
+		"downloadUrl": magnet,
+		"protocol":    "Torrent",
+		"publishDate": time.Now().UTC().Format(time.RFC3339),
+		"indexer":     "e2e-test",
+		"size":        700_000_000,
+	}, nil), "push release to Sonarr")
+
+	// Poll until Sonarr has at least one imported episode file.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	err := pollUntil(ctx, 10*time.Second, func() error {
+		var files []struct {
+			ID int `json:"id"`
+		}
+
+		if err := sonarr.get(fmt.Sprintf("/api/v3/episodefile?seriesId=%d", sonarrSeriesID), &files); err != nil {
+			return err
+		}
+
+		if len(files) == 0 {
+			return fmt.Errorf("no episode files imported yet")
+		}
+
+		return nil
+	})
+	require.NoError(t, err, "Sonarr did not import any episode file within the timeout")
+
+	// Source .mp4 must be deleted by the worker's cleanup step.
+	sourceMp4 := filepath.Join(downloadsDir, "sonarr", releaseTitle+".mp4")
+	_, statErr := os.Stat(sourceMp4)
+
+	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+
+	// .mkv must exist somewhere under the Sonarr library directory.
+	foundMKV := findMKV(t, filepath.Join(processedDir, "sonarr-library"))
+
+	assert.True(t, foundMKV, "expected .mkv in sonarr-library after import")
+}
+
+// findMKV returns true if any .mkv file exists under dir.
+func findMKV(t *testing.T, dir string) bool {
+	t.Helper()
+
+	var found bool
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() && strings.HasSuffix(strings.ToLower(path), ".mkv") {
+			found = true
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	return found
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -36,6 +36,10 @@ const (
 	bbbMP4Name = "bbb_sunflower_1080p_30fps_normal.mp4"
 )
 
+// log is a package-level slog.Logger tagged with source="e2e" so test-harness
+// messages are distinguishable from subprocess output in interleaved logs.
+var log = slog.Default().With("source", "e2e") //nolint:gochecknoglobals
+
 // Package-level state set during TestMain and shared across test functions.
 var (
 	hatchetToken    string
@@ -46,7 +50,7 @@ var (
 
 func TestMain(m *testing.M) {
 	if err := run(m); err != nil {
-		slog.Error("e2e run failed", "error", err)
+		log.Error("e2e run failed", "error", err)
 		os.Exit(1)
 	}
 }
@@ -77,7 +81,7 @@ func run(m *testing.M) error {
 
 	defer qbtStub.Close()
 
-	slog.Info("qBittorrent stub listening", "port", qbtStub.Port())
+	log.Info("qBittorrent stub listening", "port", qbtStub.Port())
 
 	// 4. Pull Docker images (may download several hundred MB on first run).
 	pullCtx, pullCancel := context.WithTimeout(context.Background(), 20*time.Minute)
@@ -119,7 +123,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("configureRadarr: %w", err)
 	}
 
-	slog.Info("Radarr configured", "movieID", radarrMovieID)
+	log.Info("Radarr configured", "movieID", radarrMovieID)
 
 	// 9. Configure Sonarr (root folder, quality profile, download client, series).
 	sonarrSeriesID, err = configureSonarr(qbtStub.Port())
@@ -127,7 +131,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("configureSonarr: %w", err)
 	}
 
-	slog.Info("Sonarr configured", "seriesID", sonarrSeriesID)
+	log.Info("Sonarr configured", "seriesID", sonarrSeriesID)
 
 	// Fetch S01E01 episode ID for use in the Sonarr release push.
 	sonarrEpisodeID, err = fetchSonarrS01E01(sonarrSeriesID)
@@ -135,7 +139,7 @@ func run(m *testing.M) error {
 		return fmt.Errorf("fetchSonarrS01E01: %w", err)
 	}
 
-	slog.Info("Sonarr S01E01 fetched", "episodeID", sonarrEpisodeID)
+	log.Info("Sonarr S01E01 fetched", "episodeID", sonarrEpisodeID)
 
 	// 10. Build watcher and worker binaries, write watcher config, start both.
 	if err = startProcesses(); err != nil {

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -6,7 +6,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -25,12 +24,12 @@ func ensureBBBFixture() (string, error) {
 	mp4Path := filepath.Join(cacheDir, bbbMP4Name)
 
 	if _, err := os.Stat(mp4Path); err == nil {
-		slog.Info("BBB fixture already cached", "path", mp4Path)
+		log.Info("BBB fixture already cached", "path", mp4Path)
 
 		return mp4Path, nil
 	}
 
-	slog.Info("downloading BBB fixture", "url", bbbZipURL)
+	log.Info("downloading BBB fixture", "url", bbbZipURL)
 
 	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
 
@@ -38,7 +37,7 @@ func ensureBBBFixture() (string, error) {
 		return "", fmt.Errorf("download BBB zip: %w", err)
 	}
 
-	slog.Info("extracting BBB mp4 from zip")
+	log.Info("extracting BBB mp4 from zip")
 
 	if err := extractFromZip(zipPath, bbbMP4Name, mp4Path); err != nil {
 		_ = os.Remove(zipPath)
@@ -49,7 +48,7 @@ func ensureBBBFixture() (string, error) {
 	// Remove the zip; only the mp4 needs to be cached.
 	_ = os.Remove(zipPath)
 
-	slog.Info("BBB fixture cached", "path", mp4Path)
+	log.Info("BBB fixture cached", "path", mp4Path)
 
 	return mp4Path, nil
 }

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// ---- BBB fixture --------------------------------------------------------
+
+func ensureBBBFixture() (string, error) {
+	// testdata/cache/ is relative to the e2e package directory.
+	cacheDir := "testdata/cache"
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir cache: %w", err)
+	}
+
+	mp4Path := filepath.Join(cacheDir, bbbMP4Name)
+
+	if _, err := os.Stat(mp4Path); err == nil {
+		log.Printf("e2e: BBB fixture already cached at %s", mp4Path)
+
+		return mp4Path, nil
+	}
+
+	log.Printf("e2e: downloading BBB fixture from %s (this may take a while)...", bbbZipURL)
+
+	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
+
+	if err := downloadFile(bbbZipURL, zipPath); err != nil {
+		return "", fmt.Errorf("download BBB zip: %w", err)
+	}
+
+	log.Printf("e2e: extracting BBB mp4 from zip...")
+
+	if err := extractFromZip(zipPath, bbbMP4Name, mp4Path); err != nil {
+		_ = os.Remove(zipPath)
+
+		return "", fmt.Errorf("extract BBB mp4: %w", err)
+	}
+
+	// Remove the zip; only the mp4 needs to be cached.
+	_ = os.Remove(zipPath)
+
+	log.Printf("e2e: BBB fixture cached at %s", mp4Path)
+
+	return mp4Path, nil
+}
+
+func downloadFile(rawURL, dest string) error {
+	resp, err := http.Get(rawURL) //nolint:noctx // setup code, no request context needed
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = f.Close() }()
+
+	_, err = io.Copy(f, resp.Body)
+
+	return err
+}
+
+// extractFromZip extracts the first file named targetName (basename match) from
+// the zip at zipPath into destPath. It writes to a .tmp file first and renames
+// on success to ensure the cached file is always complete.
+func extractFromZip(zipPath, targetName, destPath string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = r.Close() }()
+
+	for _, file := range r.File {
+		if filepath.Base(file.Name) != targetName {
+			continue
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return fmt.Errorf("open zip entry %s: %w", file.Name, err)
+		}
+
+		tmpPath := destPath + ".tmp"
+
+		out, err := os.Create(tmpPath)
+		if err != nil {
+			_ = rc.Close()
+
+			return err
+		}
+
+		if _, err = io.Copy(out, rc); err != nil {
+			_ = rc.Close()
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
+
+			return fmt.Errorf("copy entry: %w", err)
+		}
+
+		_ = rc.Close()
+
+		if err = out.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return err
+		}
+
+		return os.Rename(tmpPath, destPath)
+	}
+
+	return fmt.Errorf("entry %q not found in zip", targetName)
+}

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -16,12 +16,7 @@ import (
 
 func ensureBBBFixture() (string, error) {
 	// testdata/cache/ is relative to the e2e package directory.
-	// Use an absolute path so that callers (e.g. the qbt stub) can use it as a
-	// symlink target that resolves correctly regardless of working directory.
-	cacheDir, err := filepath.Abs("testdata/cache")
-	if err != nil {
-		return "", fmt.Errorf("abs cache dir: %w", err)
-	}
+	cacheDir := "testdata/cache"
 
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("mkdir cache: %w", err)

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -16,7 +16,12 @@ import (
 
 func ensureBBBFixture() (string, error) {
 	// testdata/cache/ is relative to the e2e package directory.
-	cacheDir := "testdata/cache"
+	// Use an absolute path so that callers (e.g. the qbt stub) can use it as a
+	// symlink target that resolves correctly regardless of working directory.
+	cacheDir, err := filepath.Abs("testdata/cache")
+	if err != nil {
+		return "", fmt.Errorf("abs cache dir: %w", err)
+	}
 
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("mkdir cache: %w", err)

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -6,7 +6,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -25,12 +25,12 @@ func ensureBBBFixture() (string, error) {
 	mp4Path := filepath.Join(cacheDir, bbbMP4Name)
 
 	if _, err := os.Stat(mp4Path); err == nil {
-		log.Printf("e2e: BBB fixture already cached at %s", mp4Path)
+		slog.Info("BBB fixture already cached", "path", mp4Path)
 
 		return mp4Path, nil
 	}
 
-	log.Printf("e2e: downloading BBB fixture from %s (this may take a while)...", bbbZipURL)
+	slog.Info("downloading BBB fixture", "url", bbbZipURL)
 
 	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
 
@@ -38,7 +38,7 @@ func ensureBBBFixture() (string, error) {
 		return "", fmt.Errorf("download BBB zip: %w", err)
 	}
 
-	log.Printf("e2e: extracting BBB mp4 from zip...")
+	slog.Info("extracting BBB mp4 from zip")
 
 	if err := extractFromZip(zipPath, bbbMP4Name, mp4Path); err != nil {
 		_ = os.Remove(zipPath)
@@ -49,7 +49,7 @@ func ensureBBBFixture() (string, error) {
 	// Remove the zip; only the mp4 needs to be cached.
 	_ = os.Remove(zipPath)
 
-	log.Printf("e2e: BBB fixture cached at %s", mp4Path)
+	slog.Info("BBB fixture cached", "path", mp4Path)
 
 	return mp4Path, nil
 }

--- a/e2e/fixture_test.go
+++ b/e2e/fixture_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 
 // ---- BBB fixture --------------------------------------------------------
 
-func ensureBBBFixture() (string, error) {
+func ensureBBBFixture(ctx context.Context) (string, error) {
 	// testdata/cache/ is relative to the e2e package directory.
 	cacheDir := "testdata/cache"
 
@@ -33,7 +34,7 @@ func ensureBBBFixture() (string, error) {
 
 	zipPath := filepath.Join(cacheDir, bbbMP4Name+".zip")
 
-	if err := downloadFile(bbbZipURL, zipPath); err != nil {
+	if err := downloadFile(ctx, bbbZipURL, zipPath); err != nil {
 		return "", fmt.Errorf("download BBB zip: %w", err)
 	}
 
@@ -53,8 +54,13 @@ func ensureBBBFixture() (string, error) {
 	return mp4Path, nil
 }
 
-func downloadFile(rawURL, dest string) error {
-	resp, err := http.Get(rawURL) //nolint:noctx // setup code, no request context needed
+func downloadFile(ctx context.Context, rawURL, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -108,6 +108,7 @@ func probeOutputFile(t *testing.T, path string) outputFileInfo {
 	for _, stream := range result.Streams {
 		if stream.CodecType == "video" {
 			info.videoCodec = stream.CodecName
+			break
 		}
 	}
 

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -3,8 +3,12 @@
 package e2e_test
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"io/fs"
+	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -13,6 +17,40 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// slogWriter is an io.Writer that forwards each line of subprocess output to
+// slog at the given level, tagged with the source label (e.g. "docker", "make").
+type slogWriter struct {
+	level  slog.Level
+	source string
+	buf    []byte
+}
+
+func (w *slogWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+
+	for {
+		idx := bytes.IndexByte(w.buf, '\n')
+		if idx < 0 {
+			break
+		}
+
+		line := string(bytes.TrimRight(w.buf[:idx], "\r"))
+		if line != "" {
+			slog.Log(context.Background(), w.level, line, "source", w.source)
+		}
+
+		w.buf = w.buf[idx+1:]
+	}
+
+	return len(p), nil
+}
+
+// newSlogWriter returns an io.Writer that routes subprocess output to slog.
+// Use LevelInfo for stdout and LevelWarn for stderr.
+func newSlogWriter(level slog.Level, source string) io.Writer {
+	return &slogWriter{level: level, source: source}
+}
 
 // outputFileInfo holds the key media properties of a transcoded output file,
 // as reported by ffprobe.
@@ -94,4 +132,3 @@ func findMKV(t *testing.T, dir string) string {
 
 	return found
 }
-

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// outputFileInfo holds the key media properties of a transcoded output file,
+// as reported by ffprobe.
+type outputFileInfo struct {
+	formatName  string
+	videoCodec  string
+	durationSec float64
+}
+
+// probeOutputFile runs ffprobe on the file at path and returns its media
+// properties. The test fails immediately if ffprobe cannot be executed or the
+// output cannot be parsed.
+func probeOutputFile(t *testing.T, path string) outputFileInfo {
+	t.Helper()
+
+	cmd := exec.Command("ffprobe",
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		path,
+	)
+
+	out, err := cmd.Output()
+	require.NoError(t, err, "ffprobe failed on %s", path)
+
+	var result struct {
+		Format struct {
+			FormatName string `json:"format_name"`
+			Duration   string `json:"duration"`
+		} `json:"format"`
+		Streams []struct {
+			CodecType string `json:"codec_type"`
+			CodecName string `json:"codec_name"`
+		} `json:"streams"`
+	}
+
+	require.NoError(t, json.Unmarshal(out, &result), "parse ffprobe output for %s", path)
+
+	info := outputFileInfo{
+		formatName: result.Format.FormatName,
+	}
+
+	for _, stream := range result.Streams {
+		if stream.CodecType == "video" {
+			info.videoCodec = stream.CodecName
+		}
+	}
+
+	if d, parseErr := strconv.ParseFloat(result.Format.Duration, 64); parseErr == nil {
+		info.durationSec = d
+	}
+
+	return info
+}
+
+// findMKV walks dir and returns the path of the first .mkv file found.
+// Returns an empty string if no .mkv is present.
+func findMKV(t *testing.T, dir string) string {
+	t.Helper()
+
+	var found string
+
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !entry.IsDir() && strings.HasSuffix(strings.ToLower(path), ".mkv") {
+			found = path
+
+			return fs.SkipAll
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err, "walking %s for .mkv", dir)
+
+	return found
+}
+

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -77,7 +77,7 @@ type outputFileInfo struct {
 func probeOutputFile(t *testing.T, path string) outputFileInfo {
 	t.Helper()
 
-	cmd := exec.Command("ffprobe",
+	cmd := exec.CommandContext(t.Context(), "ffprobe",
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_format",

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os/exec"
@@ -46,9 +45,21 @@ func (w *slogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// newSlogWriter returns an io.Writer that routes subprocess output to slog.
+// Flush emits any buffered output that did not end with a newline.
+// Call this after the subprocess exits to avoid losing the final partial line.
+func (w *slogWriter) Flush() {
+	line := string(bytes.TrimRight(w.buf, "\r"))
+	if line != "" {
+		slog.Log(context.Background(), w.level, line, "source", w.source)
+	}
+
+	w.buf = nil
+}
+
+// newSlogWriter returns a *slogWriter that routes subprocess output to slog.
 // Use LevelInfo for stdout and LevelWarn for stderr.
-func newSlogWriter(level slog.Level, source string) io.Writer {
+// Call Flush after the subprocess exits to emit any final partial line.
+func newSlogWriter(level slog.Level, source string) *slogWriter {
 	return &slogWriter{level: level, source: source}
 }
 

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -80,13 +80,4 @@ func TestRadarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
-
-	// debugging: copy the output file to /workspace/media-processor for manual inspection after the test completes
-	debugDest := filepath.Join("/workspace/media-processor", "radarr_happy_path_output.mkv")
-	if err := copyFile(mkvPath, debugDest); err != nil {
-		t.Logf("failed to copy output file for debugging: %v", err)
-		return
-	}
-
-	t.Logf("copied output file to %s for debugging", debugDest)
 }

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -80,4 +80,13 @@ func TestRadarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+
+	// debugging: copy the output file to /workspace/media-processor for manual inspection after the test completes
+	debugDest := filepath.Join("/workspace/media-processor", "radarr_happy_path_output.mkv")
+	if err := copyFile(mkvPath, debugDest); err != nil {
+		t.Logf("failed to copy output file for debugging: %v", err)
+		return
+	}
+
+	t.Logf("copied output file to %s for debugging", debugDest)
 }

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRadarrHappyPath pushes a Big Buck Bunny release to Radarr, waits for the
+// pipeline to transcode it and notify Radarr, then verifies the movie is
+// imported, the original .mp4 source file has been deleted, and the output
+// file has the expected media properties.
+func TestRadarrHappyPath(t *testing.T) {
+	radarr := newArrClient(radarrBase, radarrAPIKey)
+
+	const releaseTitle = "Big.Buck.Bunny.2008.1080p.WEB-DL"
+
+	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 1, releaseTitle)
+
+	var pushResp []json.RawMessage
+
+	require.NoError(t, radarr.post("/api/v3/release/push", map[string]any{
+		"title":       releaseTitle,
+		"downloadUrl": magnet,
+		"protocol":    "Torrent",
+		"publishDate": time.Now().UTC().Format(time.RFC3339),
+		"indexer":     "e2e-test",
+		"size":        700_000_000,
+		"movieId":     radarrMovieID,
+	}, &pushResp), "push release to Radarr")
+
+	if len(pushResp) > 0 {
+		t.Logf("Radarr push response: %s", pushResp)
+	}
+
+	// Poll until Radarr has imported the movie (hasFile=true).
+	// The timeout is set generously to accommodate a full H.265 software encode
+	// of the BBB fixture on machines without hardware acceleration.
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
+	defer cancel()
+
+	err := pollUntil(ctx, 10*time.Second, func() error {
+		var movie struct {
+			HasFile bool `json:"hasFile"`
+		}
+
+		if err := radarr.get(fmt.Sprintf("/api/v3/movie/%d", radarrMovieID), &movie); err != nil {
+			return err
+		}
+
+		if !movie.HasFile {
+			return fmt.Errorf("movie not yet imported")
+		}
+
+		return nil
+	})
+	require.NoError(t, err, "Radarr did not import the movie within the timeout")
+
+	// Source .mp4 must be deleted by the worker's cleanup step.
+	sourceMp4 := filepath.Join(downloadsDir, "radarr", releaseTitle+".mp4")
+	_, statErr := os.Stat(sourceMp4)
+
+	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+
+	// .mkv must exist somewhere under the Radarr library directory.
+	mkvPath := findMKV(t, filepath.Join(processedDir, "radarr-library"))
+	require.NotEmpty(t, mkvPath, "expected .mkv in radarr-library after import")
+
+	// Verify output file properties.
+	info := probeOutputFile(t, mkvPath)
+	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
+	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
+	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+}

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -45,7 +45,7 @@ func TestRadarrHappyPath(t *testing.T) {
 	// Poll until Radarr has imported the movie (hasFile=true).
 	// The timeout is set generously to accommodate a full H.265 software encode
 	// of the BBB fixture on machines without hardware acceleration.
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Minute)
 	defer cancel()
 
 	err := pollUntil(ctx, 10*time.Second, func() error {

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -39,7 +39,11 @@ func TestRadarrHappyPath(t *testing.T) {
 	}, &pushResp), "push release to Radarr")
 
 	if len(pushResp) > 0 {
-		t.Logf("Radarr push response: %s", pushResp)
+		if respJSON, marshalErr := json.Marshal(pushResp); marshalErr != nil {
+			t.Logf("Radarr push response (failed to marshal as JSON: %v): %+v", marshalErr, pushResp)
+		} else {
+			t.Logf("Radarr push response: %s", respJSON)
+		}
 	}
 
 	// Poll until Radarr has imported the movie (hasFile=true).

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -28,7 +28,7 @@ func TestRadarrHappyPath(t *testing.T) {
 
 	var pushResp []json.RawMessage
 
-	require.NoError(t, radarr.post("/api/v3/release/push", map[string]any{
+	require.NoError(t, radarr.post(t.Context(), "/api/v3/release/push", map[string]any{
 		"title":       releaseTitle,
 		"downloadUrl": magnet,
 		"protocol":    "Torrent",
@@ -53,7 +53,7 @@ func TestRadarrHappyPath(t *testing.T) {
 			HasFile bool `json:"hasFile"`
 		}
 
-		if err := radarr.get(fmt.Sprintf("/api/v3/movie/%d", radarrMovieID), &movie); err != nil {
+		if err := radarr.get(ctx, fmt.Sprintf("/api/v3/movie/%d", radarrMovieID), &movie); err != nil {
 			return err
 		}
 
@@ -69,7 +69,7 @@ func TestRadarrHappyPath(t *testing.T) {
 	sourceMp4 := filepath.Join(downloadsDir, "radarr", releaseTitle+".mp4")
 	_, statErr := os.Stat(sourceMp4)
 
-	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "source .mp4 should have been deleted after import")
 
 	// .mkv must exist somewhere under the Radarr library directory.
 	mkvPath := findMKV(t, filepath.Join(processedDir, "radarr-library"))

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -24,10 +24,6 @@ var (
 // ---- directory management -----------------------------------------------
 
 func resetDirs() error {
-	if err := os.RemoveAll(baseDir); err != nil {
-		return fmt.Errorf("remove base dir: %w", err)
-	}
-
 	for _, dir := range []string{
 		filepath.Join(downloadsDir, "radarr"),
 		filepath.Join(downloadsDir, "sonarr"),

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -67,27 +67,49 @@ func composeEnv() []string {
 func composePull(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "docker", composeArgs("pull")...)
 	cmd.Env = composeEnv()
-	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
-	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
+	stdout := newSlogWriter(slog.LevelInfo, "docker")
+	stderr := newSlogWriter(slog.LevelWarn, "docker")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
-	return cmd.Run()
+	err := cmd.Run()
+
+	stdout.Flush()
+	stderr.Flush()
+
+	return err
 }
 
 func composeUp() error {
-	cmd := exec.Command("docker", composeArgs("up", "-d")...)
-	cmd.Env = composeEnv()
-	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
-	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 
-	return cmd.Run()
+	cmd := exec.CommandContext(ctx, "docker", composeArgs("up", "-d")...)
+	cmd.Env = composeEnv()
+	stdout := newSlogWriter(slog.LevelInfo, "docker")
+	stderr := newSlogWriter(slog.LevelWarn, "docker")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+
+	stdout.Flush()
+	stderr.Flush()
+
+	return err
 }
 
 func composeDown() {
 	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
 	cmd.Env = composeEnv()
-	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
-	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
+	stdout := newSlogWriter(slog.LevelInfo, "docker")
+	stderr := newSlogWriter(slog.LevelWarn, "docker")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	_ = cmd.Run()
+
+	stdout.Flush()
+	stderr.Flush()
 
 	_ = os.RemoveAll(baseDir)
 }
@@ -197,11 +219,18 @@ func startProcesses() error {
 	// Build watcher and worker using the Makefile target.
 	buildCmd := exec.Command("make", "build")
 	buildCmd.Dir = root
-	buildCmd.Stdout = newSlogWriter(slog.LevelInfo, "make")
-	buildCmd.Stderr = newSlogWriter(slog.LevelWarn, "make")
+	buildStdout := newSlogWriter(slog.LevelInfo, "make")
+	buildStderr := newSlogWriter(slog.LevelWarn, "make")
+	buildCmd.Stdout = buildStdout
+	buildCmd.Stderr = buildStderr
 
-	if err := buildCmd.Run(); err != nil {
-		return fmt.Errorf("make build: %w", err)
+	buildErr := buildCmd.Run()
+
+	buildStdout.Flush()
+	buildStderr.Flush()
+
+	if buildErr != nil {
+		return fmt.Errorf("make build: %w", buildErr)
 	}
 
 	watcherBin := filepath.Join(root, "bin", "watcher")

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -324,10 +324,15 @@ func moduleRoot() string {
 // ---- polling helpers ----------------------------------------------------
 
 // pollUntil calls cond repeatedly with interval spacing until it returns nil or
-// ctx is done. It calls cond immediately on the first iteration.
+// ctx is done. It calls cond immediately on the first iteration. When ctx is
+// cancelled or times out, the returned error wraps both ctx.Err() and the last
+// error returned by cond so callers can see what was still failing at deadline.
 func pollUntil(ctx context.Context, interval time.Duration, cond func() error) error {
+	var lastErr error
+
 	for {
-		if err := cond(); err == nil {
+		lastErr = cond()
+		if lastErr == nil {
 			return nil
 		}
 
@@ -335,7 +340,7 @@ func pollUntil(ctx context.Context, interval time.Duration, cond func() error) e
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ctx.Err()
+			return fmt.Errorf("%w; last condition error: %w", ctx.Err(), lastErr)
 		case <-timer.C:
 		}
 	}

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -5,7 +5,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -54,24 +54,24 @@ func composeArgs(subcmd ...string) []string {
 // It uses ctx to enforce a timeout for potentially large image downloads.
 func composePull(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "docker", composeArgs("pull")...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
+	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 
 	return cmd.Run()
 }
 
 func composeUp() error {
 	cmd := exec.Command("docker", composeArgs("up", "-d")...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
+	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 
 	return cmd.Run()
 }
 
 func composeDown() {
 	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
+	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 	_ = cmd.Run()
 
 	_ = os.RemoveAll(baseDir)
@@ -91,13 +91,13 @@ func waitForServices(ctx context.Context) error {
 	}
 
 	for _, service := range services {
-		log.Printf("e2e: waiting for %s...", service.name)
+		slog.Info("waiting for service", "name", service.name)
 
 		if err := pollUntil(ctx, 5*time.Second, service.fn); err != nil {
 			return fmt.Errorf("%s not ready: %w", service.name, err)
 		}
 
-		log.Printf("e2e: %s ready", service.name)
+		slog.Info("service ready", "name", service.name)
 	}
 
 	return nil
@@ -174,8 +174,8 @@ func startProcesses() error {
 	// Build watcher and worker using the Makefile target.
 	buildCmd := exec.Command("make", "build")
 	buildCmd.Dir = root
-	buildCmd.Stdout = os.Stdout
-	buildCmd.Stderr = os.Stderr
+	buildCmd.Stdout = newSlogWriter(slog.LevelInfo, "make")
+	buildCmd.Stderr = newSlogWriter(slog.LevelWarn, "make")
 
 	if err := buildCmd.Run(); err != nil {
 		return fmt.Errorf("make build: %w", err)
@@ -205,14 +205,14 @@ func startProcesses() error {
 	// Start watcher subprocess.
 	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
 	watcherCmd.Env = baseEnv
-	watcherCmd.Stdout = os.Stdout
-	watcherCmd.Stderr = os.Stderr
+	watcherCmd.Stdout = newSlogWriter(slog.LevelInfo, "watcher")
+	watcherCmd.Stderr = newSlogWriter(slog.LevelWarn, "watcher")
 
 	if err := watcherCmd.Start(); err != nil {
 		return fmt.Errorf("start watcher: %w", err)
 	}
 
-	log.Printf("e2e: watcher started (PID %d)", watcherCmd.Process.Pid)
+	slog.Info("watcher started", "pid", watcherCmd.Process.Pid)
 
 	// Start worker subprocess with path-translation env vars.
 	workerEnv := append(baseEnv,
@@ -230,14 +230,14 @@ func startProcesses() error {
 
 	workerCmd = exec.Command(workerBin)
 	workerCmd.Env = workerEnv
-	workerCmd.Stdout = os.Stdout
-	workerCmd.Stderr = os.Stderr
+	workerCmd.Stdout = newSlogWriter(slog.LevelInfo, "worker")
+	workerCmd.Stderr = newSlogWriter(slog.LevelWarn, "worker")
 
 	if err := workerCmd.Start(); err != nil {
 		return fmt.Errorf("start worker: %w", err)
 	}
 
-	log.Printf("e2e: worker started (PID %d)", workerCmd.Process.Pid)
+	slog.Info("worker started", "pid", workerCmd.Process.Pid)
 
 	return nil
 }

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -50,10 +51,22 @@ func composeArgs(subcmd ...string) []string {
 	return append(args, subcmd...)
 }
 
+// composeEnv returns the current process environment with UID and GID set to
+// the running user's values. docker-compose.yml uses ${UID}:${GID} for the
+// container user field; these variables are not exported by bash by default so
+// they must be injected explicitly.
+func composeEnv() []string {
+	return append(os.Environ(),
+		"UID="+strconv.Itoa(os.Getuid()),
+		"GID="+strconv.Itoa(os.Getgid()),
+	)
+}
+
 // composePull pulls all Docker images declared in docker-compose.yml.
 // It uses ctx to enforce a timeout for potentially large image downloads.
 func composePull(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "docker", composeArgs("pull")...)
+	cmd.Env = composeEnv()
 	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
 	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 
@@ -62,6 +75,7 @@ func composePull(ctx context.Context) error {
 
 func composeUp() error {
 	cmd := exec.Command("docker", composeArgs("up", "-d")...)
+	cmd.Env = composeEnv()
 	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
 	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 
@@ -70,6 +84,7 @@ func composeUp() error {
 
 func composeDown() {
 	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
+	cmd.Env = composeEnv()
 	cmd.Stdout = newSlogWriter(slog.LevelInfo, "docker")
 	cmd.Stderr = newSlogWriter(slog.LevelWarn, "docker")
 	_ = cmd.Run()
@@ -132,6 +147,7 @@ func generateHatchetToken() (string, error) {
 		"psql", "-U", "hatchet", "-d", "hatchet", "-t", "-c",
 		`SELECT id FROM "Tenant" WHERE slug = 'default' LIMIT 1`,
 	)...)
+	tenantCmd.Env = composeEnv()
 
 	tenantOut, err := tenantCmd.Output()
 	if err != nil {
@@ -151,6 +167,7 @@ func generateHatchetToken() (string, error) {
 		"--config", "/hatchet/config",
 		"--tenant-id", tenantID,
 	)...)
+	tokenCmd.Env = composeEnv()
 
 	tokenOut, err := tokenCmd.Output()
 	if err != nil {

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -91,13 +91,13 @@ func waitForServices(ctx context.Context) error {
 	}
 
 	for _, service := range services {
-		slog.Info("waiting for service", "name", service.name)
+		log.Info("waiting for service", "name", service.name)
 
 		if err := pollUntil(ctx, 5*time.Second, service.fn); err != nil {
 			return fmt.Errorf("%s not ready: %w", service.name, err)
 		}
 
-		slog.Info("service ready", "name", service.name)
+		log.Info("service ready", "name", service.name)
 	}
 
 	return nil
@@ -212,7 +212,7 @@ func startProcesses() error {
 		return fmt.Errorf("start watcher: %w", err)
 	}
 
-	slog.Info("watcher started", "pid", watcherCmd.Process.Pid)
+	log.Info("watcher started", "pid", watcherCmd.Process.Pid)
 
 	// Start worker subprocess with path-translation env vars.
 	workerEnv := append(baseEnv,
@@ -237,7 +237,7 @@ func startProcesses() error {
 		return fmt.Errorf("start worker: %w", err)
 	}
 
-	slog.Info("worker started", "pid", workerCmd.Process.Pid)
+	log.Info("worker started", "pid", workerCmd.Process.Pid)
 
 	return nil
 }

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -1,0 +1,291 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Package-level state for the watcher and worker subprocesses.
+var (
+	watcherCmd *exec.Cmd
+	workerCmd  *exec.Cmd
+)
+
+// ---- directory management -----------------------------------------------
+
+func resetDirs() error {
+	if err := os.RemoveAll(baseDir); err != nil {
+		return fmt.Errorf("remove base dir: %w", err)
+	}
+
+	for _, dir := range []string{
+		filepath.Join(downloadsDir, "radarr"),
+		filepath.Join(downloadsDir, "sonarr"),
+		filepath.Join(processedDir, "radarr"),
+		filepath.Join(processedDir, "radarr-library"),
+		filepath.Join(processedDir, "sonarr"),
+		filepath.Join(processedDir, "sonarr-library"),
+		filepath.Join(configDir, "radarr"),
+		filepath.Join(configDir, "sonarr"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+
+	return nil
+}
+
+// ---- Docker Compose -----------------------------------------------------
+
+func composeArgs(subcmd ...string) []string {
+	args := []string{"compose", "-p", "e2e-media-processor", "-f", "docker-compose.yml"}
+
+	return append(args, subcmd...)
+}
+
+// composePull pulls all Docker images declared in docker-compose.yml.
+// It uses ctx to enforce a timeout for potentially large image downloads.
+func composePull(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "docker", composeArgs("pull")...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func composeUp() error {
+	cmd := exec.Command("docker", composeArgs("up", "-d")...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func composeDown() {
+	cmd := exec.Command("docker", composeArgs("down", "-v", "--remove-orphans")...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+
+	_ = os.RemoveAll(baseDir)
+}
+
+// waitForServices polls until Radarr, Sonarr, and the Hatchet gRPC port are up.
+func waitForServices(ctx context.Context) error {
+	type svc struct {
+		name string
+		fn   func() error
+	}
+
+	services := []svc{
+		{"radarr", func() error { return checkHTTP(radarrBase + "/ping") }},
+		{"sonarr", func() error { return checkHTTP(sonarrBase + "/ping") }},
+		{"hatchet-grpc", func() error { return checkTCP("localhost:7079") }},
+	}
+
+	for _, service := range services {
+		log.Printf("e2e: waiting for %s...", service.name)
+
+		if err := pollUntil(ctx, 5*time.Second, service.fn); err != nil {
+			return fmt.Errorf("%s not ready: %w", service.name, err)
+		}
+
+		log.Printf("e2e: %s ready", service.name)
+	}
+
+	return nil
+}
+
+func checkHTTP(url string) error {
+	resp, err := http.Get(url) //nolint:noctx // health poll, no caller context
+	if err != nil {
+		return err
+	}
+
+	_ = resp.Body.Close()
+
+	return nil
+}
+
+func checkTCP(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return err
+	}
+
+	return conn.Close()
+}
+
+// ---- Hatchet token ------------------------------------------------------
+
+func generateHatchetToken() (string, error) {
+	// Query the tenant ID from the e2e postgres container.
+	tenantCmd := exec.Command("docker", composeArgs(
+		"exec", "-T", "postgres",
+		"psql", "-U", "hatchet", "-d", "hatchet", "-t", "-c",
+		`SELECT id FROM "Tenant" WHERE slug = 'default' LIMIT 1`,
+	)...)
+
+	tenantOut, err := tenantCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("query tenant ID: %w", err)
+	}
+
+	tenantID := strings.TrimSpace(string(tenantOut))
+
+	if tenantID == "" {
+		return "", fmt.Errorf("empty tenant ID from postgres")
+	}
+
+	// Generate the token using the setup-config container.
+	tokenCmd := exec.Command("docker", composeArgs(
+		"run", "--no-deps", "--rm", "-T", "setup-config",
+		"/hatchet/hatchet-admin", "token", "create",
+		"--config", "/hatchet/config",
+		"--tenant-id", tenantID,
+	)...)
+
+	tokenOut, err := tokenCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+
+	token := strings.TrimSpace(string(tokenOut))
+
+	if token == "" {
+		return "", fmt.Errorf("empty token from hatchet-admin")
+	}
+
+	return token, nil
+}
+
+// ---- watcher + worker subprocesses --------------------------------------
+
+func startProcesses() error {
+	root := moduleRoot()
+
+	// Build watcher and worker using the Makefile target.
+	buildCmd := exec.Command("make", "build")
+	buildCmd.Dir = root
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("make build: %w", err)
+	}
+
+	watcherBin := filepath.Join(root, "bin", "watcher")
+	workerBin := filepath.Join(root, "bin", "worker")
+
+	// Write watcher YAML config.
+	watcherCfg := filepath.Join(root, "bin", "e2e-watcher.yaml")
+	cfgContent := fmt.Sprintf("watches:\n"+
+		"  - name: radarr\n    path: %s\n    media_type: movie\n"+
+		"  - name: sonarr\n    path: %s\n    media_type: show\n",
+		filepath.Join(downloadsDir, "radarr"),
+		filepath.Join(downloadsDir, "sonarr"),
+	)
+
+	if err := os.WriteFile(watcherCfg, []byte(cfgContent), 0o644); err != nil {
+		return fmt.Errorf("write watcher config: %w", err)
+	}
+
+	baseEnv := append(os.Environ(),
+		"HATCHET_CLIENT_TOKEN="+hatchetToken,
+		"HATCHET_CLIENT_TLS_STRATEGY=none",
+	)
+
+	// Start watcher subprocess.
+	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
+	watcherCmd.Env = baseEnv
+	watcherCmd.Stdout = os.Stdout
+	watcherCmd.Stderr = os.Stderr
+
+	if err := watcherCmd.Start(); err != nil {
+		return fmt.Errorf("start watcher: %w", err)
+	}
+
+	log.Printf("e2e: watcher started (PID %d)", watcherCmd.Process.Pid)
+
+	// Start worker subprocess with path-translation env vars.
+	workerEnv := append(baseEnv,
+		"MEDIA_OUTPUT_DIR="+processedDir,
+		"MEDIA_WATCHER_ROOT="+downloadsDir,
+		"RADARR_URL="+radarrBase,
+		"RADARR_API_KEY="+radarrAPIKey,
+		"SONARR_URL="+sonarrBase,
+		"SONARR_API_KEY="+sonarrAPIKey,
+		"RADARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "radarr"),
+		"RADARR_REMOTE_PATH_PREFIX=/downloads",
+		"SONARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "sonarr"),
+		"SONARR_REMOTE_PATH_PREFIX=/downloads",
+	)
+
+	workerCmd = exec.Command(workerBin)
+	workerCmd.Env = workerEnv
+	workerCmd.Stdout = os.Stdout
+	workerCmd.Stderr = os.Stderr
+
+	if err := workerCmd.Start(); err != nil {
+		return fmt.Errorf("start worker: %w", err)
+	}
+
+	log.Printf("e2e: worker started (PID %d)", workerCmd.Process.Pid)
+
+	return nil
+}
+
+func stopProcesses() {
+	for _, cmd := range []*exec.Cmd{watcherCmd, workerCmd} {
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}
+}
+
+// moduleRoot returns the absolute path of the Go module root by invoking
+// `go env GOMOD`.
+func moduleRoot() string {
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	if err == nil {
+		mod := strings.TrimSpace(string(out))
+		if mod != "" && mod != os.DevNull {
+			return filepath.Dir(mod)
+		}
+	}
+
+	// Fallback: test runs from e2e/, so module root is one level up.
+	abs, _ := filepath.Abs("..")
+
+	return abs
+}
+
+// ---- polling helpers ----------------------------------------------------
+
+// pollUntil calls cond repeatedly with interval spacing until it returns nil or
+// ctx is done. It calls cond immediately on the first iteration.
+func pollUntil(ctx context.Context, interval time.Duration, cond func() error) error {
+	for {
+		if err := cond(); err == nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -119,12 +119,18 @@ func waitForServices(ctx context.Context) error {
 }
 
 func checkHTTP(url string) error {
-	resp, err := http.Get(url) //nolint:noctx // health poll, no caller context
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	resp, err := client.Get(url) //nolint:noctx // health poll, no caller context
 	if err != nil {
 		return err
 	}
 
 	_ = resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("unexpected HTTP status %d", resp.StatusCode)
+	}
 
 	return nil
 }

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -331,10 +331,12 @@ func pollUntil(ctx context.Context, interval time.Duration, cond func() error) e
 			return nil
 		}
 
+		timer := time.NewTimer(interval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(interval):
+		case <-timer.C:
 		}
 	}
 }

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -205,8 +205,9 @@ func startProcesses() error {
 	// Start watcher subprocess.
 	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
 	watcherCmd.Env = baseEnv
-	watcherCmd.Stdout = newSlogWriter(slog.LevelInfo, "watcher")
-	watcherCmd.Stderr = newSlogWriter(slog.LevelWarn, "watcher")
+	// These already use slog so write directly to stdout/stderr to avoid double encapsulation
+	watcherCmd.Stdout = os.Stdout
+	watcherCmd.Stderr = os.Stderr
 
 	if err := watcherCmd.Start(); err != nil {
 		return fmt.Errorf("start watcher: %w", err)
@@ -230,8 +231,8 @@ func startProcesses() error {
 
 	workerCmd = exec.Command(workerBin)
 	workerCmd.Env = workerEnv
-	workerCmd.Stdout = newSlogWriter(slog.LevelInfo, "worker")
-	workerCmd.Stderr = newSlogWriter(slog.LevelWarn, "worker")
+	workerCmd.Stdout = os.Stdout
+	workerCmd.Stderr = os.Stderr
 
 	if err := workerCmd.Start(); err != nil {
 		return fmt.Errorf("start worker: %w", err)

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,35 +88,4 @@ func TestSonarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
-
-	// debugging: copy the output file to /workspace/media-processor for manual inspection after the test completes
-	debugDest := filepath.Join("/workspace/media-processor", "sonarr_happy_path_output.mkv")
-	if err := copyFile(mkvPath, debugDest); err != nil {
-		t.Logf("failed to copy output file for debugging: %v", err)
-		return
-	}
-
-	t.Logf("copied output file to %s for debugging", debugDest)
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("open: %w", err)
-	}
-
-	defer func() { _ = in.Close() }()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return fmt.Errorf("create: %w", err)
-	}
-
-	if _, err = io.Copy(out, in); err != nil {
-		_ = out.Close()
-
-		return fmt.Errorf("copy: %w", err)
-	}
-
-	return out.Close()
 }

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSonarrHappyPath pushes an S01E01 release of Colonel Bleep (TVDB 254376)
+// to Sonarr, waits for the pipeline to transcode it and notify Sonarr, then
+// verifies an episode file was imported, the original .mp4 source file has
+// been deleted, and the output file has the expected media properties.
+//
+// Colonel Bleep (1957) is a public-domain animated series (copyright lapsed
+// without renewal in 1985) with 6-minute episodes. The BBB fixture at ~9:56
+// exceeds Sonarr's 50%-of-episode-runtime sample check (threshold: 3 min).
+func TestSonarrHappyPath(t *testing.T) {
+	sonarr := newArrClient(sonarrBase, sonarrAPIKey)
+
+	// Include the year so Sonarr's title parser resolves "Colonel Bleep" with
+	// year 1957 and matches the library entry stored as "Colonel Bleep (1957)".
+	const releaseTitle = "Colonel.Bleep.1957.S01E01.1080p.WEB-DL"
+
+	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%040x&dn=%s", 2, releaseTitle)
+
+	var sonarrPushResp []json.RawMessage
+
+	require.NoError(t, sonarr.post("/api/v3/release/push", map[string]any{
+		"title":              releaseTitle,
+		"downloadUrl":        magnet,
+		"protocol":           "Torrent",
+		"publishDate":        time.Now().UTC().Format(time.RFC3339),
+		"indexer":            "e2e-test",
+		"size":               700_000_000,
+		"mappedSeriesId":     sonarrSeriesID,
+		"mappedSeasonNumber": 1,
+		"mappedEpisodeIds":   []int{sonarrEpisodeID},
+	}, &sonarrPushResp), "push release to Sonarr")
+
+	if len(sonarrPushResp) > 0 {
+		t.Logf("Sonarr push response: %s", sonarrPushResp)
+	}
+
+	// Poll until Sonarr has at least one imported episode file.
+	// The timeout is set generously to accommodate a full H.265 software encode
+	// of the BBB fixture on machines without hardware acceleration.
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
+	defer cancel()
+
+	err := pollUntil(ctx, 10*time.Second, func() error {
+		var files []struct {
+			ID int `json:"id"`
+		}
+
+		if err := sonarr.get(fmt.Sprintf("/api/v3/episodefile?seriesId=%d", sonarrSeriesID), &files); err != nil {
+			return err
+		}
+
+		if len(files) == 0 {
+			return fmt.Errorf("no episode files imported yet")
+		}
+
+		return nil
+	})
+	require.NoError(t, err, "Sonarr did not import any episode file within the timeout")
+
+	// Source .mp4 must be deleted by the worker's cleanup step.
+	sourceMp4 := filepath.Join(downloadsDir, "sonarr", releaseTitle+".mp4")
+	_, statErr := os.Stat(sourceMp4)
+
+	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+
+	// .mkv must exist somewhere under the Sonarr library directory.
+	mkvPath := findMKV(t, filepath.Join(processedDir, "sonarr-library"))
+	require.NotEmpty(t, mkvPath, "expected .mkv in sonarr-library after import")
+
+	// Verify output file properties.
+	info := probeOutputFile(t, mkvPath)
+	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
+	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
+	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+}

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -47,7 +47,11 @@ func TestSonarrHappyPath(t *testing.T) {
 	}, &sonarrPushResp), "push release to Sonarr")
 
 	if len(sonarrPushResp) > 0 {
-		t.Logf("Sonarr push response: %s", sonarrPushResp)
+		if respJSON, marshalErr := json.Marshal(sonarrPushResp); marshalErr != nil {
+			t.Logf("Sonarr push response (failed to marshal as JSON: %v): %+v", marshalErr, sonarrPushResp)
+		} else {
+			t.Logf("Sonarr push response: %s", respJSON)
+		}
 	}
 
 	// Poll until Sonarr has at least one imported episode file.

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +54,7 @@ func TestSonarrHappyPath(t *testing.T) {
 	// Poll until Sonarr has at least one imported episode file.
 	// The timeout is set generously to accommodate a full H.265 software encode
 	// of the BBB fixture on machines without hardware acceleration.
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Minute)
 	defer cancel()
 
 	err := pollUntil(ctx, 10*time.Second, func() error {
@@ -88,4 +89,35 @@ func TestSonarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+
+	// debugging: copy the output file to /workspace/media-processor for manual inspection after the test completes
+	debugDest := filepath.Join("/workspace/media-processor", "sonarr_happy_path_output.mkv")
+	if err := copyFile(mkvPath, debugDest); err != nil {
+		t.Logf("failed to copy output file for debugging: %v", err)
+		return
+	}
+
+	t.Logf("copied output file to %s for debugging", debugDest)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return out.Close()
 }

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -34,7 +34,7 @@ func TestSonarrHappyPath(t *testing.T) {
 
 	var sonarrPushResp []json.RawMessage
 
-	require.NoError(t, sonarr.post("/api/v3/release/push", map[string]any{
+	require.NoError(t, sonarr.post(t.Context(), "/api/v3/release/push", map[string]any{
 		"title":              releaseTitle,
 		"downloadUrl":        magnet,
 		"protocol":           "Torrent",
@@ -61,7 +61,7 @@ func TestSonarrHappyPath(t *testing.T) {
 			ID int `json:"id"`
 		}
 
-		if err := sonarr.get(fmt.Sprintf("/api/v3/episodefile?seriesId=%d", sonarrSeriesID), &files); err != nil {
+		if err := sonarr.get(ctx, fmt.Sprintf("/api/v3/episodefile?seriesId=%d", sonarrSeriesID), &files); err != nil {
 			return err
 		}
 
@@ -77,7 +77,7 @@ func TestSonarrHappyPath(t *testing.T) {
 	sourceMp4 := filepath.Join(downloadsDir, "sonarr", releaseTitle+".mp4")
 	_, statErr := os.Stat(sourceMp4)
 
-	assert.True(t, os.IsNotExist(statErr), "source .mp4 should have been deleted after import")
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "source .mp4 should have been deleted after import")
 
 	// .mkv must exist somewhere under the Sonarr library directory.
 	mkvPath := findMKV(t, filepath.Join(processedDir, "sonarr-library"))

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -32,12 +32,21 @@ type Torrent struct {
 	Eta        int     `json:"eta"`
 }
 
+// Category holds a qBittorrent download category.
+// Radarr and Sonarr verify category creation by reading GET /api/v2/torrents/categories
+// after POST /api/v2/torrents/createCategory; the category must appear in the response.
+type Category struct {
+	Name     string `json:"name"`
+	SavePath string `json:"savePath"`
+}
+
 // Server is an in-process qBittorrent Web API stub.
 // On torrent-add it copies a fixture file into the download directory so the
 // watcher subprocess can detect it.
 type Server struct {
 	mu          sync.Mutex
 	torrents    map[string]*Torrent
+	categories  map[string]*Category
 	listener    net.Listener
 	server      *http.Server
 	fixturePath string
@@ -56,6 +65,7 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 
 	s := &Server{
 		torrents:    make(map[string]*Torrent),
+		categories:  make(map[string]*Category),
 		listener:    ln,
 		fixturePath: fixturePath,
 		downloadDir: downloadDir,
@@ -123,8 +133,17 @@ func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
 	log.Printf("qbt stub: torrents/categories from %s", r.RemoteAddr)
 
+	s.mu.Lock()
+	out := make(map[string]*Category, len(s.categories))
+
+	for name, category := range s.categories {
+		out[name] = category
+	}
+
+	s.mu.Unlock()
+
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = fmt.Fprint(w, "{}")
+	_ = json.NewEncoder(w).Encode(out)
 }
 
 func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Request) {
@@ -138,6 +157,16 @@ func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Req
 	savePath := r.FormValue("savePath")
 
 	log.Printf("qbt stub: createCategory %q savePath=%q from %s", name, savePath, r.RemoteAddr)
+
+	if name == "" {
+		http.Error(w, "category name required", http.StatusBadRequest)
+
+		return
+	}
+
+	s.mu.Lock()
+	s.categories[name] = &Category{Name: name, SavePath: savePath}
+	s.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -87,7 +87,7 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 	mux.HandleFunc("POST /api/v2/torrents/delete", s.handleTorrentsDelete)
 	// Catch-all: log unmatched requests and return empty JSON so connection tests pass.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		logger.Warn("unmatched request", "method", r.Method, "path", r.URL.RequestURI(), "remote", r.RemoteAddr)
+		logger.Debug("unmatched request", "method", r.Method, "path", r.URL.RequestURI(), "remote", r.RemoteAddr)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, "{}")
 	})
@@ -110,32 +110,32 @@ func (s *Server) Close() {
 }
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
-	logger.Info("login", "remote", r.RemoteAddr)
+	logger.Debug("login", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "Ok.")
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
-	logger.Info("version", "remote", r.RemoteAddr)
+	logger.Debug("version", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "5.0.0")
 }
 
 func (s *Server) handleWebAPIVersion(w http.ResponseWriter, r *http.Request) {
-	logger.Info("webapiVersion", "remote", r.RemoteAddr)
+	logger.Debug("webapiVersion", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "2.9.3")
 }
 
 func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
-	logger.Info("preferences", "remote", r.RemoteAddr)
+	logger.Debug("preferences", "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprint(w, `{"save_path":"/downloads","use_subcategories":false,"use_category_paths_in_manual_mode":true,"dht":true}`)
 }
 
 func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
-	logger.Info("torrents/categories", "remote", r.RemoteAddr)
+	logger.Debug("torrents/categories", "remote", r.RemoteAddr)
 
 	s.mu.Lock()
 	out := make(map[string]*Category, len(s.categories))
@@ -160,7 +160,7 @@ func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Req
 	name := r.FormValue("category")
 	savePath := r.FormValue("savePath")
 
-	logger.Info("createCategory", "name", name, "savePath", savePath, "remote", r.RemoteAddr)
+	logger.Debug("createCategory", "name", name, "savePath", savePath, "remote", r.RemoteAddr)
 
 	if name == "" {
 		http.Error(w, "category name required", http.StatusBadRequest)
@@ -189,7 +189,7 @@ func (s *Server) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Unlock()
 
-	logger.Info("torrents/info", "query", r.URL.RawQuery, "count", len(list), "remote", r.RemoteAddr)
+	logger.Debug("torrents/info", "query", r.URL.RawQuery, "count", len(list), "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(list)
@@ -218,7 +218,7 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 		hash = "0000000000000000000000000000000000000000"
 	}
 
-	logger.Info("torrents/add", "category", category, "releaseName", releaseName, "hash", hash, "remote", r.RemoteAddr)
+	logger.Debug("torrents/add", "category", category, "releaseName", releaseName, "hash", hash, "remote", r.RemoteAddr)
 
 	destDir := filepath.Join(s.downloadDir, category)
 

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -235,6 +235,7 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		_ = os.Remove(tmpPath)
+
 		http.Error(w, fmt.Sprintf("rename fixture: %v", err), http.StatusInternalServerError)
 
 		return

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -32,19 +32,12 @@ type Torrent struct {
 	Eta        int     `json:"eta"`
 }
 
-// Category holds a qBittorrent download category.
-type Category struct {
-	Name     string `json:"name"`
-	SavePath string `json:"savePath"`
-}
-
 // Server is an in-process qBittorrent Web API stub.
 // On torrent-add it copies a fixture file into the download directory so the
 // watcher subprocess can detect it.
 type Server struct {
 	mu          sync.Mutex
 	torrents    map[string]*Torrent
-	categories  map[string]*Category
 	listener    net.Listener
 	server      *http.Server
 	fixturePath string
@@ -63,7 +56,6 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 
 	s := &Server{
 		torrents:    make(map[string]*Torrent),
-		categories:  make(map[string]*Category),
 		listener:    ln,
 		fixturePath: fixturePath,
 		downloadDir: downloadDir,
@@ -131,17 +123,8 @@ func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
 	log.Printf("qbt stub: torrents/categories from %s", r.RemoteAddr)
 
-	s.mu.Lock()
-	out := make(map[string]*Category, len(s.categories))
-
-	for name, cat := range s.categories {
-		out[name] = cat
-	}
-
-	s.mu.Unlock()
-
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(out)
+	_, _ = fmt.Fprint(w, "{}")
 }
 
 func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Request) {
@@ -155,16 +138,6 @@ func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Req
 	savePath := r.FormValue("savePath")
 
 	log.Printf("qbt stub: createCategory %q savePath=%q from %s", name, savePath, r.RemoteAddr)
-
-	if name == "" {
-		http.Error(w, "category name required", http.StatusBadRequest)
-
-		return
-	}
-
-	s.mu.Lock()
-	s.categories[name] = &Category{Name: name, SavePath: savePath}
-	s.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -225,9 +225,17 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	destPath := filepath.Join(destDir, releaseName+".mp4")
+	tmpPath := destPath + ".tmp"
 
-	if err := copyFile(s.fixturePath, destPath); err != nil {
+	if err := copyFile(s.fixturePath, tmpPath); err != nil {
 		http.Error(w, fmt.Sprintf("copy fixture: %v", err), http.StatusInternalServerError)
+
+		return
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		http.Error(w, fmt.Sprintf("rename fixture: %v", err), http.StatusInternalServerError)
 
 		return
 	}

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -83,7 +83,7 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 	mux.HandleFunc("POST /api/v2/torrents/delete", s.handleTorrentsDelete)
 	// Catch-all: log unmatched requests and return empty JSON so connection tests pass.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("qbt stub: unmatched request: %s %s (from %s)", r.Method, r.URL.RequestURI(), r.RemoteAddr)
+		slog.Warn("unmatched request", "method", r.Method, "path", r.URL.RequestURI(), "remote", r.RemoteAddr)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, "{}")
 	})
@@ -106,32 +106,32 @@ func (s *Server) Close() {
 }
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
-	log.Printf("qbt stub: login from %s", r.RemoteAddr)
+	slog.Info("login", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "Ok.")
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
-	log.Printf("qbt stub: version from %s", r.RemoteAddr)
+	slog.Info("version", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "5.0.0")
 }
 
 func (s *Server) handleWebAPIVersion(w http.ResponseWriter, r *http.Request) {
-	log.Printf("qbt stub: webapiVersion from %s", r.RemoteAddr)
+	slog.Info("webapiVersion", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "2.9.3")
 }
 
 func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
-	log.Printf("qbt stub: preferences from %s", r.RemoteAddr)
+	slog.Info("preferences", "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprint(w, `{"save_path":"/downloads","use_subcategories":false,"use_category_paths_in_manual_mode":true,"dht":true}`)
 }
 
 func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
-	log.Printf("qbt stub: torrents/categories from %s", r.RemoteAddr)
+	slog.Info("torrents/categories", "remote", r.RemoteAddr)
 
 	s.mu.Lock()
 	out := make(map[string]*Category, len(s.categories))
@@ -156,7 +156,7 @@ func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Req
 	name := r.FormValue("category")
 	savePath := r.FormValue("savePath")
 
-	log.Printf("qbt stub: createCategory %q savePath=%q from %s", name, savePath, r.RemoteAddr)
+	slog.Info("createCategory", "name", name, "savePath", savePath, "remote", r.RemoteAddr)
 
 	if name == "" {
 		http.Error(w, "category name required", http.StatusBadRequest)
@@ -185,7 +185,7 @@ func (s *Server) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Unlock()
 
-	log.Printf("qbt stub: torrents/info (query=%s) → %d torrents from %s", r.URL.RawQuery, len(list), r.RemoteAddr)
+	slog.Info("torrents/info", "query", r.URL.RawQuery, "count", len(list), "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(list)
@@ -214,7 +214,7 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 		hash = "0000000000000000000000000000000000000000"
 	}
 
-	log.Printf("qbt stub: torrents/add category=%q releaseName=%q hash=%s from %s", category, releaseName, hash, r.RemoteAddr)
+	slog.Info("torrents/add", "category", category, "releaseName", releaseName, "hash", hash, "remote", r.RemoteAddr)
 
 	destDir := filepath.Join(s.downloadDir, category)
 

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -19,6 +19,10 @@ import (
 	"sync"
 )
 
+// logger is a slog.Logger tagged with source="qbt" so its messages are
+// distinguishable from test-harness logs when output is interleaved.
+var logger = slog.Default().With("source", "qbt") //nolint:gochecknoglobals
+
 // Torrent holds the minimal torrent state that Radarr and Sonarr read from
 // GET /api/v2/torrents/info.
 type Torrent struct {
@@ -83,7 +87,7 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 	mux.HandleFunc("POST /api/v2/torrents/delete", s.handleTorrentsDelete)
 	// Catch-all: log unmatched requests and return empty JSON so connection tests pass.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		slog.Warn("unmatched request", "method", r.Method, "path", r.URL.RequestURI(), "remote", r.RemoteAddr)
+		logger.Warn("unmatched request", "method", r.Method, "path", r.URL.RequestURI(), "remote", r.RemoteAddr)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, "{}")
 	})
@@ -106,32 +110,32 @@ func (s *Server) Close() {
 }
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
-	slog.Info("login", "remote", r.RemoteAddr)
+	logger.Info("login", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "Ok.")
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
-	slog.Info("version", "remote", r.RemoteAddr)
+	logger.Info("version", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "5.0.0")
 }
 
 func (s *Server) handleWebAPIVersion(w http.ResponseWriter, r *http.Request) {
-	slog.Info("webapiVersion", "remote", r.RemoteAddr)
+	logger.Info("webapiVersion", "remote", r.RemoteAddr)
 
 	_, _ = fmt.Fprint(w, "2.9.3")
 }
 
 func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
-	slog.Info("preferences", "remote", r.RemoteAddr)
+	logger.Info("preferences", "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprint(w, `{"save_path":"/downloads","use_subcategories":false,"use_category_paths_in_manual_mode":true,"dht":true}`)
 }
 
 func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
-	slog.Info("torrents/categories", "remote", r.RemoteAddr)
+	logger.Info("torrents/categories", "remote", r.RemoteAddr)
 
 	s.mu.Lock()
 	out := make(map[string]*Category, len(s.categories))
@@ -156,7 +160,7 @@ func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Req
 	name := r.FormValue("category")
 	savePath := r.FormValue("savePath")
 
-	slog.Info("createCategory", "name", name, "savePath", savePath, "remote", r.RemoteAddr)
+	logger.Info("createCategory", "name", name, "savePath", savePath, "remote", r.RemoteAddr)
 
 	if name == "" {
 		http.Error(w, "category name required", http.StatusBadRequest)
@@ -185,7 +189,7 @@ func (s *Server) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Unlock()
 
-	slog.Info("torrents/info", "query", r.URL.RawQuery, "count", len(list), "remote", r.RemoteAddr)
+	logger.Info("torrents/info", "query", r.URL.RawQuery, "count", len(list), "remote", r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(list)
@@ -214,7 +218,7 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 		hash = "0000000000000000000000000000000000000000"
 	}
 
-	slog.Info("torrents/add", "category", category, "releaseName", releaseName, "hash", hash, "remote", r.RemoteAddr)
+	logger.Info("torrents/add", "category", category, "releaseName", releaseName, "hash", hash, "remote", r.RemoteAddr)
 
 	destDir := filepath.Join(s.downloadDir, category)
 

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -181,9 +181,9 @@ func (s *Server) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 
 	list := make([]*Torrent, 0, len(s.torrents))
-	for _, t := range s.torrents {
-		if categoryFilter == "" || t.Category == categoryFilter {
-			list = append(list, t)
+	for _, torrent := range s.torrents {
+		if categoryFilter == "" || torrent.Category == categoryFilter {
+			list = append(list, torrent)
 		}
 	}
 

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -134,8 +134,8 @@ func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request
 	s.mu.Lock()
 	out := make(map[string]*Category, len(s.categories))
 
-	for k, v := range s.categories {
-		out[k] = v
+	for name, cat := range s.categories {
+		out[name] = cat
 	}
 
 	s.mu.Unlock()
@@ -207,7 +207,10 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 		releaseName = "unknown-release"
 	}
 
-	hash := syntheticHash(releaseName)
+	hash := extractBTIH(magnetStr)
+	if hash == "" {
+		hash = "0000000000000000000000000000000000000000"
+	}
 
 	log.Printf("qbt stub: torrents/add category=%q releaseName=%q hash=%s from %s", category, releaseName, hash, r.RemoteAddr)
 
@@ -256,14 +259,14 @@ func (s *Server) handleTorrentsDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, h := range strings.Split(r.FormValue("hashes"), "|") {
-		h = strings.TrimSpace(h)
-		if h == "" {
+	for _, hash := range strings.Split(r.FormValue("hashes"), "|") {
+		hash = strings.TrimSpace(hash)
+		if hash == "" {
 			continue
 		}
 
 		s.mu.Lock()
-		delete(s.torrents, h)
+		delete(s.torrents, hash)
 		s.mu.Unlock()
 	}
 
@@ -280,18 +283,21 @@ func extractDN(magnet string) string {
 	return u.Query().Get("dn")
 }
 
-// syntheticHash returns a deterministic 40-hex-char string derived from name.
-// It is used as a stable fake infohash for the stub torrent registry.
-func syntheticHash(name string) string {
-	// FNV-1a 64-bit, zero-padded to 40 hex chars (20 bytes).
-	var h uint64 = 14695981039346656037
-
-	for _, b := range []byte(name) {
-		h ^= uint64(b)
-		h *= 1099511628211
+// extractBTIH parses the xt=urn:btih:<hash> parameter from a magnet URI and
+// returns the hash in lowercase. Returns an empty string if not found.
+func extractBTIH(magnet string) string {
+	u, err := url.Parse(magnet)
+	if err != nil || u.Scheme != "magnet" {
+		return ""
 	}
 
-	return fmt.Sprintf("%040x", h)
+	for _, xt := range u.Query()["xt"] {
+		if after, ok := strings.CutPrefix(xt, "urn:btih:"); ok {
+			return strings.ToLower(after)
+		}
+	}
+
+	return ""
 }
 
 func copyFile(src, dst string) error {

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -274,16 +274,16 @@ func (s *Server) handleTorrentsDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.mu.Lock()
 	for _, hash := range strings.Split(r.FormValue("hashes"), "|") {
 		hash = strings.TrimSpace(hash)
 		if hash == "" {
 			continue
 		}
 
-		s.mu.Lock()
 		delete(s.torrents, hash)
-		s.mu.Unlock()
 	}
+	s.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -1,0 +1,237 @@
+//go:build e2e
+
+// Package qbittorrent provides an in-process stub for the qBittorrent Web API v2.
+// It is used by the e2e test suite to simulate a download client without needing
+// a real qBittorrent instance.
+package qbittorrent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Torrent holds the minimal torrent state that Radarr and Sonarr read from
+// GET /api/v2/torrents/info.
+type Torrent struct {
+	Hash       string  `json:"hash"`
+	Name       string  `json:"name"`
+	State      string  `json:"state"`
+	Category   string  `json:"category"`
+	Progress   float64 `json:"progress"`
+	Size       int64   `json:"size"`
+	Downloaded int64   `json:"downloaded"`
+	Eta        int     `json:"eta"`
+}
+
+// Server is an in-process qBittorrent Web API stub.
+// On torrent-add it copies a fixture file into the download directory so the
+// watcher subprocess can detect it.
+type Server struct {
+	mu          sync.Mutex
+	torrents    map[string]*Torrent
+	listener    net.Listener
+	server      *http.Server
+	fixturePath string
+	downloadDir string
+}
+
+// New creates and starts a new stub server bound to 0.0.0.0:0.
+// fixturePath is the file copied to the download directory when a torrent is added.
+// downloadDir is the root download directory whose sub-directories correspond to
+// download client categories (e.g., /tmp/e2e-media-processor/downloads).
+func New(fixturePath, downloadDir string) (*Server, error) {
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	s := &Server{
+		torrents:    make(map[string]*Torrent),
+		listener:    ln,
+		fixturePath: fixturePath,
+		downloadDir: downloadDir,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v2/auth/login", s.handleLogin)
+	mux.HandleFunc("GET /api/v2/app/version", s.handleVersion)
+	mux.HandleFunc("GET /api/v2/app/webapiVersion", s.handleWebAPIVersion)
+	mux.HandleFunc("GET /api/v2/torrents/info", s.handleTorrentsInfo)
+	mux.HandleFunc("POST /api/v2/torrents/add", s.handleTorrentsAdd)
+	mux.HandleFunc("POST /api/v2/torrents/delete", s.handleTorrentsDelete)
+
+	s.server = &http.Server{Handler: mux}
+
+	go func() { _ = s.server.Serve(ln) }()
+
+	return s, nil
+}
+
+// Port returns the TCP port the stub is listening on.
+func (s *Server) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+// Close shuts down the stub server.
+func (s *Server) Close() {
+	_ = s.server.Close()
+}
+
+func (s *Server) handleLogin(w http.ResponseWriter, _ *http.Request) {
+	_, _ = fmt.Fprint(w, "Ok.")
+}
+
+func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
+	_, _ = fmt.Fprint(w, "5.0.0")
+}
+
+func (s *Server) handleWebAPIVersion(w http.ResponseWriter, _ *http.Request) {
+	_, _ = fmt.Fprint(w, "2.9.3")
+}
+
+func (s *Server) handleTorrentsInfo(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+
+	list := make([]*Torrent, 0, len(s.torrents))
+	for _, t := range s.torrents {
+		list = append(list, t)
+	}
+
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
+	// Accept both multipart/form-data and application/x-www-form-urlencoded.
+	if err := r.ParseMultipartForm(1 << 20); err != nil {
+		_ = r.ParseForm()
+	}
+
+	category := r.FormValue("category")
+
+	magnetStr := r.FormValue("urls")
+	if magnetStr == "" {
+		magnetStr = r.FormValue("magnet")
+	}
+
+	releaseName := extractDN(magnetStr)
+	if releaseName == "" {
+		releaseName = "unknown-release"
+	}
+
+	hash := syntheticHash(releaseName)
+
+	destDir := filepath.Join(s.downloadDir, category)
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		http.Error(w, fmt.Sprintf("mkdir %s: %v", destDir, err), http.StatusInternalServerError)
+
+		return
+	}
+
+	destPath := filepath.Join(destDir, releaseName+".mp4")
+
+	if err := copyFile(s.fixturePath, destPath); err != nil {
+		http.Error(w, fmt.Sprintf("copy fixture: %v", err), http.StatusInternalServerError)
+
+		return
+	}
+
+	var sz int64
+
+	if info, err := os.Stat(destPath); err == nil {
+		sz = info.Size()
+	}
+
+	s.mu.Lock()
+	s.torrents[hash] = &Torrent{
+		Hash:       hash,
+		Name:       releaseName,
+		State:      "uploading",
+		Category:   category,
+		Progress:   1.0,
+		Size:       sz,
+		Downloaded: sz,
+		Eta:        0,
+	}
+	s.mu.Unlock()
+
+	_, _ = fmt.Fprint(w, "Ok.")
+}
+
+func (s *Server) handleTorrentsDelete(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	for _, h := range strings.Split(r.FormValue("hashes"), "|") {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+
+		s.mu.Lock()
+		delete(s.torrents, h)
+		s.mu.Unlock()
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// extractDN parses the dn (display name) query parameter from a magnet URI.
+func extractDN(magnet string) string {
+	u, err := url.Parse(magnet)
+	if err != nil || u.Scheme != "magnet" {
+		return ""
+	}
+
+	return u.Query().Get("dn")
+}
+
+// syntheticHash returns a deterministic 40-hex-char string derived from name.
+// It is used as a stable fake infohash for the stub torrent registry.
+func syntheticHash(name string) string {
+	// FNV-1a 64-bit, zero-padded to 40 hex chars (20 bytes).
+	var h uint64 = 14695981039346656037
+
+	for _, b := range []byte(name) {
+		h ^= uint64(b)
+		h *= 1099511628211
+	}
+
+	return fmt.Sprintf("%040x", h)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return out.Close()
+}

--- a/e2e/stub/qbittorrent/server.go
+++ b/e2e/stub/qbittorrent/server.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -31,12 +32,19 @@ type Torrent struct {
 	Eta        int     `json:"eta"`
 }
 
+// Category holds a qBittorrent download category.
+type Category struct {
+	Name     string `json:"name"`
+	SavePath string `json:"savePath"`
+}
+
 // Server is an in-process qBittorrent Web API stub.
 // On torrent-add it copies a fixture file into the download directory so the
 // watcher subprocess can detect it.
 type Server struct {
 	mu          sync.Mutex
 	torrents    map[string]*Torrent
+	categories  map[string]*Category
 	listener    net.Listener
 	server      *http.Server
 	fixturePath string
@@ -55,6 +63,7 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 
 	s := &Server{
 		torrents:    make(map[string]*Torrent),
+		categories:  make(map[string]*Category),
 		listener:    ln,
 		fixturePath: fixturePath,
 		downloadDir: downloadDir,
@@ -64,9 +73,18 @@ func New(fixturePath, downloadDir string) (*Server, error) {
 	mux.HandleFunc("POST /api/v2/auth/login", s.handleLogin)
 	mux.HandleFunc("GET /api/v2/app/version", s.handleVersion)
 	mux.HandleFunc("GET /api/v2/app/webapiVersion", s.handleWebAPIVersion)
+	mux.HandleFunc("GET /api/v2/app/preferences", s.handlePreferences)
+	mux.HandleFunc("GET /api/v2/torrents/categories", s.handleTorrentsCategories)
+	mux.HandleFunc("POST /api/v2/torrents/createCategory", s.handleTorrentsCreateCategory)
 	mux.HandleFunc("GET /api/v2/torrents/info", s.handleTorrentsInfo)
 	mux.HandleFunc("POST /api/v2/torrents/add", s.handleTorrentsAdd)
 	mux.HandleFunc("POST /api/v2/torrents/delete", s.handleTorrentsDelete)
+	// Catch-all: log unmatched requests and return empty JSON so connection tests pass.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("qbt stub: unmatched request: %s %s (from %s)", r.Method, r.URL.RequestURI(), r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, "{}")
+	})
 
 	s.server = &http.Server{Handler: mux}
 
@@ -85,27 +103,87 @@ func (s *Server) Close() {
 	_ = s.server.Close()
 }
 
-func (s *Server) handleLogin(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	log.Printf("qbt stub: login from %s", r.RemoteAddr)
+
 	_, _ = fmt.Fprint(w, "Ok.")
 }
 
-func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	log.Printf("qbt stub: version from %s", r.RemoteAddr)
+
 	_, _ = fmt.Fprint(w, "5.0.0")
 }
 
-func (s *Server) handleWebAPIVersion(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleWebAPIVersion(w http.ResponseWriter, r *http.Request) {
+	log.Printf("qbt stub: webapiVersion from %s", r.RemoteAddr)
+
 	_, _ = fmt.Fprint(w, "2.9.3")
 }
 
-func (s *Server) handleTorrentsInfo(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handlePreferences(w http.ResponseWriter, r *http.Request) {
+	log.Printf("qbt stub: preferences from %s", r.RemoteAddr)
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, `{"save_path":"/downloads","use_subcategories":false,"use_category_paths_in_manual_mode":true,"dht":true}`)
+}
+
+func (s *Server) handleTorrentsCategories(w http.ResponseWriter, r *http.Request) {
+	log.Printf("qbt stub: torrents/categories from %s", r.RemoteAddr)
+
+	s.mu.Lock()
+	out := make(map[string]*Category, len(s.categories))
+
+	for k, v := range s.categories {
+		out[k] = v
+	}
+
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+func (s *Server) handleTorrentsCreateCategory(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	name := r.FormValue("category")
+	savePath := r.FormValue("savePath")
+
+	log.Printf("qbt stub: createCategory %q savePath=%q from %s", name, savePath, r.RemoteAddr)
+
+	if name == "" {
+		http.Error(w, "category name required", http.StatusBadRequest)
+
+		return
+	}
+
+	s.mu.Lock()
+	s.categories[name] = &Category{Name: name, SavePath: savePath}
+	s.mu.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
+	categoryFilter := r.URL.Query().Get("category")
+
 	s.mu.Lock()
 
 	list := make([]*Torrent, 0, len(s.torrents))
 	for _, t := range s.torrents {
-		list = append(list, t)
+		if categoryFilter == "" || t.Category == categoryFilter {
+			list = append(list, t)
+		}
 	}
 
 	s.mu.Unlock()
+
+	log.Printf("qbt stub: torrents/info (query=%s) → %d torrents from %s", r.URL.RawQuery, len(list), r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(list)
@@ -130,6 +208,8 @@ func (s *Server) handleTorrentsAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hash := syntheticHash(releaseName)
+
+	log.Printf("qbt stub: torrents/add category=%q releaseName=%q hash=%s from %s", category, releaseName, hash, r.RemoteAddr)
 
 	destDir := filepath.Join(s.downloadDir, category)
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0
@@ -81,7 +82,6 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/pkg/ffmpeg/cropdetect.go
+++ b/pkg/ffmpeg/cropdetect.go
@@ -61,6 +61,8 @@ func DetectCrop(ctx context.Context, inputPath string) (CropParams, error) {
 	}
 
 	codecCtx.SetTimeBase(videoStream.TimeBase())
+	codecCtx.SetThreadCount(0)
+	codecCtx.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if err := codecCtx.Open(codec, nil); err != nil {
 		return CropParams{}, fmt.Errorf("ffmpeg: DetectCrop: opening codec: %w", err)

--- a/pkg/ffmpeg/cropdetect.go
+++ b/pkg/ffmpeg/cropdetect.go
@@ -61,8 +61,6 @@ func DetectCrop(ctx context.Context, inputPath string) (CropParams, error) {
 	}
 
 	codecCtx.SetTimeBase(videoStream.TimeBase())
-	codecCtx.SetThreadCount(0)
-	codecCtx.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if err := codecCtx.Open(codec, nil); err != nil {
 		return CropParams{}, fmt.Errorf("ffmpeg: DetectCrop: opening codec: %w", err)

--- a/pkg/ffmpeg/log.go
+++ b/pkg/ffmpeg/log.go
@@ -31,9 +31,8 @@ func astiavLevelToSlog(l astiav.LogLevel) slog.Level {
 		return slog.LevelError
 	case l <= astiav.LogLevelWarning:
 		return slog.LevelWarn
-	case l <= astiav.LogLevelInfo:
-		return slog.LevelInfo
 	default:
+		// Info level libav logs can still be quite noisy, so treat them as debug output.
 		return slog.LevelDebug
 	}
 }

--- a/pkg/ffmpeg/log.go
+++ b/pkg/ffmpeg/log.go
@@ -36,3 +36,25 @@ func astiavLevelToSlog(l astiav.LogLevel) slog.Level {
 		return slog.LevelDebug
 	}
 }
+
+// x265LogLevel returns an x265 log-level string aligned with the current slog
+// level. x265 has its own logging that bypasses FFmpeg's av_log callback and
+// writes directly to stderr; this value is passed via x265-params so that the
+// encoder's native output respects the application log level.
+//
+// x265 levels: 0=none, 1=error, 2=warning, 3=info, 4=debug, 5=full.
+// Since astiavLevelToSlog already maps libav Info→slog Debug, x265 info output
+// is only shown when the application is at debug level.
+func x265LogLevel() string {
+	logger := slog.Default()
+	ctx := context.Background()
+
+	switch {
+	case logger.Enabled(ctx, slog.LevelDebug):
+		return "3" // info — show all x265 messages
+	case logger.Enabled(ctx, slog.LevelWarn):
+		return "2" // warning
+	default:
+		return "1" // error
+	}
+}

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -184,6 +184,8 @@ func (vss *videoStreamState) allocAndConfigDecoderContext(inStream *astiav.Strea
 	}
 
 	vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
+	vss.decoder.codecContext.SetThreadCount(0)
+	vss.decoder.codecContext.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if vss.decoder.hwDevCtx != nil {
 		vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
@@ -603,6 +605,11 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 	vss.encoder.codecContext.SetColorTransferCharacteristic(vss.decoder.codecContext.ColorTransferCharacteristic())
 	vss.encoder.codecContext.SetColorSpace(vss.decoder.codecContext.ColorSpace())
 	vss.encoder.codecContext.SetColorRange(vss.decoder.codecContext.ColorRange())
+
+	// Auto-detect the number of threads to use
+	vss.encoder.codecContext.SetThreadCount(0)
+	// Support both threading modes
+	vss.encoder.codecContext.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if err := vss.configureEncoderPixelFormat(enc, profile, useHW); err != nil {
 		return err

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -184,8 +184,6 @@ func (vss *videoStreamState) allocAndConfigDecoderContext(inStream *astiav.Strea
 	}
 
 	vss.decoder.codecContext.SetFramerate(inputFmt.GuessFrameRate(inStream, nil))
-	vss.decoder.codecContext.SetThreadCount(0)
-	vss.decoder.codecContext.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if vss.decoder.hwDevCtx != nil {
 		vss.decoder.codecContext.SetHardwareDeviceContext(vss.decoder.hwDevCtx)
@@ -606,10 +604,10 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 	vss.encoder.codecContext.SetColorSpace(vss.decoder.codecContext.ColorSpace())
 	vss.encoder.codecContext.SetColorRange(vss.decoder.codecContext.ColorRange())
 
-	// Auto-detect the number of threads to use
+	// Let the encoder auto-detect thread count. Do NOT set ThreadType here:
+	// libx265 manages threading internally (AV_CODEC_CAP_OTHER_THREADS) and
+	// setting FF_THREAD_FRAME on it breaks PTS propagation.
 	vss.encoder.codecContext.SetThreadCount(0)
-	// Support both threading modes
-	vss.encoder.codecContext.SetThreadType(astiav.ThreadTypeFrame | astiav.ThreadTypeSlice)
 
 	if err := vss.configureEncoderPixelFormat(enc, profile, useHW); err != nil {
 		return err

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -362,7 +362,6 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 			devCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
 			if err != nil {
 				slog.Debug("ffmpeg: VAAPI device context unavailable for crop filter, using SW-only crop", "error", err)
-
 				hwAccel = HWAccelNone
 			} else {
 				// Store so the encoder (set up later in buildStreamStates) reuses it.

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -612,7 +612,20 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 		vss.encoder.codecContext.SetFlags(vss.encoder.codecContext.Flags().Add(astiav.CodecContextFlagGlobalHeader))
 	}
 
-	if err := vss.encoder.codecContext.Open(vss.encoder.codec, nil); err != nil {
+	var openDict *astiav.Dictionary
+
+	// libx265 has its own logging that writes directly to stderr, bypassing
+	// FFmpeg's av_log callback. Align its log level with the application logger
+	// so that x265 info-level noise is suppressed unless debug logging is on.
+	if enc.Name() == "libx265" {
+		openDict = astiav.NewDictionary()
+
+		if err := openDict.Set("x265-params", "log-level="+x265LogLevel(), astiav.NewDictionaryFlags()); err != nil {
+			return fmt.Errorf("setting x265-params: %w", err)
+		}
+	}
+
+	if err := vss.encoder.codecContext.Open(vss.encoder.codec, openDict); err != nil {
 		return fmt.Errorf("opening video encoder: %w", err)
 	}
 

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -885,6 +885,13 @@ func (vss *videoStreamState) encodeVideoFrame(frame *astiav.Frame, outputFmt *as
 		}
 	}
 
+	// Clear the decoded picture type so the encoder makes its own I/P/B
+	// decisions. Passing through the decoder's picture type causes x265 to
+	// warn "specified frame type is not compatible with max B-frames" and
+	// may interfere with the encoder's GOP structure. The ffmpeg CLI does
+	// the same via its filter graph, which strips picture type.
+	encFrame.SetPictureType(astiav.PictureTypeNone)
+
 	if err := vss.encoder.codecContext.SendFrame(encFrame); err != nil {
 		return fmt.Errorf("ffmpeg: sending video frame to encoder: %w", err)
 	}

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -362,6 +362,7 @@ func (vss *videoStreamState) setupCropFilter(inStream *astiav.Stream, hwAccel HW
 			devCtx, err := astiav.CreateHardwareDeviceContext(profile.deviceType, vss.hardwareDevicePath, nil, 0)
 			if err != nil {
 				slog.Debug("ffmpeg: VAAPI device context unavailable for crop filter, using SW-only crop", "error", err)
+
 				hwAccel = HWAccelNone
 			} else {
 				// Store so the encoder (set up later in buildStreamStates) reuses it.

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -619,6 +619,7 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 	// so that x265 info-level noise is suppressed unless debug logging is on.
 	if enc.Name() == "libx265" {
 		openDict = astiav.NewDictionary()
+		defer openDict.Free()
 
 		if err := openDict.Set("x265-params", "log-level="+x265LogLevel(), astiav.NewDictionaryFlags()); err != nil {
 			return fmt.Errorf("setting x265-params: %w", err)

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -546,6 +546,14 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 			}
 
 			outStream.SetTimeBase(encCtx.TimeBase())
+
+			// Propagate the frame rate to the output stream so the container
+			// (e.g. MKV's DefaultDuration) records it. Without this, players
+			// derive frame rate from packet timestamps, which can be slightly
+			// inaccurate due to timebase rounding.
+			// This is required for VLC to correctly show the progress bar.
+			outStream.SetAvgFrameRate(encCtx.Framerate())
+			outStream.SetRFrameRate(encCtx.Framerate())
 		} else {
 			// Copy stream: copy parameters from the input stream.
 			if err := inStream.CodecParameters().Copy(outStream.CodecParameters()); err != nil {

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -567,34 +567,50 @@ func (t *Transcoder) setupOutputContext(streams map[int]stream, downmix *audioSt
 			outStream.SetTimeBase(inStream.TimeBase())
 		}
 
-		// Apply per-stream title override for audio streams.
-		if inStream.CodecParameters().MediaType() == astiav.MediaTypeAudio {
-			if title, ok := t.audioStreamTitles[inStream.Index()]; ok {
-				titleDict := astiav.NewDictionary()
-				if err := titleDict.Set("title", title, astiav.NewDictionaryFlags()); err != nil {
-					titleDict.Free()
-					outputFmt.Free()
+		// Copy input stream metadata (language, title, etc.) to the output
+		// stream so that tags are preserved for both copy and re-encoded
+		// streams. FromCodecContext (used for re-encoded streams) only copies
+		// codec parameters, not AVStream-level metadata.
+		var outMeta *astiav.Dictionary
+		if inMeta := inStream.Metadata(); inMeta != nil {
+			outMeta = astiav.NewDictionary()
+			if err := inMeta.Copy(outMeta, astiav.NewDictionaryFlags()); err != nil {
+				outMeta.Free()
+				outputFmt.Free()
 
-					return nil, noopClose, fmt.Errorf("ffmpeg: setting title metadata for stream %d: %w", inStream.Index(), err)
-				}
-
-				outStream.SetMetadata(titleDict)
+				return nil, noopClose, fmt.Errorf("ffmpeg: copying metadata for stream %d: %w", inStream.Index(), err)
 			}
 		}
 
-		// Apply per-stream title override for subtitle streams.
-		if inStream.CodecParameters().MediaType() == astiav.MediaTypeSubtitle {
-			if title, ok := t.subtitleStreamTitles[inStream.Index()]; ok {
-				titleDict := astiav.NewDictionary()
-				if err := titleDict.Set("title", title, astiav.NewDictionaryFlags()); err != nil {
-					titleDict.Free()
-					outputFmt.Free()
+		// Apply per-stream title overrides, writing into the already-copied
+		// metadata dict so other tags (e.g. language) are preserved alongside
+		// the new title.
+		var titleOverride string
 
-					return nil, noopClose, fmt.Errorf("ffmpeg: setting title metadata for stream %d: %w", inStream.Index(), err)
-				}
+		switch inStream.CodecParameters().MediaType() {
+		case astiav.MediaTypeAudio:
+			titleOverride = t.audioStreamTitles[inStream.Index()]
+		case astiav.MediaTypeSubtitle:
+			titleOverride = t.subtitleStreamTitles[inStream.Index()]
+		}
 
-				outStream.SetMetadata(titleDict)
+		if titleOverride != "" {
+			if outMeta == nil {
+				outMeta = astiav.NewDictionary()
 			}
+
+			if err := outMeta.Set("title", titleOverride, astiav.NewDictionaryFlags()); err != nil {
+				outMeta.Free()
+				outputFmt.Free()
+
+				return nil, noopClose, fmt.Errorf("ffmpeg: setting title for stream %d: %w", inStream.Index(), err)
+			}
+		}
+
+		// Assign the final metadata to the output stream. Ownership of outMeta
+		// transfers to the stream's AVStream.metadata; do not free it.
+		if outMeta != nil {
+			outStream.SetMetadata(outMeta)
 		}
 	}
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -2,6 +2,7 @@ package ffmpeg_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -703,8 +704,8 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 
 	var videoStream *ffprobe.StreamInfo
 
-	for i, s := range outputInfo.Streams {
-		if s.CodecType == ffprobe.CodecTypeVideo {
+	for i, stream := range outputInfo.Streams {
+		if stream.CodecType == ffprobe.CodecTypeVideo {
 			videoStream = &outputInfo.Streams[i]
 			break
 		}
@@ -717,8 +718,8 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 
 	var inputVideoStream *ffprobe.StreamInfo
 
-	for i, s := range inputInfo.Streams {
-		if s.CodecType == ffprobe.CodecTypeVideo {
+	for i, stream := range inputInfo.Streams {
+		if stream.CodecType == ffprobe.CodecTypeVideo {
 			inputVideoStream = &inputInfo.Streams[i]
 			break
 		}
@@ -741,9 +742,9 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 
 	videoStreamIndex := -1
 
-	for _, s := range fmtCtx.Streams() {
-		if s.CodecParameters().MediaType() == astiav.MediaTypeVideo {
-			videoStreamIndex = s.Index()
+	for _, stream := range fmtCtx.Streams() {
+		if stream.CodecParameters().MediaType() == astiav.MediaTypeVideo {
+			videoStreamIndex = stream.Index()
 			break
 		}
 	}
@@ -762,6 +763,8 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 
 	for {
 		if err := fmtCtx.ReadFrame(pkt); err != nil {
+			require.True(t, errors.Is(err, astiav.ErrEof), "unexpected ReadFrame error: %v", err)
+
 			break
 		}
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -775,6 +775,7 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 		require.NotEqual(t, astiav.NoPtsValue, pts,
 			"video packet %d must have a valid PTS", packetCount)
 		ptsValues = append(ptsValues, pts)
+
 		pkt.Unref()
 	}
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -675,6 +676,121 @@ func TestWithoutCrop_DimensionsUnchanged(t *testing.T) {
 	require.NotNil(t, videoStream, "output file should contain a video stream")
 	assert.Equal(t, 320, videoStream.WidthPixels, "width should be unchanged without crop")
 	assert.Equal(t, 220, videoStream.HeightPixels, "height should be unchanged without crop")
+}
+
+// TestTranscode_H265_VideoTimestampsValid verifies that transcoding to H.265
+// produces output with correct video timestamps: every video packet must have a
+// valid PTS (not AV_NOPTS_VALUE), display-order PTS values must increase
+// monotonically, and the output frame rate must match the input.
+//
+// This test guards against a regression where enabling multi-threaded decoding
+// caused the H.264 decoder to emit frames with AV_NOPTS_VALUE after the first
+// few frames, producing output with corrupted timestamps.
+func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "out.mkv")
+
+	err := ffmpeg.NewTranscode(testVideoPath, output).
+		ToVideoCodec(ffmpeg.CodecH265).
+		ToAudioCodec(ffmpeg.CodecCopy).
+		ToContainer(ffmpeg.ContainerMKV).
+		Build().
+		Run(t.Context())
+	require.NoError(t, err)
+
+	// Verify frame rate is preserved in the output container metadata.
+	outputInfo, err := ffprobe.Probe(t.Context(), output)
+	require.NoError(t, err)
+
+	var videoStream *ffprobe.StreamInfo
+
+	for i, s := range outputInfo.Streams {
+		if s.CodecType == ffprobe.CodecTypeVideo {
+			videoStream = &outputInfo.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, videoStream, "output must contain a video stream")
+
+	inputInfo, err := ffprobe.Probe(t.Context(), testVideoPath)
+	require.NoError(t, err)
+
+	var inputVideoStream *ffprobe.StreamInfo
+
+	for i, s := range inputInfo.Streams {
+		if s.CodecType == ffprobe.CodecTypeVideo {
+			inputVideoStream = &inputInfo.Streams[i]
+			break
+		}
+	}
+
+	require.NotNil(t, inputVideoStream)
+	assert.InDelta(t, inputVideoStream.FramesPerSecond, videoStream.FramesPerSecond, 0.5,
+		"output frame rate must match input")
+
+	// Open the output file with go-astiav and verify all video packet PTS values.
+	fmtCtx := astiav.AllocFormatContext()
+	require.NotNil(t, fmtCtx)
+
+	defer fmtCtx.Free()
+
+	require.NoError(t, fmtCtx.OpenInput(output, nil, nil))
+	defer fmtCtx.CloseInput()
+
+	require.NoError(t, fmtCtx.FindStreamInfo(nil))
+
+	videoStreamIndex := -1
+
+	for _, s := range fmtCtx.Streams() {
+		if s.CodecParameters().MediaType() == astiav.MediaTypeVideo {
+			videoStreamIndex = s.Index()
+			break
+		}
+	}
+
+	require.NotEqual(t, -1, videoStreamIndex)
+
+	pkt := astiav.AllocPacket()
+	require.NotNil(t, pkt)
+
+	defer pkt.Free()
+
+	var packetCount int
+
+	// Collect PTS values to verify they form a valid, monotonic display order.
+	var ptsValues []int64
+
+	for {
+		if err := fmtCtx.ReadFrame(pkt); err != nil {
+			break
+		}
+
+		if pkt.StreamIndex() != videoStreamIndex {
+			pkt.Unref()
+			continue
+		}
+
+		packetCount++
+		pts := pkt.Pts()
+		require.NotEqual(t, astiav.NoPtsValue, pts,
+			"video packet %d must have a valid PTS", packetCount)
+		ptsValues = append(ptsValues, pts)
+		pkt.Unref()
+	}
+
+	assert.Greater(t, packetCount, 0, "output must contain video packets")
+
+	// Sort PTS values into display order and verify monotonic increase.
+	sorted := make([]int64, len(ptsValues))
+	copy(sorted, ptsValues)
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	for i := 1; i < len(sorted); i++ {
+		assert.Greater(t, sorted[i], sorted[i-1],
+			"display-order PTS must be strictly increasing: pts[%d]=%d, pts[%d]=%d",
+			i-1, sorted[i-1], i, sorted[i])
+	}
 }
 
 // TestDetectHardwareEncoders_ValidResult verifies that DetectHardwareEncoders

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -629,10 +629,10 @@ func TestWithCrop_NarrowsOutputDimensions(t *testing.T) {
 		ToContainer(ffmpeg.ContainerMKV).
 		WithCrop(crop).
 		Build().
-		Run(context.Background())
+		Run(t.Context())
 	require.NoError(t, err)
 
-	info, err := ffprobe.Probe(context.Background(), output)
+	info, err := ffprobe.Probe(t.Context(), output)
 	require.NoError(t, err)
 
 	var videoStream *ffprobe.StreamInfo
@@ -658,10 +658,10 @@ func TestWithoutCrop_DimensionsUnchanged(t *testing.T) {
 		ToVideoCodec(ffmpeg.CodecH265).
 		ToContainer(ffmpeg.ContainerMKV).
 		Build().
-		Run(context.Background())
+		Run(t.Context())
 	require.NoError(t, err)
 
-	info, err := ffprobe.Probe(context.Background(), output)
+	info, err := ffprobe.Probe(t.Context(), output)
 	require.NoError(t, err)
 
 	var videoStream *ffprobe.StreamInfo

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 	"time"
 
@@ -784,16 +783,13 @@ func TestTranscode_H265_VideoTimestampsValid(t *testing.T) {
 
 	assert.Greater(t, packetCount, 0, "output must contain video packets")
 
-	// Sort PTS values into display order and verify monotonic increase.
-	sorted := make([]int64, len(ptsValues))
-	copy(sorted, ptsValues)
+	// Verify that no two video packets share a PTS value.
+	seen := make(map[int64]bool, len(ptsValues))
 
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
-
-	for i := 1; i < len(sorted); i++ {
-		assert.Greater(t, sorted[i], sorted[i-1],
-			"display-order PTS must be strictly increasing: pts[%d]=%d, pts[%d]=%d",
-			i-1, sorted[i-1], i, sorted[i])
+	for i, pts := range ptsValues {
+		assert.False(t, seen[pts],
+			"duplicate PTS value %d at packet %d", pts, i)
+		seen[pts] = true
 	}
 }
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -680,8 +680,8 @@ func TestWithoutCrop_DimensionsUnchanged(t *testing.T) {
 
 // TestTranscode_H265_VideoTimestampsValid verifies that transcoding to H.265
 // produces output with correct video timestamps: every video packet must have a
-// valid PTS (not AV_NOPTS_VALUE), display-order PTS values must increase
-// monotonically, and the output frame rate must match the input.
+// valid PTS (not AV_NOPTS_VALUE), packet PTS values must not be duplicated,
+// and the output frame rate must match the input.
 //
 // This test guards against a regression where enabling multi-threaded decoding
 // caused the H.264 decoder to emit frames with AV_NOPTS_VALUE after the first

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -45,21 +45,23 @@ func Setup(level string) {
 // zerolog is configured at TraceLevel so all entries pass through; slog applies
 // the active level filter inside the bridge.
 func NewZerologLogger(service string) zerolog.Logger {
-	return zerolog.New(&zerologSlogBridge{}).Level(zerolog.TraceLevel).With().Str("service", service).Logger()
+	return zerolog.New(&zerologSlogBridge{service: service}).Level(zerolog.TraceLevel).With().Str("service", service).Logger()
 }
 
 // zerologSlogBridge is an io.Writer for zerolog that re-emits each log entry
 // through the default slog handler. zerolog guarantees that Write is called
 // exactly once per complete log entry, so the bridge can parse and forward
 // without buffering.
-type zerologSlogBridge struct{}
+type zerologSlogBridge struct {
+	service string
+}
 
 func (b *zerologSlogBridge) Write(p []byte) (int, error) {
 	ctx := context.TODO()
 
 	var raw map[string]any
 	if err := json.Unmarshal(bytes.TrimRight(p, "\n"), &raw); err != nil {
-		slog.Warn("hatchet: non-JSON log entry", "raw", strings.TrimRight(string(p), "\n"))
+		slog.Warn("zerolog: non-JSON log entry", "service", b.service, "raw", strings.TrimRight(string(p), "\n"))
 
 		return len(p), nil
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -61,7 +61,13 @@ func (b *zerologSlogBridge) Write(p []byte) (int, error) {
 
 	var raw map[string]any
 	if err := json.Unmarshal(bytes.TrimRight(p, "\n"), &raw); err != nil {
-		slog.Warn("zerolog: non-JSON log entry", "service", b.service, "raw", strings.TrimRight(string(p), "\n"))
+		slog.Warn(
+			"zerolog: non-JSON log entry",
+			"service", b.service,
+			"err", err,
+			"raw_len", len(p),
+			"raw", strings.TrimRight(string(p), "\n"),
+		)
 
 		return len(p), nil
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/rs/zerolog"
 )
 
 // Setup configures the global slog logger using the provided level string (e.g.
@@ -47,4 +49,16 @@ func ZerologLevel(level string) string {
 	default:
 		return "info"
 	}
+}
+
+// NewZerologLogger returns a zerolog.Logger writing JSON to stderr, configured
+// at the level derived from the given LOG_LEVEL string and tagged with the
+// given service name. Use this to configure Hatchet SDK worker loggers so they
+// respect LOG_LEVEL rather than always defaulting to debug.
+func NewZerologLogger(level, service string) zerolog.Logger {
+	// ZerologLevel always returns a valid zerolog level string, so ParseLevel
+	// cannot fail here.
+	lvl, _ := zerolog.ParseLevel(ZerologLevel(level))
+
+	return zerolog.New(os.Stderr).Level(lvl).With().Timestamp().Str("service", service).Logger()
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -32,3 +32,19 @@ func Setup(level string) {
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l})))
 }
+
+// ZerologLevel returns a zerolog-compatible level string for the given
+// LOG_LEVEL value. This is useful for configuring third-party libraries (like
+// the Hatchet SDK) that use zerolog internally.
+func ZerologLevel(level string) string {
+	switch strings.ToLower(level) {
+	case "debug":
+		return "debug"
+	case "warn", "warning":
+		return "warn"
+	case "error":
+		return "error"
+	default:
+		return "info"
+	}
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -2,6 +2,9 @@
 package logging
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"strings"
@@ -51,14 +54,68 @@ func ZerologLevel(level string) string {
 	}
 }
 
-// NewZerologLogger returns a zerolog.Logger writing JSON to stderr, configured
-// at the level derived from the given LOG_LEVEL string and tagged with the
-// given service name. Use this to configure Hatchet SDK worker loggers so they
-// respect LOG_LEVEL rather than always defaulting to debug.
+// NewZerologLogger returns a zerolog.Logger that routes every entry through the
+// default slog handler via zerologSlogBridge. Output is therefore formatted and
+// levelled consistently with the rest of the application. The service name is
+// attached as a "service" attribute on every entry.
 func NewZerologLogger(level, service string) zerolog.Logger {
 	// ZerologLevel always returns a valid zerolog level string, so ParseLevel
 	// cannot fail here.
 	lvl, _ := zerolog.ParseLevel(ZerologLevel(level))
 
-	return zerolog.New(os.Stderr).Level(lvl).With().Timestamp().Str("service", service).Logger()
+	return zerolog.New(&zerologSlogBridge{}).Level(lvl).With().Str("service", service).Logger()
+}
+
+// zerologSlogBridge is an io.Writer for zerolog that re-emits each log entry
+// through the default slog handler. zerolog guarantees that Write is called
+// exactly once per complete log entry, so the bridge can parse and forward
+// without buffering.
+type zerologSlogBridge struct{}
+
+func (b *zerologSlogBridge) Write(p []byte) (int, error) {
+	ctx := context.TODO()
+
+	var raw map[string]any
+	if err := json.Unmarshal(bytes.TrimRight(p, "\n"), &raw); err != nil {
+		slog.Warn("hatchet: non-JSON log entry", "raw", strings.TrimRight(string(p), "\n"))
+
+		return len(p), nil
+	}
+
+	lvlStr, _ := raw["level"].(string)
+	lvl := zerologLevelToSlog(lvlStr)
+
+	if !slog.Default().Enabled(ctx, lvl) {
+		return len(p), nil
+	}
+
+	msg, _ := raw["message"].(string)
+
+	attrs := make([]any, 0, len(raw)*2)
+
+	for k, v := range raw {
+		if k == "level" || k == "message" || k == "time" {
+			continue
+		}
+
+		attrs = append(attrs, k, v)
+	}
+
+	slog.Log(ctx, lvl, msg, attrs...)
+
+	return len(p), nil
+}
+
+// zerologLevelToSlog maps a zerolog level string to the equivalent slog.Level.
+func zerologLevelToSlog(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error", "fatal", "panic":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -38,32 +38,14 @@ func Setup(level string) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l})))
 }
 
-// ZerologLevel returns a zerolog-compatible level string for the given
-// LOG_LEVEL value. This is useful for configuring third-party libraries (like
-// the Hatchet SDK) that use zerolog internally.
-func ZerologLevel(level string) string {
-	switch strings.ToLower(level) {
-	case "debug":
-		return "debug"
-	case "warn", "warning":
-		return "warn"
-	case "error":
-		return "error"
-	default:
-		return "info"
-	}
-}
-
 // NewZerologLogger returns a zerolog.Logger that routes every entry through the
 // default slog handler via zerologSlogBridge. Output is therefore formatted and
 // levelled consistently with the rest of the application. The service name is
 // attached as a "service" attribute on every entry.
-func NewZerologLogger(level, service string) zerolog.Logger {
-	// ZerologLevel always returns a valid zerolog level string, so ParseLevel
-	// cannot fail here.
-	lvl, _ := zerolog.ParseLevel(ZerologLevel(level))
-
-	return zerolog.New(&zerologSlogBridge{}).Level(lvl).With().Str("service", service).Logger()
+// zerolog is configured at TraceLevel so all entries pass through; slog applies
+// the active level filter inside the bridge.
+func NewZerologLogger(service string) zerolog.Logger {
+	return zerolog.New(&zerologSlogBridge{}).Level(zerolog.TraceLevel).With().Str("service", service).Logger()
 }
 
 // zerologSlogBridge is an io.Writer for zerolog that re-emits each log entry

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -91,7 +91,7 @@ func (b *zerologSlogBridge) Write(p []byte) (int, error) {
 // zerologLevelToSlog maps a zerolog level string to the equivalent slog.Level.
 func zerologLevelToSlog(level string) slog.Level {
 	switch strings.ToLower(level) {
-	case "debug":
+	case "trace", "debug":
 		return slog.LevelDebug
 	case "warn", "warning":
 		return slog.LevelWarn

--- a/pkg/medialib/internal/artwork/artwork.go
+++ b/pkg/medialib/internal/artwork/artwork.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -104,14 +105,6 @@ func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseU
 		return nil, "", nil
 	}
 
-	// Pre-fetch extension check: only accept JPEG and PNG.
-	ext := strings.ToLower(img.Extension)
-	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
-		slog.WarnContext(ctx, "skipping poster candidate: unsupported extension", "extension", img.Extension)
-
-		return nil, "", nil
-	}
-
 	imageURL := img.URL
 	if imageURL == "" {
 		imageURL = img.RemoteURL
@@ -119,6 +112,23 @@ func fetchPosterCandidate(ctx context.Context, img *starr.Image, normalizedBaseU
 
 	if imageURL == "" {
 		slog.WarnContext(ctx, "skipping poster candidate: no URL or RemoteURL set")
+
+		return nil, "", nil
+	}
+
+	// Pre-fetch extension check: only accept JPEG and PNG.
+	// Prefer img.Extension when set; fall back to the URL path extension because
+	// some arr versions (e.g. Radarr's /api/v3/movie/{id}) omit the Extension field.
+	ext := strings.ToLower(img.Extension)
+	if ext == "" {
+		rawU, parseErr := url.Parse(imageURL)
+		if parseErr == nil {
+			ext = strings.ToLower(path.Ext(rawU.Path))
+		}
+	}
+
+	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
+		slog.WarnContext(ctx, "skipping poster candidate: unsupported extension", "extension", ext)
 
 		return nil, "", nil
 	}

--- a/pkg/medialib/internal/artwork/artwork_test.go
+++ b/pkg/medialib/internal/artwork/artwork_test.go
@@ -76,7 +76,17 @@ func TestFetchPosterImage(t *testing.T) {
 			wantMime:  "",
 		},
 		{
-			name: "empty extension returns nil",
+			name: "empty Extension field falls back to URL path extension",
+			images: func(baseURL string) []*starr.Image {
+				// Radarr's /api/v3/movie/{id} omits the Extension field but includes
+				// a URL with a query string: /MediaCover/1/poster.jpg?lastWrite=...
+				return []*starr.Image{{CoverType: "poster", Extension: "", URL: "/MediaCover/1/poster.jpg?lastWrite=12345"}}
+			},
+			wantBytes: jpegBytes,
+			wantMime:  "image/jpeg",
+		},
+		{
+			name: "empty Extension field with extensionless URL returns nil",
 			images: func(baseURL string) []*starr.Image {
 				return []*starr.Image{{CoverType: "poster", Extension: "", URL: "/MediaCover/1/poster"}}
 			},

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -99,13 +99,19 @@ func (c *Client) GetMovieByFilePath(ctx context.Context, path string) (medialib.
 
 // parseFilePath calls Radarr's /api/v3/parse endpoint to identify a movie
 // from a file path. Returns nil if Radarr cannot identify the movie.
+//
+// The title parameter (filename stem without extension) is used instead of the
+// path parameter because Radarr's parse endpoint matches path against library
+// paths only, returning 204 No Content for download paths that haven't been
+// imported yet.
 func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Movie, error) {
 	var output struct {
 		Movie *radarrlib.Movie `json:"movie"`
 	}
 
+	base := filepath.Base(path)
 	q := make(url.Values)
-	q.Set("path", path)
+	q.Set("title", strings.TrimSuffix(base, filepath.Ext(base)))
 
 	req := starr.Request{URI: radarrlib.APIver + "/parse", Query: q}
 	if err := c.radarr.GetInto(ctx, req, &output); err != nil {

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -34,6 +34,8 @@ type testServerConfig struct {
 	imageType string           // Content-Type for image responses
 	// onCommand is called with the raw command request when /api/v3/command is hit.
 	onCommand func(t *testing.T, r *http.Request)
+	// onParse is called with the raw parse request when /api/v3/parse is hit.
+	onParse func(t *testing.T, r *http.Request)
 }
 
 func newTestServer(t *testing.T, parseResp *parseResponse) *httptest.Server {
@@ -47,6 +49,10 @@ func newTestServerWithConfig(t *testing.T, cfg testServerConfig) *httptest.Serve
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
+		if cfg.onParse != nil {
+			cfg.onParse(t, r)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(cfg.parseResp))
 	})
@@ -238,6 +244,29 @@ func TestImportByFilePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMovieByFilePath_UsesFileStemAsTitleParam(t *testing.T) {
+	var gotTitle, gotPath string
+
+	knownMovie := &radarrlib.Movie{ID: 1, Title: "Big Buck Bunny", Year: 2008}
+
+	srv := newTestServerWithConfig(t, testServerConfig{
+		parseResp: &parseResponse{Movie: knownMovie},
+		onParse: func(t *testing.T, r *http.Request) {
+			gotTitle = r.URL.Query().Get("title")
+			gotPath = r.URL.Query().Get("path")
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, err := client.GetMovieByFilePath(t.Context(), "/downloads/Big.Buck.Bunny.2008.1080p.WEB-DL.mp4")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Big.Buck.Bunny.2008.1080p.WEB-DL", gotTitle, "title param should be filename stem")
+	assert.Empty(t, gotPath, "path param must not be sent")
 }
 
 func TestGetMovieByFilePath_UnreachableURL(t *testing.T) {

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -84,6 +84,7 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 	// parse endpoint matches path against library paths only, returning 204 No
 	// Content for download paths that haven't been imported yet.
 	base := filepath.Base(path)
+
 	parsed, err := c.sonarr.ParseContext(ctx, &sonarrlib.ParseInput{Title: strings.TrimSuffix(base, filepath.Ext(base))})
 	if err != nil {
 		return medialib.Episode{}, fmt.Errorf("parse file path: %w", err)

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -80,7 +80,11 @@ func (c *Client) GetEpisodeByFilePath(ctx context.Context, path string) (mediali
 		return medialib.Episode{}, err
 	}
 
-	parsed, err := c.sonarr.ParseContext(ctx, &sonarrlib.ParseInput{Path: path})
+	// Use the title parameter (filename stem) rather than path because Sonarr's
+	// parse endpoint matches path against library paths only, returning 204 No
+	// Content for download paths that haven't been imported yet.
+	base := filepath.Base(path)
+	parsed, err := c.sonarr.ParseContext(ctx, &sonarrlib.ParseInput{Title: strings.TrimSuffix(base, filepath.Ext(base))})
 	if err != nil {
 		return medialib.Episode{}, fmt.Errorf("parse file path: %w", err)
 	}

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -28,6 +28,8 @@ type sonarrTestServerConfig struct {
 	imageType  string
 	// onCommand is called with the raw command request when /api/v3/command is hit.
 	onCommand func(t *testing.T, r *http.Request)
+	// onParse is called with the raw parse request when /api/v3/parse is hit.
+	onParse func(t *testing.T, r *http.Request)
 }
 
 func newSonarrTestServer(t *testing.T, parseResp *sonarrlib.ParseOutput) *httptest.Server {
@@ -41,6 +43,10 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/v3/parse", func(w http.ResponseWriter, r *http.Request) {
+		if cfg.onParse != nil {
+			cfg.onParse(t, r)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(cfg.parseResp))
 	})
@@ -242,6 +248,39 @@ func TestImportByFilePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetEpisodeByFilePath_UsesFileStemAsTitleParam(t *testing.T) {
+	var gotTitle, gotPath string
+
+	knownParseOutput := &sonarrlib.ParseOutput{
+		Title: "Colonel Bleep",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Colonel Bleep",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
+		},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 1, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+		},
+	}
+
+	srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+		parseResp: knownParseOutput,
+		onParse: func(t *testing.T, r *http.Request) {
+			gotTitle = r.URL.Query().Get("title")
+			gotPath = r.URL.Query().Get("path")
+		},
+	})
+	t.Cleanup(srv.Close)
+
+	client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+
+	_, err := client.GetEpisodeByFilePath(t.Context(), "/downloads/Colonel.Bleep.S01E01.1080p.WEB-DL.mp4")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Colonel.Bleep.S01E01.1080p.WEB-DL", gotTitle, "title param should be filename stem")
+	assert.Empty(t, gotPath, "path param must not be sent")
 }
 
 func TestGetEpisodeByFilePath_UnreachableURL(t *testing.T) {

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -151,7 +151,7 @@ func NewMediaWorkflow(
 		}
 
 		return shared.DetectCropOutput{Crop: crop}, nil
-	}, hatchet.WithParents(probeTask), skipIfInvalid)
+	}, hatchet.WithParents(probeTask), skipIfInvalid, hatchet.WithExecutionTimeout(30*time.Minute))
 
 	// transcode: re-encode or copy the video stream directly into cfg.OutputDir under a
 	// temp name, then atomically rename it to the final path. Writing to the output
@@ -179,7 +179,7 @@ func NewMediaWorkflow(
 		}
 
 		return out, err
-	}, hatchet.WithParents(probeTask, detectcropTask), skipIfInvalid)
+	}, hatchet.WithParents(probeTask, detectcropTask), skipIfInvalid, hatchet.WithExecutionTimeout(4*time.Hour))
 
 	// notify: send a DownloadedMoviesScan/DownloadedEpisodesScan command to Radarr/Sonarr
 	// for the processed output file, triggering import into the library. The import path is

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
@@ -79,6 +80,7 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 			return ProbeOutput{}, fmt.Errorf("remove unrecognised file: %w", removeErr)
 		}
 
+		slog.WarnContext(ctx, "failed to probe file", "file", filePath, "error", err)
 		return ProbeOutput{IsValidMedia: false}, nil
 	}
 

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -81,6 +81,7 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 		}
 
 		slog.WarnContext(ctx, "failed to probe file", "file", filePath, "error", err)
+
 		return ProbeOutput{IsValidMedia: false}, nil
 	}
 


### PR DESCRIPTION
## Summary

- Adds `e2e/docker-compose.yml` — static compose file with Postgres, Hatchet, Radarr (ghcr.io/home-operations/radarr:6.1.2, port 7878), and Sonarr (ghcr.io/home-operations/sonarr:4.0.17, port 8989) on fixed ports that avoid conflicts with the dev stack
- Adds `e2e/stub/qbittorrent/server.go` — in-process HTTP stub implementing the qBittorrent Web API v2; on torrent-add it copies the BBB fixture into the download directory so the watcher can detect it
- Adds `e2e/e2e_test.go` — `//go:build e2e`; `TestMain` orchestrates Docker Compose, stub startup, Hatchet token generation, Radarr/Sonarr configuration, and watcher/worker subprocess lifecycle; `TestRadarrHappyPath` and `TestSonarrHappyPath` push releases and poll until import completes
- Updates `Makefile` with `test-e2e` target, `CLAUDE.md` with the new command, and `.gitignore` with `e2e/testdata/cache/`
- Fixes bugs with the service that cause the functionally correct e2e tests to fail.

## Test plan

- [x] `make test-e2e` — requires Docker and internet access; first run downloads the ~700 MB BBB fixture to `e2e/testdata/cache/`; subsequent runs use the cache
- [x] `TestRadarrHappyPath` polls `GET /api/v3/movie/{id}` until `hasFile=true`, then asserts source `.mp4` deleted and `.mkv` present in the Radarr library
- [x] `TestSonarrHappyPath` polls `GET /api/v3/episodefile?seriesId={id}` until non-empty, then asserts source `.mp4` deleted and `.mkv` present in the Sonarr library
- [x] Normal `make test` continues to pass (verified locally)
- [x] `golangci-lint run --build-tags=e2e ./e2e/...` reports 0 issues (verified locally)

Both `TestRadarrHappyPath` and `TestSonarrHappyPath` pass end-to-end.

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)