### PR TITLE
feat(watcher): add per-watch preserveSource option to skip source file deletion

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,17 +106,21 @@ No config file merging is performed. Exactly one YAML config file path is accept
 ### Watcher config example
 
 ```yaml
-cron_schedule: "*/5 * * * * *"
+cronSchedule: "*/5 * * * * *"
 watches:
   - name: movies
     path: /media/incoming/movies
-    media_type: movie
+    mediaType: movie
     ignorePatterns:
       - \.!qB$
       - (^|/)_unpack(/|$)
   - name: shows
     path: /media/incoming/tv
-    media_type: show
+    mediaType: show
+  - name: archive
+    path: /media/incoming/archive
+    mediaType: movie
+    preserveSource: true
 ```
 
-`cron_schedule` and `ignorePatterns` are both optional. A minimal entry only needs `name`, `path`, and `media_type`. `ignorePatterns` accepts Go regular expressions; a matching file is silently skipped, a matching directory skips its entire subtree.
+`cronSchedule`, `ignorePatterns`, and `preserveSource` are all optional. A minimal entry only needs `name`, `path`, and `mediaType`. `ignorePatterns` accepts Go regular expressions; a matching file is silently skipped, a matching directory skips its entire subtree. When `preserveSource: true` is set on a watch entry, the source file is kept after successful processing; omitting it or setting it to `false` retains the default behaviour of deleting the source file.

--- a/cmd/watcher/config_test.go
+++ b/cmd/watcher/config_test.go
@@ -157,7 +157,7 @@ watches: []
 watches:
   - name: movies
     path: /watch/movies
-    media_type: movie
+    mediaType: movie
     preserveSource: true
 `,
 			expected: Config{

--- a/cmd/watcher/config_test.go
+++ b/cmd/watcher/config_test.go
@@ -152,6 +152,22 @@ watches: []
 			},
 		},
 		{
+			name: "preserveSource true is parsed and set on watch entry",
+			content: `
+watches:
+  - name: movies
+    path: /watch/movies
+    media_type: movie
+    preserveSource: true
+`,
+			expected: Config{
+				CronSchedule: watcherconfig.DefaultCronSchedule,
+				Watches: []WatchEntry{
+					{Name: "movies", Path: "/watch/movies", MediaType: medialib.MovieType, PreserveSource: true},
+				},
+			},
+		},
+		{
 			name: "invalid regex in ignorePatterns returns error",
 			content: `
 watches:

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -30,8 +30,9 @@ func statusAttr(status string) attribute.KeyValue {
 	return attribute.String("status", status)
 }
 
-// dispatchFunc submits a workflow run for the given absolute file path, media type, and mapping name.
-type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string) error
+// dispatchFunc submits a workflow run for the given absolute file path, media type, mapping name,
+// and whether to preserve the source file after processing.
+type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool) error
 
 // scanInstruments holds all OTel instruments used during scan. Instruments are registered
 // once at startup and reused across every scan invocation.
@@ -123,14 +124,15 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterPro
 	task := client.NewStandaloneTask(
 		"directory-scan",
 		func(ctx hatchet.Context, _ struct{}) (struct{}, error) {
-			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string) error {
+			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool) error {
 				_, err := client.RunNoWait(
 					dispatchCtx,
 					media.MediaWorkflowName,
-					map[string]string{
-						"file_path":    filePath,
-						"media_type":   string(mediaType),
-						"mapping_name": mappingName,
+					media.MediaInput{
+						FilePath:       filePath,
+						MediaType:      mediaType,
+						MappingName:    mappingName,
+						PreserveSource: preserveSource,
 					},
 					hatchet.WithRunKey(filePath),
 				)
@@ -229,7 +231,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
 
-			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name); dispatchErr != nil {
+			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
 
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -186,7 +186,7 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 
 	var calls []call
 
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string) error {
+	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string, _ bool) error {
 		calls = append(calls, call{fp, mt, mn})
 		return nil
 	}
@@ -217,7 +217,7 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -244,7 +244,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 
 	var count int
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
 		count++
 		return errors.New("simulated dispatch failure")
 	}
@@ -271,7 +271,7 @@ func TestScan_ContextCancellationStopsWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately before scan starts
 
-	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil })
+	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil })
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -293,7 +293,7 @@ func TestScan_MultipleWatchEntries(t *testing.T) {
 	}
 
 	dispatched := make(map[string]medialib.MediaType) // path → media type
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, _ string, _ bool) error {
 		dispatched[fp] = mt
 		return nil
 	}
