### PR TITLE
refactor(config): standardize environment variable naming and add operator documentation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,7 +86,7 @@ Sonarr/Radarr has `/processed-output` bind-mounted as its own `/downloads`. This
 2. **Download initiated.** Sonarr/Radarr searches configured indexers, selects a release, and sends it to the configured download client.
 3. **File lands in `/downloads`.** The download client saves the completed file to the real `/downloads` directory and reports the file path back to Sonarr/Radarr.
 4. **Watcher detects the file.** The `cmd/watcher` process, which watches `/downloads` via `fsnotify`, detects the new file and submits a media-processor workflow job to Hatchet.
-5. **Workflow runs.** The `cmd/worker` process picks up the job. It probes the file with `pkg/ffprobe`, then transcodes or transmuxes it if required via `pkg/ffmpeg`/`pkg/medialib`, writing the output to `/processed-output`. When `MEDIA_WATCHER_ROOT` is set to `/downloads`, the worker mirrors the input's relative subdirectory under `/processed-output` (e.g., `/downloads/my-media-item/video.mp4` produces `/processed-output/my-media-item/video.mkv`). **`MEDIA_WATCHER_ROOT` must be configured** for nested downloads to produce matching subdirectory structure; without it, all output is written flat into `/processed-output` and the import path in step 6 will not resolve correctly for nested inputs.
+5. **Workflow runs.** The `cmd/worker` process picks up the job. It probes the file with `pkg/ffprobe`, then transcodes or transmuxes it if required via `pkg/ffmpeg`/`pkg/medialib`, writing the output to `/processed-output`. When `MEDIA_INPUT_ROOT` is set to `/downloads`, the worker mirrors the input's relative subdirectory under `/processed-output` (e.g., `/downloads/my-media-item/video.mp4` produces `/processed-output/my-media-item/video.mkv`). **`MEDIA_INPUT_ROOT` must be configured** for nested downloads to produce matching subdirectory structure; without it, all output is written flat into `/processed-output` and the import path in step 6 will not resolve correctly for nested inputs.
 6. **Library import triggered.** The workflow's `notify` step calls `ArrLibrary.ImportByFilePath` with a path derived from the original input file path: the same directory and stem as the downloaded file, but with the extension replaced by `.mkv` to match the transcoded output (e.g., if the input was `/downloads/my-media-item/video.mp4`, the import path is `/downloads/my-media-item/video.mkv`). The path is translated if necessary via `LocalPathPrefix`/`RemotePathPrefix` to produce the path as Sonarr/Radarr sees it (e.g., `/downloads/my-media-item/video.mkv`), then a `DownloadedMoviesScan` (Radarr) or `DownloadedEpisodesScan` (Sonarr) command is sent with that path. The arr service scans the file at that path (which resolves to the transcoded output via the bind mount) and triggers the normal import pipeline.
 7. **Sonarr/Radarr imports the file.** On receiving the refresh command, Sonarr/Radarr scans its `/downloads` path (which resolves to `/processed-output` on the host) and finds the processed file, then imports it into the library.
 
