### PR TITLE
fix: derive hardware_accelerated metric label from runtime encoder selection

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -92,7 +92,7 @@ Every `media_workflow_*` histogram observation carries the full standard label s
 | `destination_codec`     | e.g. `hevc`, `copy`       | Video codec written to the output (`copy` when the source was remuxed without re-encode).                                             |
 | `source_container`      | e.g. `matroska,webm`      | Container format of the source file as reported by libavformat (comma-joined list).                                                   |
 | `destination_container` | `mkv`                     | Container format of the output file (always `mkv`).                                                                                   |
-| `hardware_accelerated`  | `true`, `false`           | `true` only when `MEDIA_HARDWARE_DEVICE_PATH` is set. Does **not** reflect whether a hardware encoder was actually selected at runtime. |
+| `hardware_accelerated`  | `true`, `false`           | `true` when at least one video stream was encoded with a hardware encoder (NVENC, QSV, VAAPI) at runtime. `false` when the encoder fell back to software (e.g. libx265), even if `MEDIA_HARDWARE_DEVICE_PATH` is set. |
 | `crop_applied`          | `true`, `false`           | Whether a crop filter was applied during transcoding.                                                                                 |
 
 ### Media workflow counters

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -277,6 +277,8 @@ func (t *Transcoder) HardwareAccelerated() bool {
 // context is cancelled, or an error occurs. A cancelled context causes Run to
 // return promptly with ctx.Err().
 func (t *Transcoder) Run(ctx context.Context) error {
+	t.hardwareAccelerated = false
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -263,6 +263,14 @@ func (b *TranscodeBuilder) Build() *Transcoder {
 // It embeds TranscodeBuilder so all configuration is accessible in one place.
 type Transcoder struct {
 	TranscodeBuilder
+	hardwareAccelerated bool // set by Run after encoder setup
+}
+
+// HardwareAccelerated reports whether any video stream used a hardware encoder
+// during the most recent Run call. Always false before Run is called or when
+// Run returns an error before encoder setup completes.
+func (t *Transcoder) HardwareAccelerated() bool {
+	return t.hardwareAccelerated
 }
 
 // Run executes the transcode job. It blocks until the job completes, the
@@ -307,6 +315,8 @@ func (t *Transcoder) Run(ctx context.Context) error {
 	defer outputFmt.Free()
 	defer closeIO()
 
+	t.hardwareAccelerated = anyStreamHWAccel(streams)
+
 	if err := outputFmt.WriteHeader(nil); err != nil {
 		return fmt.Errorf("ffmpeg: writing header: %w", err)
 	}
@@ -324,6 +334,18 @@ func (t *Transcoder) Run(ctx context.Context) error {
 	}
 
 	return outputFmt.WriteTrailer()
+}
+
+// anyStreamHWAccel reports whether any video stream in streams selected a
+// hardware encoder during setupEncoder.
+func anyStreamHWAccel(streams map[int]stream) bool {
+	for _, s := range streams {
+		if vss, ok := s.(*videoStreamState); ok && vss.encoder.usesHardwareAccelerator {
+			return true
+		}
+	}
+
+	return false
 }
 
 // resolveHWAccel resolves HWAccelAuto to a concrete value by detecting the

--- a/pkg/ffmpeg/transcode.go
+++ b/pkg/ffmpeg/transcode.go
@@ -277,8 +277,6 @@ func (t *Transcoder) HardwareAccelerated() bool {
 // context is cancelled, or an error occurs. A cancelled context causes Run to
 // return promptly with ctx.Err().
 func (t *Transcoder) Run(ctx context.Context) error {
-	t.hardwareAccelerated = false
-
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -283,7 +283,7 @@ func NewMediaWorkflow(
 			}
 		}
 
-		hardwareAccelerated := cfg.HardwareDevicePath != ""
+		hardwareAccelerated := transcode.HardwareAccelerated
 		totalElapsed := time.Since(probe.StartedAt)
 		recorder.RecordRun(ctx, input, probe, transcode, mediaInfo, hardwareAccelerated, totalElapsed)
 

--- a/workflows/media/recorder_test.go
+++ b/workflows/media/recorder_test.go
@@ -169,6 +169,47 @@ func TestRecorder_CropAppliedLabel(t *testing.T) {
 	}
 }
 
+func TestRecorder_HardwareAcceleratedLabel(t *testing.T) {
+	tests := []struct {
+		name                    string
+		hardwareAccelerated     bool
+		wantHardwareAccelerated string
+	}{
+		{
+			name:                    "software encoder — label is false",
+			hardwareAccelerated:     false,
+			wantHardwareAccelerated: "false",
+		},
+		{
+			name:                    "hardware encoder — label is true",
+			hardwareAccelerated:     true,
+			wantHardwareAccelerated: "true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, reader := newTestRecorder(t, false)
+
+			transcode := sampleTranscode()
+			transcode.HardwareAccelerated = tc.hardwareAccelerated
+
+			rec.RecordRun(t.Context(), sampleInput(medialib.MovieType), sampleProbe(), transcode, nil, tc.hardwareAccelerated, 5*time.Second)
+
+			rm := collectMetrics(t, reader)
+
+			m := findMetric(rm, "media_workflow_audio_track_count")
+			require.NotNil(t, m)
+			dps := histogramDataPoints(t, m)
+			require.Len(t, dps, 1)
+
+			val, present := dps[0].Attributes.Value(attributeKey("hardware_accelerated"))
+			assert.True(t, present, "hardware_accelerated label should be present")
+			assert.Equal(t, tc.wantHardwareAccelerated, val.AsString())
+		})
+	}
+}
+
 func TestRecorder_InvalidFileRecordsOnlyCounter(t *testing.T) {
 	rec, reader := newTestRecorder(t, false)
 

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -128,6 +128,11 @@ type TranscodeOutput struct {
 	ArtworkFetchSkipped bool `json:"artwork_fetch_skipped,omitempty"`
 	// CropApplied is true when a crop filter was applied during transcoding.
 	CropApplied bool `json:"crop_applied,omitempty"`
+	// HardwareAccelerated is true when at least one video stream was encoded
+	// using a hardware encoder (e.g. NVENC, QSV, VAAPI) at runtime. False when
+	// the encoder fell back to software (e.g. libx265) even if
+	// MEDIA_HARDWARE_DEVICE_PATH is set.
+	HardwareAccelerated bool `json:"hardware_accelerated,omitempty"`
 }
 
 // codecName returns a human-readable name for a codec, matching the names used
@@ -351,7 +356,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		}
 	}
 
-	if err := ffmpeg.NewTranscode(filePath, tempPath).
+	transcoder := ffmpeg.NewTranscode(filePath, tempPath).
 		ToVideoCodec(videoCodec).
 		ToContainer(ffmpeg.ContainerMKV).
 		HardwareAccel(ffmpeg.HWAccelAuto).
@@ -367,8 +372,9 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		WithH265CRF(h265CRF).
 		WithCoverArt(artBytes, artMime).
 		WithCrop(cropParams).
-		Build().
-		Run(ctx); err != nil {
+		Build()
+
+	if err := transcoder.Run(ctx); err != nil {
 		if removeErr := os.Remove(tempPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return TranscodeOutput{}, errors.Join(
 				fmt.Errorf("transcode: %w", err),
@@ -404,5 +410,6 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		TranscodeDurationSeconds: time.Since(transcodeStart).Seconds(),
 		ArtworkFetchSkipped:      artworkSkipped,
 		CropApplied:              cropParams != nil,
+		HardwareAccelerated:      transcoder.HardwareAccelerated(),
 	}, nil
 }


### PR DESCRIPTION
## Summary

- `hardware_accelerated` metric label was previously set to `cfg.HardwareDevicePath != ""` — a config-time check that does not reflect whether a hardware encoder was actually used. If a hardware device path was configured but the encoder fell back to software (missing driver, unsupported codec), the label would still read `true`.
- `Transcoder` now stores whether any video stream used hardware acceleration during `Run()`, computed from the per-stream `usesHardwareAccelerator` flag that is already set by `selectVideoEncoder`. A new `HardwareAccelerated()` method exposes it without changing `Run()`'s signature.
- `TranscodeOutput.HardwareAccelerated` threads the value up from the ffmpeg layer through `RunTranscode` to the workflow's `record_metrics` step.
- Docs updated to reflect the corrected semantics.

## Changes

- `pkg/ffmpeg/transcode.go` — add `hardwareAccelerated bool` field to `Transcoder`, `HardwareAccelerated()` accessor, and `anyStreamHWAccel` helper; set the field after `setupOutputContext` succeeds in `Run()`
- `workflows/steps/transcode.go` — add `HardwareAccelerated bool` to `TranscodeOutput`; split `.Build().Run()` chain to capture and expose the value
- `workflows/media/media.go` — replace `cfg.HardwareDevicePath != ""` with `transcode.HardwareAccelerated`
- `docs/metrics.md` — update `hardware_accelerated` label description

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (all existing tests green — no test signature changes required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)