### PR TITLE
feat(ffmpeg): add MEDIA_H265_CRF env var for configurable H.265 quality

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -117,6 +117,11 @@ func run(ctx context.Context) error {
 		return err
 	}
 
+	h265CRF, err := parseH265CRF("MEDIA_H265_CRF")
+	if err != nil {
+		return err
+	}
+
 	mediaWorkflow := media.NewMediaWorkflow(client, media.MediaWorkflowConfig{
 		OutputDir:             mediaOutputDir,
 		WatcherRoot:           os.Getenv("MEDIA_INPUT_ROOT"),
@@ -128,6 +133,7 @@ func run(ctx context.Context) error {
 		MinCropY:              minCropY,
 		DetectCropTimeout:     detectCropTimeout,
 		TranscodeTimeout:      transcodeTimeout,
+		H265CRF:               h265CRF,
 	}, radarrClient, sonarrClient, webhookClient)
 
 	workerLogger := logging.NewZerologLogger("worker")
@@ -162,6 +168,23 @@ func parseCropThreshold(envVar string, defaultVal int) (int, error) {
 	v, err := strconv.Atoi(raw)
 	if err != nil {
 		return 0, fmt.Errorf("%s must be an integer (got %q): %w", envVar, raw, err)
+	}
+
+	return v, nil
+}
+
+// parseH265CRF reads the H.265 constant-quality value from the named environment
+// variable. If the variable is unset or empty, 0 is returned (encoder default).
+// Valid values are 1–51; any other non-integer or out-of-range value is a fatal error.
+func parseH265CRF(envVar string) (int, error) {
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		return 0, nil
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 1 || v > 51 {
+		return 0, fmt.Errorf("%s must be an integer between 1 and 51 (got %q)", envVar, raw)
 	}
 
 	return v, nil

--- a/cmd/worker/run_test.go
+++ b/cmd/worker/run_test.go
@@ -18,6 +18,82 @@ func TestRun_MissingToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "HATCHET_CLIENT_TOKEN")
 }
 