@@ -125,3 +125,38 @@ watches:
 ```
 
 `cronSchedule`, `ignorePatterns`, `preserveSource`, and `retainEmptyDirectories` are all optional. A minimal entry only needs `name`, `path`, and `mediaType`. `ignorePatterns` accepts Go regular expressions; a matching file is silently skipped, a matching directory skips its entire subtree. When `preserveSource: true` is set on a watch entry, the source file is kept after successful processing; omitting it or setting it to `false` retains the default behaviour of deleting the source file. By default, after a source file is deleted (either because it is invalid media or after successful processing), any parent directories that become empty are removed bottom-up, stopping at the watch root. Set `retainEmptyDirectories: true` to disable this behaviour and leave empty directories in place.
+
+### Environment variables
+
+Variables marked **Required** cause the binary to exit immediately on startup when unset or empty.
+
+#### Shared (`cmd/watcher` and `cmd/worker`)
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `LOG_LEVEL` | string | `info` | Optional | Log verbosity: `debug`, `info`, `warn`, or `error`. An unrecognised value falls back to `info`. |
+| `HATCHET_CLIENT_TOKEN` | string | — | **Required** | Hatchet API token used by the client SDK. |
+
+#### `cmd/worker`
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `MEDIA_OUTPUT_DIR` | string (path) | — | **Required** | Directory where transcoded output files are written. |
+| `RADARR_URL` | string (URL) | — | **Required** | Radarr base URL (e.g. `http://radarr:7878`). |
+| `RADARR_API_KEY` | string | — | **Required** | Radarr API key. |
+| `SONARR_URL` | string (URL) | — | **Required** | Sonarr base URL (e.g. `http://sonarr:8989`). |
+| `SONARR_API_KEY` | string | — | **Required** | Sonarr API key. |
+| `RADARR_LOCAL_PATH_PREFIX` | string (path) | `""` | Optional | Local-side prefix for Radarr path translation. When set, `RADARR_REMOTE_PATH_PREFIX` must also be set. |
+| `RADARR_REMOTE_PATH_PREFIX` | string (path) | `""` | Optional | Remote-side prefix for Radarr path translation. |
+| `SONARR_LOCAL_PATH_PREFIX` | string (path) | `""` | Optional | Local-side prefix for Sonarr path translation. When set, `SONARR_REMOTE_PATH_PREFIX` must also be set. |
+| `SONARR_REMOTE_PATH_PREFIX` | string (path) | `""` | Optional | Remote-side prefix for Sonarr path translation. |
+| `MEDIA_WEBHOOK_URL` | string (URL) | `""` | Optional | Webhook endpoint notified on workflow failure. No notification is sent when empty. |
+| `MEDIA_INPUT_ROOT` | string (path) | `""` | Optional | Root of the watched input directories. When set, transcoded output is placed in a mirrored subdirectory under `MEDIA_OUTPUT_DIR`, preserving the original directory structure. |
+| `MEDIA_HARDWARE_DEVICE_PATH` | string (path) | `""` | Optional | Hardware device path for hardware-accelerated transcoding (e.g. `/dev/dri/renderD128`). When empty, the software encoder is used. |
+| `MEDIA_MIN_CROP_X` | integer | `10` | Optional | Minimum number of pixels that must be trimmed horizontally before a crop is applied. Set to `-1` to accept any detected crop. |
+| `MEDIA_MIN_CROP_Y` | integer | `10` | Optional | Minimum number of pixels that must be trimmed vertically before a crop is applied. Set to `-1` to accept any detected crop. |
+| `MEDIA_DETECT_CROP_TIMEOUT` | Go duration | `30m` | Optional | Hatchet execution timeout for the crop-detection step (e.g. `45m`, `1h`). |
+| `MEDIA_TRANSCODE_TIMEOUT` | Go duration | `4h` | Optional | Hatchet execution timeout for the transcode step (e.g. `2h`, `8h`). |
+| `METRICS_ADDR` | string (TCP address) | `""` | Optional | TCP address on which to expose the Prometheus `/metrics` pull endpoint (e.g. `:9090`). Disabled when empty. |
+| `METRICS_HIGH_CARDINALITY_LABELS` | `true` / `false` | `false` | Optional | When `true`, per-item labels (id, title, year, etc.) are attached to metric observations. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | string (URL) | `""` | Optional | OTLP gRPC endpoint for pushing metrics (e.g. `http://otel-collector:4317`). Disabled when empty. Follows the standard OpenTelemetry convention. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -136,6 +136,8 @@ Variables marked **Required** cause the binary to exit immediately on startup wh
 |----------|------|---------|----------|-------------|
 | `LOG_LEVEL` | string | `info` | Optional | Log verbosity: `debug`, `info`, `warn`, or `error`. An unrecognised value falls back to `info`. |
 | `HATCHET_CLIENT_TOKEN` | string | — | **Required** | Hatchet API token used by the client SDK. |
+| `METRICS_ADDR` | string (TCP address) | `""` | Optional | TCP address on which to expose the Prometheus `/metrics` pull endpoint (e.g. `:9090`). Disabled when empty. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | string (URL) | `""` | Optional | OTLP gRPC endpoint for pushing metrics (e.g. `http://otel-collector:4317`). Disabled when empty. Follows the standard OpenTelemetry convention. |
 
 #### `cmd/worker`
 
@@ -157,6 +159,4 @@ Variables marked **Required** cause the binary to exit immediately on startup wh
 | `MEDIA_MIN_CROP_Y` | integer | `10` | Optional | Minimum number of pixels that must be trimmed vertically before a crop is applied. Set to `-1` to accept any detected crop. |
 | `MEDIA_DETECT_CROP_TIMEOUT` | Go duration | `30m` | Optional | Hatchet execution timeout for the crop-detection step (e.g. `45m`, `1h`). |
 | `MEDIA_TRANSCODE_TIMEOUT` | Go duration | `4h` | Optional | Hatchet execution timeout for the transcode step (e.g. `2h`, `8h`). |