@@ -320,7 +320,7 @@ func TestScan_MetricsPresenceAfterScan(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 
@@ -348,7 +348,7 @@ func TestScan_SuccessCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_scans_total")
@@ -377,7 +377,7 @@ func TestScan_ErrorCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
 		return errors.New("simulated dispatch failure")
 	})
 
@@ -409,7 +409,7 @@ func TestScan_DurationObservedPerMapping(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_scan_duration_seconds")
@@ -448,7 +448,7 @@ func TestScan_LastSuccessfulScanSetOnSuccess(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_last_successful_scan_unix_seconds")
@@ -476,7 +476,7 @@ func TestScan_FilesDiscoveredCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_files_discovered_total")
@@ -508,7 +508,7 @@ func TestScan_DispatchesTotalCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_dispatches_total")
@@ -542,7 +542,7 @@ func TestScan_IgnorePatternSkipsMatchingFile(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -571,7 +571,7 @@ func TestScan_IgnorePatternPrunesMatchingDirectory(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -598,7 +598,7 @@ func TestScan_NonMatchingFileDispatchedWithIgnorePatterns(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -623,7 +623,7 @@ func TestScan_DispatchErrorsCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
 		return errors.New("hatchet unavailable")
 	})
 
@@ -640,4 +640,48 @@ func TestScan_DispatchErrorsCounter(t *testing.T) {
 	})
 	require.NotNil(t, dp, "expected data point with mapping_name=movies media_type=movie")
 	assert.EqualValues(t, 1, dp.Value)
+}
+
+// TestScan_PreserveSourceForwardedToDispatch verifies that the preserveSource value from a
+// WatchEntry is forwarded verbatim to the dispatch callback for each discovered file.
+func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		preserveSource bool
+	}{
+		{name: "preserveSource true is forwarded", preserveSource: true},
+		{name: "preserveSource false is forwarded", preserveSource: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+			cfg := &Config{
+				Watches: []WatchEntry{
+					{Name: "movies", Path: dir, MediaType: medialib.MovieType, PreserveSource: tt.preserveSource},
+				},
+			}
+
+			var gotPreserveSource bool
+
+			var dispatched bool
+
+			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, ps bool) error {
+				gotPreserveSource = ps
+				dispatched = true
+
+				return nil
+			}
+
+			require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
+			require.True(t, dispatched, "expected dispatch to be called")
+			assert.Equal(t, tt.preserveSource, gotPreserveSource)
+		})
+	}
 }

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -75,6 +75,10 @@ type WatchEntry struct {
 	// skipped; a matching directory causes its entire subtree to be pruned. Patterns are
 	// compiled at config load; an invalid expression causes loadConfig to return an error.
 	IgnorePatterns []CompiledRegexp `yaml:"ignorePatterns,omitempty" validate:"omitempty"`
+	// PreserveSource controls whether the source file is deleted after successful processing.
+	// When true, the source file is kept; when false or omitted, the source file is deleted
+	// (default behaviour).
+	PreserveSource bool `yaml:"preserveSource,omitempty"`
 }
 
 // Config is the top-level watcher configuration loaded from the YAML config file.

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -51,6 +51,9 @@
             "$ref": "#/$defs/CompiledRegexp"
           },
           "type": "array"