+func TestParseH265CRF(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int
+		errFunc  require.ErrorAssertionFunc
+	}{
+		{
+			name:     "unset returns 0",
+			envValue: "",
+			expected: 0,
+		},
+		{
+			name:     "minimum valid value",
+			envValue: "1",
+			expected: 1,
+		},
+		{
+			name:     "maximum valid value",
+			envValue: "51",
+			expected: 51,
+		},
+		{
+			name:     "typical quality value",
+			envValue: "24",
+			expected: 24,
+		},
+		{
+			name:     "zero is out of range",
+			envValue: "0",
+			errFunc:  require.Error,
+		},
+		{
+			name:     "52 is out of range",
+			envValue: "52",
+			errFunc:  require.Error,
+		},
+		{
+			name:     "negative value is out of range",
+			envValue: "-1",
+			errFunc:  require.Error,
+		},
+		{
+			name:     "non-integer returns error naming var and value",
+			envValue: "high",
+			errFunc:  require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const envVar = "TEST_PARSE_H265_CRF_VAR"
+			t.Setenv(envVar, test.envValue)
+
+			errFunc := test.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			got, err := parseH265CRF(envVar)
+			errFunc(t, err)
+
+			if err != nil {
+				if test.envValue != "" {
+					assert.Contains(t, err.Error(), envVar)
+					assert.Contains(t, err.Error(), test.envValue)
+				}
+
+				return
+			}
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
 func TestParseTimeout(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -279,6 +279,7 @@ func startProcesses() error {
 		"RADARR_REMOTE_PATH_PREFIX=/downloads",
 		"SONARR_LOCAL_PATH_PREFIX="+filepath.Join(downloadsDir, "sonarr"),
 		"SONARR_REMOTE_PATH_PREFIX=/downloads",
+		"MEDIA_H265_CRF=51",
 	)
 
 	workerCmd = exec.Command(workerBin)

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 
 	"github.com/asticode/go-astiav"
 )
@@ -74,6 +75,10 @@ type videoStreamState struct {
 
 	// cropParams is the requested spatial crop region, or nil when no crop is needed.
 	cropParams *CropParams
+	// h265CRF is the constant-quality value for H.265 encoders. 0 means use the
+	// encoder's default. For libx265 this is the CRF; for hevc_nvenc it is the CQ
+	// value; for hevc_qsv and hevc_vaapi it is the global_quality (ICQ) value.
+	h265CRF int
 	// plan captures the outputs of the decoder and crop-filter setup phases and
 	// is consumed by the encoder setup and per-frame processing. See videoProcessingPlan.
 	plan videoProcessingPlan
@@ -619,16 +624,40 @@ func (vss *videoStreamState) openVideoEncoderContext(enc *astiav.Codec, profile 
 	}
 
 	var openDict *astiav.Dictionary
+	defer func() {
+		if openDict != nil {
+			openDict.Free()
+		}
+	}()
 
-	// libx265 has its own logging that writes directly to stderr, bypassing
-	// FFmpeg's av_log callback. Align its log level with the application logger
-	// so that x265 info-level noise is suppressed unless debug logging is on.
-	if enc.Name() == "libx265" {
+	switch enc.Name() {
+	case "libx265":
+		// libx265 has its own logging that writes directly to stderr, bypassing
+		// FFmpeg's av_log callback. Align its log level with the application logger
+		// so that x265 info-level noise is suppressed unless debug logging is on.
 		openDict = astiav.NewDictionary()
-		defer openDict.Free()
-
-		if err := openDict.Set("x265-params", "log-level="+x265LogLevel(), astiav.NewDictionaryFlags()); err != nil {
+		x265Params := "log-level=" + x265LogLevel()
+		if vss.h265CRF > 0 {
+			x265Params += fmt.Sprintf(":crf=%d", vss.h265CRF)
+		}
+		if err := openDict.Set("x265-params", x265Params, astiav.NewDictionaryFlags()); err != nil {
 			return fmt.Errorf("setting x265-params: %w", err)
+		}
+
+	case "hevc_nvenc":
+		if vss.h265CRF > 0 {
+			openDict = astiav.NewDictionary()
+			if err := openDict.Set("cq", strconv.Itoa(vss.h265CRF), astiav.NewDictionaryFlags()); err != nil {
+				return fmt.Errorf("setting hevc_nvenc cq: %w", err)
+			}
+		}
+
+	case "hevc_qsv", "hevc_vaapi":
+		if vss.h265CRF > 0 {
+			openDict = astiav.NewDictionary()
+			if err := openDict.Set("global_quality", strconv.Itoa(vss.h265CRF), astiav.NewDictionaryFlags()); err != nil {
+				return fmt.Errorf("setting %s global_quality: %w", enc.Name(), err)
+			}
 		}
 	}
 

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -30,6 +30,7 @@ type TranscodeBuilder struct {
 	coverArtBytes         []byte         // raw image bytes to embed as MKV attachment; nil = no cover art
 	coverArtMimeType      string         // MIME type of coverArtBytes ("image/jpeg" or "image/png")
 	cropParams            *CropParams    // crop region to apply during video encode; nil = no crop
+	h265CRF               int            // constant-quality for H.265 encoders; 0 = use encoder default
 }
 
 // NewTranscode returns a builder for a transcode job from inputPath to outputPath.
@@ -198,6 +199,20 @@ func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *Tra
 
 	b.coverArtBytes = imageBytes
 	b.coverArtMimeType = mimeType
+
+	return b
+}
+
+// WithH265CRF sets the constant-quality value for H.265 video encoders. A value
+// of 0 (the default) leaves the encoder's built-in default in effect. For
+// libx265 this sets the CRF; for hevc_nvenc it sets the CQ value; for hevc_qsv
+// and hevc_vaapi it sets the global_quality (ICQ) value. Typical values range
+// from 18 (high quality) to 28 (lower quality). Has no effect when the video
+// codec is CodecCopy or when the encoder is not an H.265 variant.
+func (b *TranscodeBuilder) WithH265CRF(crf int) *TranscodeBuilder {
+	if crf > 0 {
+		b.h265CRF = crf
+	}
 
 	return b
 }
@@ -442,7 +457,7 @@ func (t *Transcoder) buildStreamStates(inputFmt *astiav.FormatContext, hwAccel H
 
 		switch {
 		case mediaType == astiav.MediaTypeVideo && t.videoCodec != CodecCopy:
-			videoState := &videoStreamState{copyStreamState: base, encoder: videoEncoderState{codecID: t.videoCodec}, hardwareDevicePath: t.hardwareDevicePath, cropParams: t.cropParams}
+			videoState := &videoStreamState{copyStreamState: base, encoder: videoEncoderState{codecID: t.videoCodec}, hardwareDevicePath: t.hardwareDevicePath, cropParams: t.cropParams, h265CRF: t.h265CRF}
 			if err := videoState.setupDecoder(inStream, inputFmt, hwAccel); err != nil {
 				freeStreams(streams)
 				return nil, fmt.Errorf("ffmpeg: setting up decoder for stream %d: %w", inStream.Index(), err)

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -206,11 +206,12 @@ func (b *TranscodeBuilder) WithCoverArt(imageBytes []byte, mimeType string) *Tra
 // WithH265CRF sets the constant-quality value for H.265 video encoders. A value
 // of 0 (the default) leaves the encoder's built-in default in effect. For
 // libx265 this sets the CRF; for hevc_nvenc it sets the CQ value; for hevc_qsv
-// and hevc_vaapi it sets the global_quality (ICQ) value. Typical values range
-// from 18 (high quality) to 28 (lower quality). Has no effect when the video
-// codec is CodecCopy or when the encoder is not an H.265 variant.
+// and hevc_vaapi it sets the global_quality (ICQ) value. Valid explicit values
+// are 1 through 51; values outside that range are treated as a no-op. Typical
+// values range from 18 (high quality) to 28 (lower quality). Has no effect
+// when the video codec is CodecCopy or when the encoder is not an H.265 variant.
 func (b *TranscodeBuilder) WithH265CRF(crf int) *TranscodeBuilder {
-	if crf > 0 {
+	if crf >= 1 && crf <= 51 {
 		b.h265CRF = crf
 	}
 

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -70,6 +70,12 @@ type MediaWorkflowConfig struct {
 	// When zero, NewMediaWorkflow applies a default of 4 hours. Set by the caller
 	// (e.g. cmd/worker via parseTimeout from MEDIA_TRANSCODE_TIMEOUT).
 	TranscodeTimeout time.Duration
+	// H265CRF is the constant-quality value passed to H.265 encoders. 0 means
+	// use the encoder's built-in default. For libx265 this is the CRF; for
+	// hevc_nvenc it is the CQ value; for hevc_qsv and hevc_vaapi it is the
+	// global_quality (ICQ) value. Set by the caller (e.g. cmd/worker via
+	// MEDIA_H265_CRF).
+	H265CRF int
 }
 
 // MediaInput is the workflow's trigger payload.
@@ -199,7 +205,7 @@ func NewMediaWorkflow(
 			return steps.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
 		}
 
-		out, err := steps.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, library)
+		out, err := steps.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, cfg.H265CRF, library)
 		if err == nil && out.ArtworkFetchSkipped {
 			recorder.RecordArtworkFetchSkipped(ctx)
 		}

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -163,7 +163,7 @@ func codecName(c ffmpeg.Codec) string {
 // ArtworkFetchSkipped is not set. When non-nil and the fetch yields no
 // embeddable image, transcoding proceeds without an embedded attachment and
 // ArtworkFetchSkipped is set to true.
-func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropParams *ffmpeg.CropParams, outputDir string, watcherRoot string, hardwareDevicePath string, library medialib.ArrLibrary) (TranscodeOutput, error) {
+func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropParams *ffmpeg.CropParams, outputDir string, watcherRoot string, hardwareDevicePath string, h265CRF int, library medialib.ArrLibrary) (TranscodeOutput, error) {
 	transcodeStart := time.Now()
 
 	srcInfo, err := os.Stat(filePath)
@@ -359,6 +359,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		WithDownmixTitle(downmixLangName).
 		WithAutoDownmixTitle().
 		WithHardwareDevice(hardwareDevicePath).
+		WithH265CRF(h265CRF).
 		WithCoverArt(artBytes, artMime).
 		WithCrop(cropParams).
 		Build().

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -158,6 +158,11 @@ func codecName(c ffmpeg.Codec) string {
 // written flat into outputDir (no subdirectory).
 // hardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
 // an empty string uses the libav default (auto-select).
+// h265CRF is the constant-quality value for H.265 encoders. 0 means use the
+// encoder's built-in default; valid explicit values are 1–51 (lower = higher
+// quality). For libx265 this is the CRF; for hevc_nvenc it is the CQ value;
+// for hevc_qsv and hevc_vaapi it is the global_quality (ICQ) value. Values
+// outside 1–51 are silently ignored and the encoder default is used.
 // library is the arr library used to fetch poster artwork. When nil, no fetch
 // is attempted and transcoding proceeds without an embedded attachment, and
 // ArtworkFetchSkipped is not set. When non-nil and the fetch yields no

--- a/workflows/steps/transcode_test.go
+++ b/workflows/steps/transcode_test.go
@@ -572,7 +572,7 @@ func TestRunTranscode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
 
-			out, err := RunTranscode(t.Context(), inputPath, tt.probe, nil, outputDir, "", "", nil)
+			out, err := RunTranscode(t.Context(), inputPath, tt.probe, nil, outputDir, "", "", 0, nil)
 
 			tt.errFunc(t, err)
 
@@ -607,7 +607,7 @@ func TestRunTranscode_WatcherRoot_SubdirIsPreservedInOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
+	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, nil)
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "my-media-item", "video.mkv")
@@ -638,7 +638,7 @@ func TestRunTranscode_WatcherRoot_FlatInputProducesFlatOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
+	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, nil)
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "video.mkv")
@@ -667,7 +667,7 @@ func TestRunTranscode_WatcherRoot_InputOutsideWatcherRootReturnsError(t *testing
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	_, err = RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", nil)
+	_, err = RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, nil)
 	require.Error(t, err, "input outside watcherRoot should return an error")
 
 	entries, readErr := os.ReadDir(outputDir)


### PR DESCRIPTION
## Summary

- Adds `MEDIA_H265_CRF` environment variable to configure the constant-quality level for H.265 encoding
- Maps to the appropriate per-encoder parameter: CRF for `libx265`, `cq` for `hevc_nvenc`, and `global_quality` (ICQ) for `hevc_qsv` / `hevc_vaapi`
- Defaults to 0 (unset) which preserves each encoder's built-in default; valid values are 1–51
- Threads the setting through `MediaWorkflowConfig.H265CRF` → `RunTranscode` → `TranscodeBuilder.WithH265CRF` → encoder codec context options

## Test plan

- [x] `make build` passes cleanly
- [x] `make test` passes (all packages, including `pkg/ffmpeg` and `workflows/steps`)
- [x] Manual smoke test with `MEDIA_H265_CRF=24` to verify libx265 honours the CRF value (requires a running worker environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)