-| `METRICS_ADDR` | string (TCP address) | `""` | Optional | TCP address on which to expose the Prometheus `/metrics` pull endpoint (e.g. `:9090`). Disabled when empty. |
 | `METRICS_HIGH_CARDINALITY_LABELS` | `true` / `false` | `false` | Optional | When `true`, per-item labels (id, title, year, etc.) are attached to metric observations. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | string (URL) | `""` | Optional | OTLP gRPC endpoint for pushing metrics (e.g. `http://otel-collector:4317`). Disabled when empty. Follows the standard OpenTelemetry convention. |

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -85,7 +85,7 @@ func run(ctx context.Context) error {
 	})
 
 	webhookClient := &webhook.Client{
-		URL: os.Getenv("WEBHOOK_URL"),
+		URL: os.Getenv("MEDIA_WEBHOOK_URL"),
 	}
 
 	clientLogger := logging.NewZerologLogger("client")
@@ -107,7 +107,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	detectCropTimeout, err := parseTimeout("MEDIA_DETECTCROP_TIMEOUT", media.DefaultDetectCropTimeout)
+	detectCropTimeout, err := parseTimeout("MEDIA_DETECT_CROP_TIMEOUT", media.DefaultDetectCropTimeout)
 	if err != nil {
 		return err
 	}
@@ -119,9 +119,9 @@ func run(ctx context.Context) error {
 
 	mediaWorkflow := media.NewMediaWorkflow(client, media.MediaWorkflowConfig{
 		OutputDir:             mediaOutputDir,
-		WatcherRoot:           os.Getenv("MEDIA_WATCHER_ROOT"),
+		WatcherRoot:           os.Getenv("MEDIA_INPUT_ROOT"),
 		WebhookURL:            webhookClient.URL,
-		HardwareDevicePath:    os.Getenv("HARDWARE_DEVICE_PATH"),
+		HardwareDevicePath:    os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"),
 		MeterProvider:         metricsProvider.MeterProvider(),
 		HighCardinalityLabels: os.Getenv("METRICS_HIGH_CARDINALITY_LABELS") == "true",
 		MinCropX:              minCropX,

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -270,7 +270,7 @@ func startProcesses() error {
 	// Start worker subprocess with path-translation env vars.
 	workerEnv := append(baseEnv,
 		"MEDIA_OUTPUT_DIR="+processedDir,
-		"MEDIA_WATCHER_ROOT="+downloadsDir,
+		"MEDIA_INPUT_ROOT="+downloadsDir,
 		"RADARR_URL="+radarrBase,
 		"RADARR_API_KEY="+radarrAPIKey,
 		"SONARR_URL="+sonarrBase,

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -64,7 +64,7 @@ type MediaWorkflowConfig struct {
 	MinCropY int
 	// DetectCropTimeout is the Hatchet execution timeout for the detectcrop step.
 	// When zero, NewMediaWorkflow applies a default of 30 minutes. Set by the caller
-	// (e.g. cmd/worker via parseTimeout from MEDIA_DETECTCROP_TIMEOUT).
+	// (e.g. cmd/worker via parseTimeout from MEDIA_DETECT_CROP_TIMEOUT).
 	DetectCropTimeout time.Duration
 	// TranscodeTimeout is the Hatchet execution timeout for the transcode step.
 	// When zero, NewMediaWorkflow applies a default of 4 hours. Set by the caller


### PR DESCRIPTION
Fixes #93

## Summary

- Renames four environment variables in `cmd/worker` to follow the `MEDIA_` prefix convention:
  - `HARDWARE_DEVICE_PATH` → `MEDIA_HARDWARE_DEVICE_PATH`
  - `WEBHOOK_URL` → `MEDIA_WEBHOOK_URL`
  - `MEDIA_DETECTCROP_TIMEOUT` → `MEDIA_DETECT_CROP_TIMEOUT`
  - `MEDIA_WATCHER_ROOT` → `MEDIA_INPUT_ROOT`
- Updates the old `MEDIA_WATCHER_ROOT` reference in the SPEC.md flow description to `MEDIA_INPUT_ROOT`.
- Adds a comprehensive "Environment Variables" sub-section to SPEC.md listing every variable accepted by `cmd/watcher` and `cmd/worker` with name, type, default, and required/optional status.

## Test plan

- [x] `make build` — both binaries compile cleanly
- [x] `make test` — all unit tests pass
- [x] No old variable names remain in any `.go` or `.md` source file
- [x] `make test-e2e` — requires Docker; validates the `MEDIA_INPUT_ROOT` rename in the e2e harness (Docker daemon not available in this environment; human must verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)