+        },
+        "preserveSource": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/workflows/media/integration_test.go
+++ b/workflows/media/integration_test.go
@@ -72,6 +72,32 @@ func TestMediaWorkflow_Movie_ValidVideoIsTranscodedAndSourceDeleted(t *testing.T
 	assert.True(t, os.IsNotExist(statErr), "source file should be deleted by cleanup step")
 }
 
+func TestMediaWorkflow_Movie_SourcePreservedWhenPreserveSourceIsTrue(t *testing.T) {
+	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
+		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")
+	}
+
+	client, err := hatchet.NewClient()
+	require.NoError(t, err)
+
+	inputPath := copyTestVideo(t)
+	outputDir := t.TempDir()
+
+	wf := NewMediaWorkflow(client, MediaWorkflowConfig{OutputDir: outputDir}, &stubLibraryClient{}, &stubLibraryClient{}, &webhook.Client{})
+	startMediaWorker(t, client, wf)
+
+	_, err = wf.Run(t.Context(), MediaInput{FilePath: inputPath, MediaType: medialib.MovieType, PreserveSource: true})
+	require.NoError(t, err)
+
+	inputBase := filepath.Base(inputPath)
+	mkvBase := strings.TrimSuffix(inputBase, filepath.Ext(inputBase)) + ".mkv"
+	_, statErr := os.Stat(filepath.Join(outputDir, mkvBase))
+	assert.NoError(t, statErr, "transcoded output file should exist in outputDir")
+
+	_, statErr = os.Stat(inputPath)
+	assert.NoError(t, statErr, "source file should be preserved when PreserveSource is true")
+}
+
 func TestMediaWorkflow_Movie_ImportByFilePathIsCalledAfterTranscode(t *testing.T) {
 	if os.Getenv("HATCHET_CLIENT_TOKEN") == "" {
 		t.Skip("HATCHET_CLIENT_TOKEN not set; run 'make hatchet-up' and 'source .env.hatchet' first")

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -74,9 +74,10 @@ type MediaWorkflowConfig struct {
 
 // MediaInput is the workflow's trigger payload.
 type MediaInput struct {
-	FilePath    string             `json:"file_path"`
-	MediaType   medialib.MediaType `json:"media_type"`
-	MappingName string             `json:"mapping_name"`
+	FilePath       string             `json:"file_path"`
+	MediaType      medialib.MediaType `json:"media_type"`
+	MappingName    string             `json:"mapping_name"`
+	PreserveSource bool               `json:"preserve_source,omitempty"`
 }
 
 // NewMediaWorkflow returns a Hatchet workflow that transcodes a media file (movie or TV
@@ -234,8 +235,13 @@ func NewMediaWorkflow(
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
-	// cleanup: delete the original source file after successful processing.
+	// cleanup: delete the original source file after successful processing, unless
+	// PreserveSource is set on the originating watch entry.
 	cleanupTask := wf.NewTask("cleanup", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+		if input.PreserveSource {
+			return struct{}{}, nil
+		}
+
 		return struct{}{}, shared.RunCleanup(input.FilePath)
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 


### PR DESCRIPTION
## Summary

- Adds `preserveSource: bool` to `WatchEntry` (watcher config) and `MediaInput` (workflow payload)
- Gates the cleanup step's `shared.RunCleanup` call on `!input.PreserveSource`; when `true`, the source file is left untouched after successful processing
- Changes the dispatch payload from `map[string]string` to `media.MediaInput` so `PreserveSource` is serialised as a native JSON boolean
- Updates `SPEC.md` config example to document the new field

## Test plan

- [x] `make test` — all unit tests pass including new `TestScan_PreserveSourceForwardedToDispatch` and the `preserveSource: true` config parse case
- [x] `make lint` — 0 issues
- [x] AC1/AC2 (source file preserved/deleted after processing) — requires `make test-e2e` with Docker

Fixes #88