### PR TITLE
feat(schema): add descriptions to watcher config JSON schema fields

### DIFF
--- a/cmd/gen-config-schema/main.go
+++ b/cmd/gen-config-schema/main.go
@@ -15,6 +15,11 @@ func main() {
 		FieldNameTag: "yaml",
 	}
 
+	if err := r.AddGoComments("github.com/solidDoWant/media-processor", "./internal/watcherconfig"); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load Go comments: %v\n", err)
+		os.Exit(1)
+	}
+
 	schema := r.Reflect(&watcherconfig.Config{})
 
 	out, err := json.Marshal(schema)

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -20,7 +20,11 @@ type CronExpression string
 
 // JSONSchema returns a JSON Schema for CronExpression using the canonical Hatchet cron regex.
 func (CronExpression) JSONSchema() *jsonschema.Schema {
-	return &jsonschema.Schema{Type: "string", Pattern: sixFieldCronPattern}
+	return &jsonschema.Schema{
+		Type:        "string",
+		Pattern:     sixFieldCronPattern,
+		Description: "Hatchet 6-field cron expression (seconds-leading) controlling how often the watcher scans directories. Example: \"*/5 * * * * *\" runs every 5 seconds.",
+	}
 }
 
 // CompiledRegexp is a Go regular expression that is compiled at YAML parse time. An invalid
