### PR TITLE
refactor: rename workflows/shared package to workflows/steps

### DIFF
--- a/workflows/media/attrs.go
+++ b/workflows/media/attrs.go
@@ -6,7 +6,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
-	"github.com/solidDoWant/media-processor/workflows/shared"
+	"github.com/solidDoWant/media-processor/workflows/steps"
 )
 
 func mediaTypeAttr(mt medialib.MediaType) attribute.KeyValue {
@@ -18,7 +18,7 @@ func mappingNameAttr(name string) attribute.KeyValue {
 }
 
 // buildStandardAttrs returns the full standard label set for processing metrics.
-func buildStandardAttrs(input MediaInput, probe shared.ProbeOutput, transcode shared.TranscodeOutput, hardwareAccelerated bool) []attribute.KeyValue {
+func buildStandardAttrs(input MediaInput, probe steps.ProbeOutput, transcode steps.TranscodeOutput, hardwareAccelerated bool) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("source_codec", probe.VideoCodec),
 		attribute.String("destination_codec", transcode.DestCodec),

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/pkg/webhook"
-	"github.com/solidDoWant/media-processor/workflows/shared"
+	"github.com/solidDoWant/media-processor/workflows/steps"
 )
 
 const (
@@ -142,10 +142,10 @@ func NewMediaWorkflow(
 	// (without error) when the file is not a recognisable media file or has no video stream,
 	// which causes all downstream steps to be skipped via WithSkipIf.
 	// StartedAt is set here (not inside RunProbe) so existing RunProbe tests are unaffected.
-	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (shared.ProbeOutput, error) {
+	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (steps.ProbeOutput, error) {
 		start := time.Now()
 
-		out, err := shared.RunProbe(ctx, input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		out, err := steps.RunProbe(ctx, input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 		if err != nil {
 			return out, err
 		}
@@ -165,41 +165,41 @@ func NewMediaWorkflow(
 	// Crop pointer when no crop is warranted (both axes disabled or trim below threshold).
 	// cfg.MinCropX and cfg.MinCropY are passed directly; defaults are applied by the
 	// caller (cmd/worker) via parseCropThreshold before constructing MediaWorkflowConfig.
-	detectcropTask := wf.NewTask("detectcrop", func(ctx hatchet.Context, input MediaInput) (shared.DetectCropOutput, error) {
-		var probe shared.ProbeOutput
+	detectcropTask := wf.NewTask("detectcrop", func(ctx hatchet.Context, input MediaInput) (steps.DetectCropOutput, error) {
+		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
-			return shared.DetectCropOutput{}, fmt.Errorf("get probe output: %w", err)
+			return steps.DetectCropOutput{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		crop, err := shared.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, cfg.MinCropX, cfg.MinCropY)
+		crop, err := steps.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, cfg.MinCropX, cfg.MinCropY)
 		if err != nil {
-			return shared.DetectCropOutput{}, err
+			return steps.DetectCropOutput{}, err
 		}
 
-		return shared.DetectCropOutput{Crop: crop}, nil
+		return steps.DetectCropOutput{Crop: crop}, nil
 	}, hatchet.WithParents(probeTask), skipIfInvalid, hatchet.WithExecutionTimeout(cfg.DetectCropTimeout))
 
 	// transcode: re-encode or copy the video stream directly into cfg.OutputDir under a
 	// temp name, then atomically rename it to the final path. Writing to the output
 	// directory (rather than the system temp dir) means the rename is always within the
 	// same filesystem, so it is guaranteed to be atomic on Linux.
-	transcodeTask := wf.NewTask("transcode", func(ctx hatchet.Context, input MediaInput) (shared.TranscodeOutput, error) {
-		var probe shared.ProbeOutput
+	transcodeTask := wf.NewTask("transcode", func(ctx hatchet.Context, input MediaInput) (steps.TranscodeOutput, error) {
+		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
-			return shared.TranscodeOutput{}, fmt.Errorf("get probe output: %w", err)
+			return steps.TranscodeOutput{}, fmt.Errorf("get probe output: %w", err)
 		}
 
-		var detectcrop shared.DetectCropOutput
+		var detectcrop steps.DetectCropOutput
 		if err := ctx.ParentOutput(detectcropTask, &detectcrop); err != nil {
-			return shared.TranscodeOutput{}, fmt.Errorf("get detectcrop output: %w", err)
+			return steps.TranscodeOutput{}, fmt.Errorf("get detectcrop output: %w", err)
 		}
 
 		library, err := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
 		if err != nil {
-			return shared.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
+			return steps.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
 		}
 
-		out, err := shared.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, library)
+		out, err := steps.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, library)
 		if err == nil && out.ArtworkFetchSkipped {
 			recorder.RecordArtworkFetchSkipped(ctx)
 		}
@@ -213,7 +213,7 @@ func NewMediaWorkflow(
 	// by .mkv, so that the path points to the actual transcoded file as seen by the arr
 	// service (via the LocalPathPrefix/RemotePathPrefix translation in ImportByFilePath).
 	notifyTask := wf.NewTask("notify", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
-		var transcode shared.TranscodeOutput
+		var transcode steps.TranscodeOutput
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
 			return struct{}{}, fmt.Errorf("get transcode output: %w", err)
 		}
@@ -244,18 +244,18 @@ func NewMediaWorkflow(
 			return struct{}{}, nil
 		}
 
-		return struct{}{}, shared.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		return struct{}{}, steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// record_metrics: record per-run OTel observations for valid-media completions.
 	// Runs after cleanup so total_duration_seconds covers the full probe→cleanup span.
 	_ = wf.NewTask("record_metrics", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
-		var probe shared.ProbeOutput
+		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			return struct{}{}, fmt.Errorf("get probe output for metrics: %w", err)
 		}
 
-		var transcode shared.TranscodeOutput
+		var transcode steps.TranscodeOutput
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
 			return struct{}{}, fmt.Errorf("get transcode output for metrics: %w", err)
 		}
@@ -294,7 +294,7 @@ func NewMediaWorkflow(
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
-		return struct{}{}, shared.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), MediaWorkflowName, input.FilePath, webhookClient)
+		return struct{}{}, steps.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), MediaWorkflowName, input.FilePath, webhookClient)
 	})
 
 	return wf

--- a/workflows/media/recorder.go
+++ b/workflows/media/recorder.go
@@ -9,7 +9,7 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
-	"github.com/solidDoWant/media-processor/workflows/shared"
+	"github.com/solidDoWant/media-processor/workflows/steps"
 )
 
 // Recorder holds OTel instruments for the media workflow and records per-run observations.
@@ -123,8 +123,8 @@ func NewRecorder(mp otelmetric.MeterProvider, highCardinality bool) (*Recorder, 
 func (r *Recorder) RecordRun(
 	ctx context.Context,
 	input MediaInput,
-	probe shared.ProbeOutput,
-	transcode shared.TranscodeOutput,
+	probe steps.ProbeOutput,
+	transcode steps.TranscodeOutput,
 	mediaInfo medialib.MediaInfo,
 	hardwareAccelerated bool,
 	totalElapsed time.Duration,

--- a/workflows/media/recorder_test.go
+++ b/workflows/media/recorder_test.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
-	"github.com/solidDoWant/media-processor/workflows/shared"
+	"github.com/solidDoWant/media-processor/workflows/steps"
 )
 
 // attributeKey converts a label name to an OTel attribute.Key for use in test assertions.
@@ -75,17 +75,17 @@ func sampleInput(mt medialib.MediaType) MediaInput {
 }
 
 // sampleProbe returns a ProbeOutput suitable for testing.
-func sampleProbe() shared.ProbeOutput {
-	return shared.ProbeOutput{
+func sampleProbe() steps.ProbeOutput {
+	return steps.ProbeOutput{
 		IsValidMedia:    true,
 		VideoCodec:      "h264",
 		Format:          "mov,mp4,m4a,3gp,3g2,mj2",
 		DurationSeconds: 120.5,
-		AudioStreams: []shared.AudioStreamInfo{
-			{StreamInfo: shared.StreamInfo{Index: 1, Language: "eng"}, ReportedChannelCount: 2, EffectiveChannelCount: 2},
-			{StreamInfo: shared.StreamInfo{Index: 2, Language: "eng"}, ReportedChannelCount: 6, EffectiveChannelCount: 6},
+		AudioStreams: []steps.AudioStreamInfo{
+			{StreamInfo: steps.StreamInfo{Index: 1, Language: "eng"}, ReportedChannelCount: 2, EffectiveChannelCount: 2},
+			{StreamInfo: steps.StreamInfo{Index: 2, Language: "eng"}, ReportedChannelCount: 6, EffectiveChannelCount: 6},
 		},
-		SubtitleStreams: []shared.StreamInfo{
+		SubtitleStreams: []steps.StreamInfo{
 			{Index: 3, Language: "eng"},
 		},
 		StartedAt: time.Now().Add(-5 * time.Second),
@@ -93,8 +93,8 @@ func sampleProbe() shared.ProbeOutput {
 }
 
 // sampleTranscode returns a TranscodeOutput suitable for testing.
-func sampleTranscode() shared.TranscodeOutput {
-	return shared.TranscodeOutput{
+func sampleTranscode() steps.TranscodeOutput {
+	return steps.TranscodeOutput{
 		DestCodec:                "hevc",
 		DestContainer:            "mkv",
 		DestFilePath:             "/output/test.mkv",

--- a/workflows/steps/audio_title.go
+++ b/workflows/steps/audio_title.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"fmt"

--- a/workflows/steps/audio_title_test.go
+++ b/workflows/steps/audio_title_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"testing"

--- a/workflows/steps/cleanup.go
+++ b/workflows/steps/cleanup.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"errors"

--- a/workflows/steps/cleanup_test.go
+++ b/workflows/steps/cleanup_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"os"

--- a/workflows/steps/detectcrop.go
+++ b/workflows/steps/detectcrop.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"context"

--- a/workflows/steps/detectcrop_test.go
+++ b/workflows/steps/detectcrop_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"testing"

--- a/workflows/steps/language.go
+++ b/workflows/steps/language.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import iso639 "github.com/barbashov/iso639-3"
 

--- a/workflows/steps/language_test.go
+++ b/workflows/steps/language_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"testing"

--- a/workflows/steps/onfailure.go
+++ b/workflows/steps/onfailure.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"context"

--- a/workflows/steps/onfailure_test.go
+++ b/workflows/steps/onfailure_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"encoding/json"

--- a/workflows/steps/probe.go
+++ b/workflows/steps/probe.go
@@ -1,5 +1,5 @@
-// Package shared provides workflow step implementations shared across workflow types.
-package shared
+// Package steps provides workflow step implementations for the media processing workflows.
+package steps
 
 import (
 	"context"

--- a/workflows/steps/probe_test.go
+++ b/workflows/steps/probe_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"context"

--- a/workflows/steps/testhelpers_test.go
+++ b/workflows/steps/testhelpers_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"os"

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"context"

--- a/workflows/steps/transcode_test.go
+++ b/workflows/steps/transcode_test.go
@@ -1,4 +1,4 @@
-package shared
+package steps
 
 import (
 	"os"


### PR DESCRIPTION
## Summary

- Renames `workflows/shared` to `workflows/steps` — the name "shared" implied reuse across multiple workflow types, but only the media workflow consumes this package
- "steps" accurately describes the contents: the step implementations (`RunProbe`, `RunTranscode`, `RunDetectCrop`, `RunCleanup`, `NotifyWorkflowFailure`) used to build the media processing DAG
- Updates all four import sites in `workflows/media` and the package doc comment in `probe.go`
- No behaviour change; purely a rename

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes (all packages green, including `workflows/steps` and `workflows/media`)
- [x] `make lint` reports no new issues (three pre-existing findings in `cleanup.go` and `cmd/watcher/watcher.go` are unchanged from master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)