### PR TITLE
feat(e2e): verify Prometheus metrics emitted by watcher and worker

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -42,10 +42,12 @@ var log = slog.Default().With("source", "e2e") //nolint:gochecknoglobals
 
 // Package-level state set during TestMain and shared across test functions.
 var (
-	hatchetToken    string
-	radarrMovieID   int
-	sonarrSeriesID  int
-	sonarrEpisodeID int
+	hatchetToken       string
+	radarrMovieID      int
+	sonarrSeriesID     int
+	sonarrEpisodeID    int
+	watcherMetricsAddr string
+	workerMetricsAddr  string
 )
 
 func TestMain(m *testing.M) {

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -158,9 +158,14 @@ func (m metricSeries) sum(name string, filter map[string]string) float64 {
 		}
 	}
 
+	family := m[baseName]
+	if family == nil {
+		return 0
+	}
+
 	var total float64
 
-	for _, metric := range m[baseName].GetMetric() {
+	for _, metric := range family.GetMetric() {
 		if labelsMatch(metric.GetLabel(), filter) {
 			total += getValue(metric)
 		}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -8,12 +8,17 @@ import (
 	"encoding/json"
 	"io/fs"
 	"log/slog"
+	"net/http"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -117,6 +122,98 @@ func probeOutputFile(t *testing.T, path string) outputFileInfo {
 	}
 
 	return info
+}
+
+// metricSeries wraps the metric-family map returned by expfmt.TextParser,
+// keyed by the base metric name (e.g. "media_workflow_total_duration_seconds").
+type metricSeries map[string]*dto.MetricFamily
+
+// sum returns the combined value of all samples of the named metric that match
+// every (key, value) pair in filter. An empty filter matches all samples.
+//
+// Names ending in _count or _sum are resolved against the histogram base name:
+// "foo_count" → foo.SampleCount, "foo_sum" → foo.SampleSum.
+// All other names are read from their Counter or Gauge field.
+func (m metricSeries) sum(name string, filter map[string]string) float64 {
+	var (
+		baseName string
+		getValue func(*dto.Metric) float64
+	)
+
+	switch {
+	case strings.HasSuffix(name, "_count"):
+		baseName = strings.TrimSuffix(name, "_count")
+		getValue = func(metric *dto.Metric) float64 { return float64(metric.GetHistogram().GetSampleCount()) }
+	case strings.HasSuffix(name, "_sum"):
+		baseName = strings.TrimSuffix(name, "_sum")
+		getValue = func(metric *dto.Metric) float64 { return metric.GetHistogram().GetSampleSum() }
+	default:
+		baseName = name
+		getValue = func(metric *dto.Metric) float64 {
+			if c := metric.GetCounter(); c != nil {
+				return c.GetValue()
+			}
+
+			return metric.GetGauge().GetValue()
+		}
+	}
+
+	var total float64
+
+	for _, metric := range m[baseName].GetMetric() {
+		if labelsMatch(metric.GetLabel(), filter) {
+			total += getValue(metric)
+		}
+	}
+
+	return total
+}
+
+// labelsMatch reports whether labels contains all key/value pairs in filter.
+func labelsMatch(labels []*dto.LabelPair, filter map[string]string) bool {
+	for key, want := range filter {
+		found := false
+
+		for _, lp := range labels {
+			if lp.GetName() == key {
+				found = lp.GetValue() == want
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+// fetchMetrics GETs /metrics on addr, parses the Prometheus text exposition,
+// and returns the metric families keyed by base name. Network, protocol, and
+// parse errors fail the test immediately.
+func fetchMetrics(t *testing.T, addr string) metricSeries {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/metrics", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "GET /metrics from %s", addr)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status from %s", addr)
+
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+
+	families, err := parser.TextToMetricFamilies(resp.Body)
+	require.NoError(t, err, "parse /metrics from %s", addr)
+
+	return metricSeries(families)
 }
 
 // findMKV walks dir and returns the path of the first .mkv file found.

--- a/e2e/radarr_test.go
+++ b/e2e/radarr_test.go
@@ -91,4 +91,35 @@ func TestRadarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+
+	assertRadarrPipelineMetrics(t)
+}
+
+func assertRadarrPipelineMetrics(t *testing.T) {
+	t.Helper()
+
+	// The watcher counters are updated synchronously from the scan goroutine;
+	// the worker's record_metrics task runs after cleanup, so poll until it lands.
+	filter := map[string]string{"mapping_name": "radarr"}
+
+	var workerSeries metricSeries
+
+	require.Eventually(t, func() bool {
+		workerSeries = fetchMetrics(t, workerMetricsAddr)
+		return workerSeries.sum("media_workflow_total_duration_seconds_count", filter) >= 1
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected worker to record at least one completed media_workflow run for the radarr mapping")
+
+	watcherSeries := fetchMetrics(t, watcherMetricsAddr)
+	assert.Greater(t, watcherSeries.sum("watcher_scans_total", filter), 0.0,
+		"watcher should have completed at least one scan of the radarr mapping")
+	assert.Greater(t, watcherSeries.sum("watcher_files_discovered_total", filter), 0.0,
+		"watcher should have discovered the radarr source file")
+	assert.Greater(t, watcherSeries.sum("watcher_dispatches_total", filter), 0.0,
+		"watcher should have dispatched the radarr workflow to Hatchet")
+
+	assert.GreaterOrEqual(t, workerSeries.sum("media_workflow_transcode_duration_seconds_count", filter), 1.0,
+		"worker should have recorded the radarr transcode duration")
+	assert.Greater(t, workerSeries.sum("media_workflow_destination_file_size_bytes_sum", filter), 0.0,
+		"worker should have recorded a positive destination-file-size observation")
 }

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -254,9 +254,23 @@ func startProcesses() error {
 		"HATCHET_CLIENT_TLS_STRATEGY=none",
 	)
 
+	// Pick free loopback ports for the Prometheus /metrics endpoints so parallel
+	// runs and local port conflicts don't interfere. The TOCTOU race is accepted
+	// per project convention.
+	var err error
+	if watcherMetricsAddr, err = reserveFreeAddr(); err != nil {
+		return fmt.Errorf("reserve watcher metrics addr: %w", err)
+	}
+
+	if workerMetricsAddr, err = reserveFreeAddr(); err != nil {
+		return fmt.Errorf("reserve worker metrics addr: %w", err)
+	}
+
+	watcherEnv := append(baseEnv, "METRICS_ADDR="+watcherMetricsAddr)
+
 	// Start watcher subprocess.
 	watcherCmd = exec.Command(watcherBin, "--config", watcherCfg)
-	watcherCmd.Env = baseEnv
+	watcherCmd.Env = watcherEnv
 	// These already use slog so write directly to stdout/stderr to avoid double encapsulation
 	watcherCmd.Stdout = os.Stdout
 	watcherCmd.Stderr = os.Stderr
@@ -269,6 +283,7 @@ func startProcesses() error {
 
 	// Start worker subprocess with path-translation env vars.
 	workerEnv := append(baseEnv,
+		"METRICS_ADDR="+workerMetricsAddr,
 		"MEDIA_OUTPUT_DIR="+processedDir,
 		"MEDIA_INPUT_ROOT="+downloadsDir,
 		"RADARR_URL="+radarrBase,
@@ -303,6 +318,21 @@ func stopProcesses() {
 			_ = cmd.Wait()
 		}
 	}
+}
+
+// reserveFreeAddr binds a TCP listener on a random loopback port, closes it, and
+// returns the address string. There is an inherent TOCTOU race between close and
+// the caller's re-bind, but this matches the convention used elsewhere in the
+// codebase (see pkg/metrics/metrics_test.go freeAddr).
+func reserveFreeAddr() (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+
+	addr := listener.Addr().String()
+
+	return addr, listener.Close()
 }
 
 // moduleRoot returns the absolute path of the Go module root by invoking

--- a/e2e/sonarr_test.go
+++ b/e2e/sonarr_test.go
@@ -99,4 +99,35 @@ func TestSonarrHappyPath(t *testing.T) {
 	assert.Contains(t, info.formatName, "matroska", "output container should be Matroska")
 	assert.Equal(t, "hevc", info.videoCodec, "output video codec should be H.265")
 	assert.Greater(t, info.durationSec, 300.0, "output duration should be at least 5 minutes")
+
+	assertSonarrPipelineMetrics(t)
+}
+
+func assertSonarrPipelineMetrics(t *testing.T) {
+	t.Helper()
+
+	// The watcher counters are updated synchronously from the scan goroutine;
+	// the worker's record_metrics task runs after cleanup, so poll until it lands.
+	filter := map[string]string{"mapping_name": "sonarr"}
+
+	var workerSeries metricSeries
+
+	require.Eventually(t, func() bool {
+		workerSeries = fetchMetrics(t, workerMetricsAddr)
+		return workerSeries.sum("media_workflow_total_duration_seconds_count", filter) >= 1
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected worker to record at least one completed media_workflow run for the sonarr mapping")
+
+	watcherSeries := fetchMetrics(t, watcherMetricsAddr)
+	assert.Greater(t, watcherSeries.sum("watcher_scans_total", filter), 0.0,
+		"watcher should have completed at least one scan of the sonarr mapping")
+	assert.Greater(t, watcherSeries.sum("watcher_files_discovered_total", filter), 0.0,
+		"watcher should have discovered the sonarr source file")
+	assert.Greater(t, watcherSeries.sum("watcher_dispatches_total", filter), 0.0,
+		"watcher should have dispatched the sonarr workflow to Hatchet")
+
+	assert.GreaterOrEqual(t, workerSeries.sum("media_workflow_transcode_duration_seconds_count", filter), 1.0,
+		"worker should have recorded the sonarr transcode duration")
+	assert.Greater(t, workerSeries.sum("media_workflow_destination_file_size_bytes_sum", filter), 0.0,
+		"worker should have recorded a positive destination-file-size observation")
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/hatchet-dev/hatchet v0.83.25
 	github.com/invopop/jsonschema v0.13.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.35.0
 	github.com/stretchr/testify v1.11.1
@@ -77,8 +79,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect


### PR DESCRIPTION
## Summary

- Starts the watcher and worker subprocesses with `METRICS_ADDR` set so both expose `/metrics` during the test run.
- Adds `assertRadarrPipelineMetrics` and `assertSonarrPipelineMetrics` helpers (each in their own test file) that scrape the Prometheus endpoints after each happy-path test completes and assert that the expected counters and histogram observations are present, filtered by `mapping_name` label.
- Worker metrics use `require.Eventually` since the `record_metrics` Hatchet task runs asynchronously after cleanup; watcher metrics are checked directly since a successful dispatch (proven by `hasFile=true`) guarantees at least one scan has already completed.
- Uses `expfmt.NewTextParser` from `prometheus/common` for correct Prometheus text-format parsing, promoting `prometheus/common` and `prometheus/client_model` from indirect to direct dependencies.

## Test plan

- [x] Run `make test-e2e` and confirm `TestRadarrHappyPath` and `TestSonarrHappyPath` both pass including the new metrics assertions.
- [x] Temporarily remove `METRICS_ADDR` from one subprocess env in `setup_test.go` and confirm the corresponding metrics assertions fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)