@@ -34,7 +38,11 @@ type CompiledRegexp struct {
 // (the regex pattern) at YAML parse time; reflecting the Go struct would produce an empty object
 // schema, so this method overrides that to describe the on-disk shape accurately.
 func (CompiledRegexp) JSONSchema() *jsonschema.Schema {
-	return &jsonschema.Schema{Type: "string", Format: "regex"}
+	return &jsonschema.Schema{
+		Type:        "string",
+		Format:      "regex",
+		Description: "Go regular expression matched against the absolute path of each file or directory. A matching file is skipped; a matching directory prunes its entire subtree.",
+	}
 }
 
 // UnmarshalYAML compiles the scalar YAML string as a Go regular expression. It returns an error
@@ -65,10 +73,11 @@ var validMediaTypes = []medialib.MediaType{medialib.MovieType, medialib.ShowType
 // WatchEntry describes a watched location, mapping a filesystem path to a media type for dispatch
 // and carrying a human-readable name for identification.
 type WatchEntry struct {
+	// Name is a human-readable label for this watch entry, used in logs and metrics.
 	Name string `yaml:"name" jsonschema:"minLength=1" validate:"min=1"`
+	// Path is the absolute filesystem path to the directory to watch.
 	Path string `yaml:"path" jsonschema:"minLength=1" validate:"min=1"`
-	// MediaType must be one of the values in validMediaTypes; validated by the mediatype tag.
-	// The validate tag is required for runtime enforcement; medialib.MediaType.JSONSchema handles schema generation.
+	// MediaType indicates whether this directory contains movies or TV show episodes.
 	MediaType medialib.MediaType `yaml:"mediaType" validate:"mediatype"`
 	// IgnorePatterns is an optional list of Go regular expressions matched against the absolute
 	// path of each file and directory encountered during a scan. A matching file is silently
@@ -88,12 +97,10 @@ type WatchEntry struct {
 
 // Config is the top-level watcher configuration loaded from the YAML config file.
 type Config struct {
-	// CronSchedule is the Hatchet cron expression controlling how often the watcher
-	// scans directories (default: every 5 seconds). Supports Hatchet's 6-field format
-	// with a leading seconds field, e.g. "*/5 * * * * *".
-	// The CronExpression type provides the JSON Schema pattern; hatchetcron validates at runtime.
+	// CronSchedule controls how often the watcher scans directories (default: every 5 seconds).
+	// Uses Hatchet's 6-field cron format with a leading seconds field, e.g. "*/5 * * * * *".
 	CronSchedule CronExpression `yaml:"cronSchedule,omitempty" validate:"omitempty,hatchetcron"`
-	// Watches uses validate:"dive" to validate each WatchEntry element in the slice.
+	// Watches lists the directories to monitor and their associated media types.
 	Watches []WatchEntry `yaml:"watches,omitempty" validate:"dive"`
 }
 

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -92,7 +92,7 @@ type WatchEntry struct {
 	// RetainEmptyDirectories controls whether empty parent directories are removed after the
 	// source file is deleted. When false or omitted (the default), parent directories that
 	// become empty as a result of source-file deletion are pruned bottom-up, stopping at the
-	// watch root. When true, no directory removal is performed (current behaviour).
+	// watch root. When true, no directory removal is performed.
 	RetainEmptyDirectories bool `yaml:"retainEmptyDirectories,omitempty"`
 }
 

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -75,14 +75,15 @@ var validMediaTypes = []medialib.MediaType{medialib.MovieType, medialib.ShowType
 type WatchEntry struct {
 	// Name is a human-readable label for this watch entry, used in logs and metrics.
 	Name string `yaml:"name" jsonschema:"minLength=1" validate:"min=1"`
-	// Path is the absolute filesystem path to the directory to watch.
+	// Path is the filesystem path to the directory to watch. Relative paths are resolved
+	// against the watcher's working directory.
 	Path string `yaml:"path" jsonschema:"minLength=1" validate:"min=1"`
 	// MediaType indicates whether this directory contains movies or TV show episodes.
 	MediaType medialib.MediaType `yaml:"mediaType" validate:"mediatype"`
 	// IgnorePatterns is an optional list of Go regular expressions matched against the absolute
 	// path of each file and directory encountered during a scan. A matching file is silently
 	// skipped; a matching directory causes its entire subtree to be pruned. Patterns are
-	// compiled at config load; an invalid expression causes loadConfig to return an error.
+	// compiled when the configuration is loaded; an invalid expression causes configuration loading to fail.
 	IgnorePatterns []CompiledRegexp `yaml:"ignorePatterns,omitempty" validate:"omitempty"`
 	// PreserveSource controls whether the source file is deleted after successful processing.
 	// When true, the source file is kept; when false or omitted, the source file is deleted

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -24,8 +24,9 @@ const (
 // JSONSchema returns a JSON Schema for MediaType restricting values to the valid types.
 func (MediaType) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Type: "string",
-		Enum: []any{string(MovieType), string(ShowType)},
+		Type:        "string",
+		Enum:        []any{string(MovieType), string(ShowType)},
+		Description: "Whether the watched directory contains movies (\"movie\") or TV show episodes (\"show\").",
 	}
 }
 

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -5,58 +5,70 @@
   "$defs": {
     "CompiledRegexp": {
       "type": "string",
-      "format": "regex"
+      "format": "regex",
+      "description": "Go regular expression matched against the absolute path of each file or directory. A matching file is skipped; a matching directory prunes its entire subtree."
     },
     "Config": {
       "properties": {
         "cronSchedule": {
-          "$ref": "#/$defs/CronExpression"
+          "$ref": "#/$defs/CronExpression",
+          "description": "CronSchedule controls how often the watcher scans directories (default: every 5 seconds).\nUses Hatchet's 6-field cron format with a leading seconds field, e.g. \"*/5 * * * * *\"."
         },
         "watches": {
           "items": {
             "$ref": "#/$defs/WatchEntry"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Watches lists the directories to monitor and their associated media types."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Config is the top-level watcher configuration loaded from the YAML config file."
     },
     "CronExpression": {
       "type": "string",
-      "pattern": "^(\\S+ ){5}\\S+$"
+      "pattern": "^(\\S+ ){5}\\S+$",
+      "description": "Hatchet 6-field cron expression (seconds-leading) controlling how often the watcher scans directories. Example: \"*/5 * * * * *\" runs every 5 seconds."
     },
     "MediaType": {
       "type": "string",
       "enum": [
         "movie",
         "show"
-      ]
+      ],
+      "description": "Whether the watched directory contains movies (\"movie\") or TV show episodes (\"show\")."
     },
     "WatchEntry": {
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Name is a human-readable label for this watch entry, used in logs and metrics."
         },
         "path": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Path is the absolute filesystem path to the directory to watch."
         },
         "mediaType": {
-          "$ref": "#/$defs/MediaType"
+          "$ref": "#/$defs/MediaType",
+          "description": "MediaType indicates whether this directory contains movies or TV show episodes."
         },
         "ignorePatterns": {
           "items": {
             "$ref": "#/$defs/CompiledRegexp"
           },
-          "type": "array"
+          "type": "array",
+          "description": "IgnorePatterns is an optional list of Go regular expressions matched against the absolute\npath of each file and directory encountered during a scan. A matching file is silently\nskipped; a matching directory causes its entire subtree to be pruned. Patterns are\ncompiled at config load; an invalid expression causes loadConfig to return an error."
         },
         "preserveSource": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "PreserveSource controls whether the source file is deleted after successful processing.\nWhen true, the source file is kept; when false or omitted, the source file is deleted\n(default behaviour)."
         },
         "retainEmptyDirectories": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "RetainEmptyDirectories controls whether empty parent directories are removed after the\nsource file is deleted. When false or omitted (the default), parent directories that\nbecome empty as a result of source-file deletion are pruned bottom-up, stopping at the\nwatch root. When true, no directory removal is performed (current behaviour)."
         }
       },
       "additionalProperties": false,
@@ -65,7 +77,8 @@
         "name",
         "path",
         "mediaType"
-      ]
+      ],
+      "description": "WatchEntry describes a watched location, mapping a filesystem path to a media type for dispatch and carrying a human-readable name for identification."
     }
   }
 }

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -49,7 +49,7 @@
         "path": {
           "type": "string",
           "minLength": 1,
-          "description": "Path is the absolute filesystem path to the directory to watch."
+          "description": "Path is the filesystem path to the directory to watch. Relative paths are resolved\nagainst the watcher's working directory."
         },
         "mediaType": {
           "$ref": "#/$defs/MediaType",
@@ -60,7 +60,7 @@
             "$ref": "#/$defs/CompiledRegexp"
           },
           "type": "array",
