### PR TITLE
feat(watcher): remove empty parent directories during source file cleanup

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -121,6 +121,7 @@ watches:
     path: /media/incoming/archive
     mediaType: movie
     preserveSource: true
+    retainEmptyDirectories: true
 ```
 
-`cronSchedule`, `ignorePatterns`, and `preserveSource` are all optional. A minimal entry only needs `name`, `path`, and `mediaType`. `ignorePatterns` accepts Go regular expressions; a matching file is silently skipped, a matching directory skips its entire subtree. When `preserveSource: true` is set on a watch entry, the source file is kept after successful processing; omitting it or setting it to `false` retains the default behaviour of deleting the source file.
+`cronSchedule`, `ignorePatterns`, `preserveSource`, and `retainEmptyDirectories` are all optional. A minimal entry only needs `name`, `path`, and `mediaType`. `ignorePatterns` accepts Go regular expressions; a matching file is silently skipped, a matching directory skips its entire subtree. When `preserveSource: true` is set on a watch entry, the source file is kept after successful processing; omitting it or setting it to `false` retains the default behaviour of deleting the source file. By default, after a source file is deleted (either because it is invalid media or after successful processing), any parent directories that become empty are removed bottom-up, stopping at the watch root. Set `retainEmptyDirectories: true` to disable this behaviour and leave empty directories in place.

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -221,14 +221,8 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				return nil
 			}
 
-			absPath, err := filepath.Abs(path)
-			if err != nil {
-				mappingErrs = append(mappingErrs, fmt.Errorf("resolve absolute path for %q: %w", path, err))
-				return nil
-			}
-
 			for _, pattern := range w.IgnorePatterns {
-				if pattern.MatchString(absPath) {
+				if pattern.MatchString(path) {
 					if d.IsDir() {
 						return filepath.SkipDir
 					}
@@ -243,8 +237,8 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
 
-			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories); dispatchErr != nil {
-				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
+			if dispatchErr := dispatch(ctx, path, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories); dispatchErr != nil {
+				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", path, w.MediaType, dispatchErr))
 
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)
 			} else {

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -31,8 +31,9 @@ func statusAttr(status string) attribute.KeyValue {
 }
 
 // dispatchFunc submits a workflow run for the given absolute file path, media type, mapping name,
-// and whether to preserve the source file after processing.
-type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool) error
+// whether to preserve the source file after processing, the watch root directory, and whether to
+// retain empty parent directories after source-file deletion.
+type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool) error
 
 // scanInstruments holds all OTel instruments used during scan. Instruments are registered
 // once at startup and reused across every scan invocation.
@@ -124,15 +125,17 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterPro
 	task := client.NewStandaloneTask(
 		"directory-scan",
 		func(ctx hatchet.Context, _ struct{}) (struct{}, error) {
-			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool) error {
+			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool) error {
 				_, err := client.RunNoWait(
 					dispatchCtx,
 					media.MediaWorkflowName,
 					media.MediaInput{
-						FilePath:       filePath,
-						MediaType:      mediaType,
-						MappingName:    mappingName,
-						PreserveSource: preserveSource,
+						FilePath:               filePath,
+						MediaType:              mediaType,
+						MappingName:            mappingName,
+						PreserveSource:         preserveSource,
+						WatchRoot:              watchRoot,
+						RetainEmptyDirectories: retainEmptyDirs,
 					},
 					hatchet.WithRunKey(filePath),
 				)
@@ -231,7 +234,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
 
-			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource); dispatchErr != nil {
+			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource, w.Path, w.RetainEmptyDirectories); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
 
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -200,9 +200,18 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 		var mappingErrs []error
 
+		// Normalise the watch path to an absolute path once per entry so that watchRoot
+		// is always comparable to the absolute file paths produced inside the walk callback.
+		absWatchRoot, err := filepath.Abs(w.Path)
+		if err != nil {
+			mappingErrs = append(mappingErrs, fmt.Errorf("resolve absolute path for watch directory %q: %w", w.Path, err))
+			errs = append(errs, mappingErrs...)
+			continue
+		}
+
 		start := time.Now()
 
-		if err := filepath.WalkDir(w.Path, func(path string, d fs.DirEntry, err error) error {
+		if err := filepath.WalkDir(absWatchRoot, func(path string, d fs.DirEntry, err error) error {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return ctxErr
 			}
@@ -234,7 +243,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
 
-			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource, w.Path, w.RetainEmptyDirectories); dispatchErr != nil {
+			if dispatchErr := dispatch(ctx, absPath, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", absPath, w.MediaType, dispatchErr))
 
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -186,7 +186,7 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 
 	var calls []call
 
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string, _ bool, _ string, _ bool) error {
 		calls = append(calls, call{fp, mt, mn})
 		return nil
 	}
@@ -217,7 +217,7 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -244,7 +244,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 
 	var count int
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		count++
 		return errors.New("simulated dispatch failure")
 	}
@@ -271,7 +271,9 @@ func TestScan_ContextCancellationStopsWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately before scan starts
 
-	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil })
+	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	})
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -293,7 +295,7 @@ func TestScan_MultipleWatchEntries(t *testing.T) {
 	}
 
 	dispatched := make(map[string]medialib.MediaType) // path → media type
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		dispatched[fp] = mt
 		return nil
 	}
@@ -320,7 +322,9 @@ func TestScan_MetricsPresenceAfterScan(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 
@@ -348,7 +352,9 @@ func TestScan_SuccessCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_scans_total")
@@ -377,7 +383,7 @@ func TestScan_ErrorCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		return errors.New("simulated dispatch failure")
 	})
 
@@ -409,7 +415,9 @@ func TestScan_DurationObservedPerMapping(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_scan_duration_seconds")
@@ -448,7 +456,9 @@ func TestScan_LastSuccessfulScanSetOnSuccess(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_last_successful_scan_unix_seconds")
@@ -476,7 +486,9 @@ func TestScan_FilesDiscoveredCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_files_discovered_total")
@@ -508,7 +520,9 @@ func TestScan_DispatchesTotalCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error { return nil }))
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		return nil
+	}))
 
 	rm := collectMetrics(t, reader)
 	m := findMetric(rm, "watcher_dispatches_total")
@@ -542,7 +556,7 @@ func TestScan_IgnorePatternSkipsMatchingFile(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -571,7 +585,7 @@ func TestScan_IgnorePatternPrunesMatchingDirectory(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -598,7 +612,7 @@ func TestScan_NonMatchingFileDispatchedWithIgnorePatterns(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool) error {
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		dispatched = append(dispatched, fp)
 		return nil
 	}
@@ -623,7 +637,7 @@ func TestScan_DispatchErrorsCounter(t *testing.T) {
 	}
 
 	instruments, reader := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
 		return errors.New("hatchet unavailable")
 	})
 
@@ -672,7 +686,7 @@ func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {
 
 			var dispatched bool
 
-			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, ps bool) error {
+			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, ps bool, _ string, _ bool) error {
 				gotPreserveSource = ps
 				dispatched = true
 
@@ -682,6 +696,80 @@ func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {
 			require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
 			require.True(t, dispatched, "expected dispatch to be called")
 			assert.Equal(t, tt.preserveSource, gotPreserveSource)
+		})
+	}
+}
+
+// TestScan_WatchRootForwardedToDispatch verifies that the watch entry's Path is forwarded
+// as watchRoot to the dispatch callback for each discovered file.
+func TestScan_WatchRootForwardedToDispatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	var gotWatchRoot string
+
+	var dispatched bool
+
+	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, wr string, _ bool) error {
+		gotWatchRoot = wr
+		dispatched = true
+
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
+	require.True(t, dispatched, "expected dispatch to be called")
+	assert.Equal(t, dir, gotWatchRoot)
+}
+
+// TestScan_RetainEmptyDirsForwardedToDispatch verifies that the retainEmptyDirectories value
+// from a WatchEntry is forwarded verbatim to the dispatch callback for each discovered file.
+func TestScan_RetainEmptyDirsForwardedToDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		retainEmptyDirectories bool
+	}{
+		{name: "retainEmptyDirectories true is forwarded", retainEmptyDirectories: true},
+		{name: "retainEmptyDirectories false is forwarded", retainEmptyDirectories: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+
+			cfg := &Config{
+				Watches: []WatchEntry{
+					{Name: "movies", Path: dir, MediaType: medialib.MovieType, RetainEmptyDirectories: tt.retainEmptyDirectories},
+				},
+			}
+
+			var gotRetainEmptyDirs bool
+
+			var dispatched bool
+
+			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, red bool) error {
+				gotRetainEmptyDirs = red
+				dispatched = true
+
+				return nil
+			}
+
+			require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
+			require.True(t, dispatched, "expected dispatch to be called")
+			assert.Equal(t, tt.retainEmptyDirectories, gotRetainEmptyDirs)
 		})
 	}
 }

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -79,6 +79,11 @@ type WatchEntry struct {
 	// When true, the source file is kept; when false or omitted, the source file is deleted
 	// (default behaviour).
 	PreserveSource bool `yaml:"preserveSource,omitempty"`
+	// RetainEmptyDirectories controls whether empty parent directories are removed after the
+	// source file is deleted. When false or omitted (the default), parent directories that
+	// become empty as a result of source-file deletion are pruned bottom-up, stopping at the
+	// watch root. When true, no directory removal is performed (current behaviour).
+	RetainEmptyDirectories bool `yaml:"retainEmptyDirectories,omitempty"`
 }
 
 // Config is the top-level watcher configuration loaded from the YAML config file.

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -54,6 +54,9 @@
         },
         "preserveSource": {
           "type": "boolean"
+        },
+        "retainEmptyDirectories": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -74,10 +74,12 @@ type MediaWorkflowConfig struct {
 
 // MediaInput is the workflow's trigger payload.
 type MediaInput struct {
-	FilePath       string             `json:"file_path"`
-	MediaType      medialib.MediaType `json:"media_type"`
-	MappingName    string             `json:"mapping_name"`
-	PreserveSource bool               `json:"preserve_source,omitempty"`
+	FilePath               string             `json:"file_path"`
+	MediaType              medialib.MediaType `json:"media_type"`
+	MappingName            string             `json:"mapping_name"`
+	PreserveSource         bool               `json:"preserve_source,omitempty"`
+	WatchRoot              string             `json:"watch_root,omitempty"`
+	RetainEmptyDirectories bool               `json:"retain_empty_directories,omitempty"`
 }
 
 // NewMediaWorkflow returns a Hatchet workflow that transcodes a media file (movie or TV
@@ -143,7 +145,7 @@ func NewMediaWorkflow(
 	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (shared.ProbeOutput, error) {
 		start := time.Now()
 
-		out, err := shared.RunProbe(ctx, input.FilePath)
+		out, err := shared.RunProbe(ctx, input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 		if err != nil {
 			return out, err
 		}
@@ -242,7 +244,7 @@ func NewMediaWorkflow(
 			return struct{}{}, nil
 		}
 
-		return struct{}{}, shared.RunCleanup(input.FilePath)
+		return struct{}{}, shared.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// record_metrics: record per-run OTel observations for valid-media completions.

--- a/workflows/shared/cleanup.go
+++ b/workflows/shared/cleanup.go
@@ -43,14 +43,25 @@ func pruneEmptyParents(filePath, watchRoot string) {
 	dir := filepath.Dir(filePath)
 
 	for {
-		rel, err := filepath.Rel(watchRoot, dir)
-		// rel == "." means dir IS the watch root; !filepath.IsLocal catches paths that
-		// escape the root (e.g. "..") — both are stopping conditions.
-		if err != nil || rel == "." || !filepath.IsLocal(rel) {
+		relDir, err := filepath.Rel(watchRoot, dir)
+		if err != nil {
+			slog.Warn("prune empty parent: could not compute relative path", "dir", dir, "watchRoot", watchRoot, "error", err)
 			return
 		}
 
-		d, err := root.Open(rel)
+		// Reached the watch root — stop without removing it.
+		if relDir == "." {
+			return
+		}
+
+		// relDir escapes watchRoot (e.g. filePath was outside the watch tree). This
+		// indicates a misconfiguration or security issue; log and stop.
+		if !filepath.IsLocal(relDir) {
+			slog.Warn("prune empty parent: directory is outside watch root", "dir", dir, "watchRoot", watchRoot)
+			return
+		}
+
+		d, err := root.Open(relDir)
 		if err != nil {
 			return
 		}
@@ -60,8 +71,8 @@ func pruneEmptyParents(filePath, watchRoot string) {
 			return
 		}
 
-		if removeErr := root.Remove(rel); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			slog.Warn("prune empty parent: failed to remove directory", "dir", filepath.Join(watchRoot, rel), "error", removeErr)
+		if removeErr := root.Remove(relDir); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			slog.Warn("prune empty parent: failed to remove directory", "dir", filepath.Join(watchRoot, relDir), "error", removeErr)
 			return
 		}
 

--- a/workflows/shared/cleanup.go
+++ b/workflows/shared/cleanup.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -65,9 +66,11 @@ func pruneEmptyParents(filePath, watchRoot string) {
 		if err != nil {
 			return
 		}
-		entries, err := d.ReadDir(-1)
+		// ReadDir(1) reads at most one entry — enough to determine whether the
+		// directory is empty without loading the full listing.
+		entries, err := d.ReadDir(1)
 		_ = d.Close()
-		if err != nil || len(entries) > 0 {
+		if len(entries) > 0 || (err != nil && !errors.Is(err, io.EOF)) {
 			return
 		}
 

--- a/workflows/shared/cleanup.go
+++ b/workflows/shared/cleanup.go
@@ -3,14 +3,64 @@ package shared
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
-// RunCleanup deletes the original source file after successful processing.
-func RunCleanup(filePath string) error {
+// RunCleanup deletes the original source file after successful processing and,
+// unless retainEmptyDirs is true, removes any parent directories that become
+// empty as a result, stopping at watchRoot.
+func RunCleanup(filePath, watchRoot string, retainEmptyDirs bool) error {
 	if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("delete source file: %w", err)
 	}
 
+	if !retainEmptyDirs {
+		pruneEmptyParents(filePath, watchRoot)
+	}
+
 	return nil
+}
+
+// pruneEmptyParents removes parent directories of filePath bottom-up as long as each
+// directory is empty, stopping when it reaches watchRoot or a non-empty directory.
+// The watch root itself is never removed. If watchRoot is empty, no pruning is performed.
+// Removal errors are logged and do not propagate; they are expected in concurrent-write
+// scenarios (e.g. a new file was written to the directory between the ReadDir check and Remove).
+func pruneEmptyParents(filePath, watchRoot string) {
+	if watchRoot == "" {
+		return
+	}
+
+	cleanRoot := filepath.Clean(watchRoot)
+	dir := filepath.Dir(filePath)
+
+	for {
+		cleanDir := filepath.Clean(dir)
+
+		if cleanDir == cleanRoot {
+			return
+		}
+
+		// Stop if dir is not a descendant of watchRoot — protects against misconfiguration
+		// where filePath is outside the watch tree.
+		if !strings.HasPrefix(cleanDir+string(filepath.Separator), cleanRoot+string(filepath.Separator)) {
+			return
+		}
+
+		entries, err := os.ReadDir(cleanDir)
+		if err != nil || len(entries) > 0 {
+			return
+		}
+
+		if removeErr := os.Remove(cleanDir); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			slog.Warn("prune empty parent: failed to remove directory", "dir", cleanDir, "error", removeErr)
+
+			return
+		}
+
+		dir = filepath.Dir(dir)
+	}
 }

--- a/workflows/shared/cleanup.go
+++ b/workflows/shared/cleanup.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // RunCleanup deletes the original source file after successful processing and,
@@ -34,30 +33,35 @@ func pruneEmptyParents(filePath, watchRoot string) {
 		return
 	}
 
-	cleanRoot := filepath.Clean(watchRoot)
+	root, err := os.OpenRoot(watchRoot)
+	if err != nil {
+		slog.Warn("prune empty parent: failed to open watch root", "watchRoot", watchRoot, "error", err)
+		return
+	}
+	defer root.Close()
+
 	dir := filepath.Dir(filePath)
 
 	for {
-		cleanDir := filepath.Clean(dir)
-
-		if cleanDir == cleanRoot {
+		rel, err := filepath.Rel(watchRoot, dir)
+		// rel == "." means dir IS the watch root; !filepath.IsLocal catches paths that
+		// escape the root (e.g. "..") — both are stopping conditions.
+		if err != nil || rel == "." || !filepath.IsLocal(rel) {
 			return
 		}
 
-		// Stop if dir is not a descendant of watchRoot — protects against misconfiguration
-		// where filePath is outside the watch tree.
-		if !strings.HasPrefix(cleanDir+string(filepath.Separator), cleanRoot+string(filepath.Separator)) {
+		d, err := root.Open(rel)
+		if err != nil {
 			return
 		}
-
-		entries, err := os.ReadDir(cleanDir)
+		entries, err := d.ReadDir(-1)
+		_ = d.Close()
 		if err != nil || len(entries) > 0 {
 			return
 		}
 
-		if removeErr := os.Remove(cleanDir); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			slog.Warn("prune empty parent: failed to remove directory", "dir", cleanDir, "error", removeErr)
-
+		if removeErr := root.Remove(rel); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			slog.Warn("prune empty parent: failed to remove directory", "dir", filepath.Join(watchRoot, rel), "error", removeErr)
 			return
 		}
 

--- a/workflows/shared/cleanup_test.go
+++ b/workflows/shared/cleanup_test.go
@@ -41,7 +41,7 @@ func TestRunCleanup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := tt.setupPath(t)
 
-			err := RunCleanup(path)
+			err := RunCleanup(path, "", false)
 
 			tt.errFunc(t, err)
 
@@ -51,4 +51,115 @@ func TestRunCleanup(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunCleanup_PrunesEmptyParents verifies that empty parent directories between the
+// deleted file and the watch root are removed bottom-up after cleanup.
+func TestRunCleanup_PrunesEmptyParents(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "Some.Release.Name")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "video.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+	require.NoError(t, RunCleanup(filePath, watchRoot, false))
+
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "source file should be deleted")
+
+	_, statErr = os.Stat(subdir)
+	assert.True(t, os.IsNotExist(statErr), "empty wrapper directory should be removed")
+
+	_, statErr = os.Stat(watchRoot)
+	assert.NoError(t, statErr, "watch root must not be removed")
+}
+
+// TestRunCleanup_StopsAtNonEmptyParent verifies that traversal stops when a sibling file
+// exists next to the deleted source file.
+func TestRunCleanup_StopsAtNonEmptyParent(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "release")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "video.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+	sibling := filepath.Join(subdir, "subtitle.srt")
+	require.NoError(t, os.WriteFile(sibling, []byte("sub"), 0o600))
+
+	require.NoError(t, RunCleanup(filePath, watchRoot, false))
+
+	_, statErr := os.Stat(subdir)
+	assert.NoError(t, statErr, "directory with sibling file should not be removed")
+}
+
+// TestRunCleanup_RetainEmptyDirsSkipsPruning verifies that empty parent directories are
+// left intact when retainEmptyDirs is true.
+func TestRunCleanup_RetainEmptyDirsSkipsPruning(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "release")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "video.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+	require.NoError(t, RunCleanup(filePath, watchRoot, true))
+
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "source file should still be deleted")
+
+	_, statErr = os.Stat(subdir)
+	assert.NoError(t, statErr, "empty parent should be kept when retainEmptyDirs is true")
+}
+
+// TestRunCleanup_WatchRootNotRemoved verifies that the watch root itself is never removed
+// even when it becomes empty after the source file is deleted.
+func TestRunCleanup_WatchRootNotRemoved(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	filePath := filepath.Join(watchRoot, "video.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+	require.NoError(t, RunCleanup(filePath, watchRoot, false))
+
+	_, statErr := os.Stat(watchRoot)
+	assert.NoError(t, statErr, "watch root must not be removed even when empty")
+}
+
+// TestRunCleanup_PrunesMultiLevelEmptyChain verifies that multiple levels of empty
+// ancestor directories are removed bottom-up until a non-empty ancestor or the watch root.
+func TestRunCleanup_PrunesMultiLevelEmptyChain(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	nested := filepath.Join(watchRoot, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	filePath := filepath.Join(nested, "video.mkv")
+	require.NoError(t, os.WriteFile(filePath, []byte("data"), 0o600))
+
+	require.NoError(t, RunCleanup(filePath, watchRoot, false))
+
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "source file should be deleted")
+
+	for _, dir := range []string{
+		filepath.Join(watchRoot, "a", "b", "c"),
+		filepath.Join(watchRoot, "a", "b"),
+		filepath.Join(watchRoot, "a"),
+	} {
+		_, statErr = os.Stat(dir)
+		assert.True(t, os.IsNotExist(statErr), "empty ancestor %q should be removed", dir)
+	}
+
+	_, statErr = os.Stat(watchRoot)
+	assert.NoError(t, statErr, "watch root must not be removed")
 }

--- a/workflows/shared/probe.go
+++ b/workflows/shared/probe.go
@@ -67,7 +67,9 @@ type ProbeOutput struct {
 // RunProbe reads codec and container info for filePath. If the file is not a
 // recognised media file or has no video stream, it deletes the file and returns
 // IsValidMedia=false (without error), causing all downstream steps to be skipped.
-func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
+// When retainEmptyDirs is false and a deletion occurs, empty parent directories up
+// to watchRoot are also removed via pruneEmptyParents.
+func RunProbe(ctx context.Context, filePath, watchRoot string, retainEmptyDirs bool) (ProbeOutput, error) {
 	info, err := ffprobe.Probe(ctx, filePath)
 	if err != nil {
 		// Context errors are operational — propagate them so the step fails and
@@ -78,6 +80,10 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 
 		if removeErr := os.Remove(filePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return ProbeOutput{}, fmt.Errorf("remove unrecognised file: %w", removeErr)
+		}
+
+		if !retainEmptyDirs {
+			pruneEmptyParents(filePath, watchRoot)
 		}
 
 		slog.WarnContext(ctx, "failed to probe file", "file", filePath, "error", err)
@@ -136,6 +142,10 @@ func RunProbe(ctx context.Context, filePath string) (ProbeOutput, error) {
 	// No video stream found.
 	if removeErr := os.Remove(filePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 		return ProbeOutput{}, fmt.Errorf("remove file with no video streams: %w", removeErr)
+	}
+
+	if !retainEmptyDirs {
+		pruneEmptyParents(filePath, watchRoot)
 	}
 
 	return ProbeOutput{IsValidMedia: false}, nil

--- a/workflows/shared/probe_test.go
+++ b/workflows/shared/probe_test.go
@@ -45,7 +45,7 @@ func TestRunProbe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := tt.setupPath(t)
 
-			got, err := RunProbe(t.Context(), path)
+			got, err := RunProbe(t.Context(), path, "", false)
 
 			tt.errFunc(t, err)
 			assert.Equal(t, tt.expected, got)
@@ -61,7 +61,7 @@ func TestRunProbe(t *testing.T) {
 func TestRunProbe_ValidMediaFile(t *testing.T) {
 	path := copyTestVideo(t)
 
-	got, err := RunProbe(t.Context(), path)
+	got, err := RunProbe(t.Context(), path, "", false)
 
 	require.NoError(t, err)
 	// Check all non-float fields via struct equality (DurationSeconds zeroed out).
@@ -90,9 +90,81 @@ func TestRunProbe_CancelledContextPropagatesError(t *testing.T) {
 
 	path := copyTestVideo(t)
 
-	_, err := RunProbe(ctx, path)
+	_, err := RunProbe(ctx, path, "", false)
 	require.ErrorIs(t, err, context.Canceled, "cancelled context should propagate as error, not delete the file")
 
 	_, statErr := os.Stat(path)
 	assert.NoError(t, statErr, "file must not be deleted on context cancellation")
+}
+
+// TestRunProbe_PrunesEmptyParentsOnInvalidFile verifies that when a non-media file is
+// deleted by the probe step, empty parent directories up to the watch root are removed.
+func TestRunProbe_PrunesEmptyParentsOnInvalidFile(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "Some.Release.Name")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "notavideo.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o600))
+
+	got, err := RunProbe(t.Context(), filePath, watchRoot, false)
+	require.NoError(t, err)
+	assert.False(t, got.IsValidMedia)
+
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "invalid file should be deleted")
+
+	_, statErr = os.Stat(subdir)
+	assert.True(t, os.IsNotExist(statErr), "empty wrapper directory should be removed")
+
+	_, statErr = os.Stat(watchRoot)
+	assert.NoError(t, statErr, "watch root must not be removed")
+}
+
+// TestRunProbe_StopsAtNonEmptyParentOnInvalidFile verifies that traversal stops when a
+// sibling file exists in the same directory as the deleted file.
+func TestRunProbe_StopsAtNonEmptyParentOnInvalidFile(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "release")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "notavideo.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o600))
+
+	sibling := filepath.Join(subdir, "other.mkv")
+	require.NoError(t, os.WriteFile(sibling, []byte("data"), 0o600))
+
+	got, err := RunProbe(t.Context(), filePath, watchRoot, false)
+	require.NoError(t, err)
+	assert.False(t, got.IsValidMedia)
+
+	_, statErr := os.Stat(subdir)
+	assert.NoError(t, statErr, "directory with sibling file should not be removed")
+}
+
+// TestRunProbe_RetainEmptyDirsSkipsPruning verifies that empty parent directories are
+// left intact when retainEmptyDirs is true.
+func TestRunProbe_RetainEmptyDirsSkipsPruning(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	subdir := filepath.Join(watchRoot, "release")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	filePath := filepath.Join(subdir, "notavideo.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o600))
+
+	got, err := RunProbe(t.Context(), filePath, watchRoot, true)
+	require.NoError(t, err)
+	assert.False(t, got.IsValidMedia)
+
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "invalid file should still be deleted")
+
+	_, statErr = os.Stat(subdir)
+	assert.NoError(t, statErr, "empty parent should be kept when retainEmptyDirs is true")
 }


### PR DESCRIPTION
## Summary

- Add `pruneEmptyParents` helper in `workflows/shared/cleanup.go` that walks up from a deleted file's parent, removing each empty directory until it reaches the watch root or a non-empty ancestor
- Call `pruneEmptyParents` from all three deletion sites: `RunCleanup` (successful processing) and both `os.Remove` paths in `RunProbe` (ffprobe failure and no-video-stream), guarded by `!retainEmptyDirs`
- Add `RetainEmptyDirectories bool` to `WatchEntry` and thread `WatchRoot`/`RetainEmptyDirectories` through `MediaInput` so the worker observes them at cleanup time
- Document `retainEmptyDirectories` in `SPEC.md` alongside `preserveSource`

## Test plan

- [ ] `make test` passes (all unit tests green, race detector clean)
- [ ] `make lint` passes (0 issues)
- [ ] `TestRunCleanup_PrunesEmptyParents` — empty wrapper dir removed after source deletion
- [ ] `TestRunCleanup_StopsAtNonEmptyParent` — sibling file keeps parent dir
- [ ] `TestRunCleanup_RetainEmptyDirsSkipsPruning` — opt-out leaves dirs intact
- [ ] `TestRunCleanup_WatchRootNotRemoved` — watch root survives even when empty
- [ ] `TestRunCleanup_PrunesMultiLevelEmptyChain` — multi-level empty chain pruned
- [ ] `TestRunProbe_PrunesEmptyParentsOnInvalidFile` — invalid-media path prunes dirs
- [ ] `TestRunProbe_StopsAtNonEmptyParentOnInvalidFile` — sibling stops traversal
- [ ] `TestRunProbe_RetainEmptyDirsSkipsPruning` — opt-out on probe path
- [ ] `TestScan_WatchRootForwardedToDispatch` — watch path wired to MediaInput
- [ ] `TestScan_RetainEmptyDirsForwardedToDispatch` — retainEmptyDirectories wired to MediaInput

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)