-          "description": "IgnorePatterns is an optional list of Go regular expressions matched against the absolute\npath of each file and directory encountered during a scan. A matching file is silently\nskipped; a matching directory causes its entire subtree to be pruned. Patterns are\ncompiled at config load; an invalid expression causes loadConfig to return an error."
+          "description": "IgnorePatterns is an optional list of Go regular expressions matched against the absolute\npath of each file and directory encountered during a scan. A matching file is silently\nskipped; a matching directory causes its entire subtree to be pruned. Patterns are\ncompiled when the configuration is loaded; an invalid expression causes configuration loading to fail."
         },
         "preserveSource": {
           "type": "boolean",

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -68,7 +68,7 @@
         },
         "retainEmptyDirectories": {
           "type": "boolean",
-          "description": "RetainEmptyDirectories controls whether empty parent directories are removed after the\nsource file is deleted. When false or omitted (the default), parent directories that\nbecome empty as a result of source-file deletion are pruned bottom-up, stopping at the\nwatch root. When true, no directory removal is performed (current behaviour)."
+          "description": "RetainEmptyDirectories controls whether empty parent directories are removed after the\nsource file is deleted. When false or omitted (the default), parent directories that\nbecome empty as a result of source-file deletion are pruned bottom-up, stopping at the\nwatch root. When true, no directory removal is performed."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Enables `AddGoComments` on the `jsonschema.Reflector` in `gen-config-schema` so existing Go doc comments on `Config` and `WatchEntry` fields are automatically surfaced as JSON Schema `description` properties.
- Adds `Description` to the `JSONSchema()` overrides for `CronExpression`, `CompiledRegexp`, and `MediaType` (these bypass the reflector, so they need manual descriptions).
- Adds doc comments to the previously undocumented `name` and `path` fields in `WatchEntry`.
- Cleans up a few field comments that leaked implementation details (e.g. `validate:"dive"`, `hatchetcron validates at runtime`) to keep descriptions user-facing.

## Test plan

- [x] `make generate-schema` produces an updated `schemas/watcher.schema.json` with `description` on every field
- [x] `make test` passes (all unit tests green)
- [x] Lint errors are pre-existing on `master` and unrelated to this change (verified by stashing and re-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)