### PR TITLE
build(containers): add minimal libav Nix derivation and OCI image derivations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,22 @@ generate-schema: ## Generate JSON schema for the watcher config file.
 
 ##@ Container Images
 
+VERSION = 0.0.1-dev
+CONTAINER_REGISTRY = ghcr.io/soliddowant
+PUSH_ALL ?= false
+
+INCLUDE_LATEST = $(PUSH_ALL)
+
+WATCHER_IMAGE_TAGS = $(CONTAINER_REGISTRY)/watcher:$(VERSION) $(if $(filter true,$(INCLUDE_LATEST)),$(CONTAINER_REGISTRY)/watcher:latest)
+WORKER_IMAGE_TAGS = $(CONTAINER_REGISTRY)/worker:$(VERSION) $(if $(filter true,$(INCLUDE_LATEST)),$(CONTAINER_REGISTRY)/worker:latest)
+
 .PHONY: build-images
 build-images: ## Build watcher and worker OCI images and load them into the local Docker daemon.
 	$$(nix build --print-out-paths --no-link .#watcher-image) | docker load
+	$(foreach tag,$(WATCHER_IMAGE_TAGS),docker tag watcher:latest $(tag);)
 	$$(nix build --print-out-paths --no-link .#worker-image) | docker load
+	$(foreach tag,$(WORKER_IMAGE_TAGS),docker tag worker:latest $(tag);)
+	$(if $(findstring t,$(PUSH_ALL)),$(foreach tag,$(WATCHER_IMAGE_TAGS) $(WORKER_IMAGE_TAGS),docker push $(tag);))
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,13 @@ generate-schema: ## Generate JSON schema for the watcher config file.
 	@mkdir -p schemas
 	go run ./cmd/gen-config-schema | jq > schemas/watcher.schema.json
 
+##@ Container Images
+
+.PHONY: build-images
+build-images: ## Build watcher and worker OCI images and load them into the local Docker daemon.
+	$$(nix build --print-out-paths --no-link .#watcher-image) | docker load
+	$$(nix build --print-out-paths --no-link .#worker-image) | docker load
+
 ##@ Build
 
 # Note: CGO is required. FFmpeg 8 development headers must be available via pkg-config.

--- a/flake.nix
+++ b/flake.nix
@@ -18,12 +18,23 @@
         pkgs = nixpkgs.legacyPackages.${system};
 
         libav-minimal = pkgs.ffmpeg-headless.overrideAttrs (old: {
+          # Drop outputs that won't be populated: programs are disabled so no
+          # binaries are installed, and documentation is disabled so no man
+          # pages or HTML docs are installed. Nix fails if a declared output
+          # path is never created.
+          outputs = builtins.filter (o: o != "bin" && o != "doc" && o != "man") (old.outputs or [ "out" ]);
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.libvpl ];
-          configureFlags =
-            (builtins.filter
-              (f: f != "--enable-ffmpeg" && f != "--enable-ffprobe" && f != "--enable-ffplay")
-              (old.configureFlags or [ ]))
-            ++ [ "--disable-programs" "--enable-libvpl" "--disable-doc" ];
+          # Append last so these override any earlier enable-* flags from the
+          # upstream ffmpeg-headless expression.
+          configureFlags = (old.configureFlags or [ ]) ++ [
+            "--disable-programs"
+            "--disable-manpages"
+            "--disable-doc"
+            "--enable-libvpl"
+          ];
+          # make check runs fate tests that invoke the ffmpeg CLI; skip since
+          # we disabled programs.
+          doCheck = false;
         });
 
         mkBin = { name, subPackage }: pkgs.buildGoModule {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,53 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-      in {
+
+        libav-minimal = pkgs.ffmpeg-headless.overrideAttrs (old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.libvpl ];
+          configureFlags =
+            (builtins.filter
+              (f: f != "--enable-ffmpeg" && f != "--enable-ffprobe" && f != "--enable-ffplay")
+              (old.configureFlags or [ ]))
+            ++ [ "--disable-programs" "--enable-libvpl" "--disable-doc" ];
+        });
+
+        mkBin = { name, subPackage }: pkgs.buildGoModule {
+          inherit name;
+          src = ./.;
+          vendorHash = "sha256-8Hlizevwdoeb3IjSDuszsf/rwyoQv8Y18NiUjUA0jBo=";
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [ libav-minimal.dev ];
+          subPackages = [ subPackage ];
+        };
+
+        watcher-bin = mkBin { name = "watcher"; subPackage = "cmd/watcher"; };
+        worker-bin = mkBin { name = "worker"; subPackage = "cmd/worker"; };
+
+        baseContents = [ libav-minimal pkgs.cacert ];
+      in
+      {
+        packages.watcher-image = pkgs.dockerTools.streamLayeredImage {
+          name = "watcher";
+          tag = "latest";
+          contents = baseContents ++ [ watcher-bin ];
+          config = {
+            Entrypoint = [ "/bin/watcher" ];
+          };
+        };
+
+        packages.worker-image = pkgs.dockerTools.streamLayeredImage {
+          name = "worker";
+          tag = "latest";
+          contents = baseContents ++ [ pkgs.intel-media-driver pkgs.vpl-gpu-rt worker-bin ];
+          config = {
+            Entrypoint = [ "/bin/worker" ];
+            Env = [
+              "LIBVA_DRIVERS_PATH=${pkgs.intel-media-driver}/lib/dri"
+              "ONEVPL_SEARCH_PATH=${pkgs.vpl-gpu-rt}/lib"
+            ];
+          };
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             pkgs.go_1_26

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,31 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        libav-minimal = pkgs.ffmpeg-headless.overrideAttrs (old: {
+        libav-minimal = pkgs.ffmpeg-headless.overrideAttrs (old:
+          let
+            # Packages whose corresponding FFmpeg feature flag is disabled below.
+            # Filtering them out of buildInputs prevents the linker from pulling
+            # them into the shared-library RPATH even when the configure flag is
+            # set to --disable-*.
+            removedBuildInputPnames = [
+              "alsa-lib" "amf-headers" "libaom" "libass" "libbluray" "bzip2"
+              "fontconfig" "freetype" "fribidi" "gmp-with-cxx" "gnutls"
+              "harfbuzz" "xz" "lame" "openapv" "openjpeg" "libopenmpt"
+              "libopus" "librist" "soxr" "speex" "srt" "libssh" "svt-av1"
+              "libtheora" "v4l-utils" "vid.stab" "libvorbis" "libvpx"
+              "libwebp" "libxml2" "xvidcore" "zimg" "zvbi"
+            ];
+          in {
           # Drop outputs that won't be populated: programs are disabled so no
           # binaries are installed, and documentation is disabled so no man
           # pages or HTML docs are installed. Nix fails if a declared output
           # path is never created.
           outputs = builtins.filter (o: o != "bin" && o != "doc" && o != "man") (old.outputs or [ "out" ]);
-          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.libvpl ];
+          buildInputs =
+            (builtins.filter
+              (dep: !(builtins.elem (dep.pname or dep.name or "") removedBuildInputPnames))
+              (old.buildInputs or [ ]))
+            ++ [ pkgs.libvpl ];
           # Append last so these override any earlier enable-* flags from the
           # upstream ffmpeg-headless expression.
           configureFlags = (old.configureFlags or [ ]) ++ [
@@ -31,6 +49,56 @@
             "--disable-manpages"
             "--disable-doc"
             "--enable-libvpl"
+
+            # Software codec encoders not used by any workflow (hardware paths
+            # cover H.264/H.265/VP9/AV1; built-in decoders handle the input side):
+            "--disable-libsvtav1"
+            "--disable-libaom"
+            "--disable-libvpx"
+            "--disable-libopus"
+            "--disable-libvorbis"
+            "--disable-libtheora"
+            "--disable-libspeex"
+            "--disable-libmp3lame"
+            "--disable-libopenmpt"
+            "--disable-libwebp"
+            "--disable-libopenjpeg"
+            "--disable-libxvid"
+            "--disable-libvidstab"
+            "--disable-libzvbi"
+            "--disable-liboapv"
+
+            # Text / subtitle / font rendering (drawtext filter, burn-in subs —
+            # none of which are used):
+            "--disable-libass"
+            "--disable-libfreetype"
+            "--disable-libfribidi"
+            "--disable-libharfbuzz"
+            "--disable-fontconfig"
+            "--disable-libfontconfig"
+
+            # Network protocols (local file I/O only; file:// is always built in):
+            "--disable-network"
+            "--disable-librist"
+            "--disable-libsrt"
+            "--disable-libssh"
+            "--disable-gnutls"
+            "--disable-gmp"
+            "--disable-libxml2"
+
+            # Compression formats beyond zlib (not needed for MP4/MKV):
+            "--disable-bzlib"
+            "--disable-lzma"
+
+            # Miscellaneous unused features:
+            "--disable-libzimg"   # zscale filter
+            "--disable-libsoxr"   # optional swresample backend; built-in suffices
+            "--disable-amf"       # AMD AMF (only QSV/NVENC/VAAPI implemented)
+            "--disable-alsa"      # audio device I/O (server-side processing)
+            "--disable-libv4l2"   # V4L2 camera input
+            "--disable-v4l2-m2m"  # V4L2 memory-to-memory encoding
+            "--disable-opencl"    # OpenCL compute (GPU done via VAAPI/QSV/NVENC)
+            "--disable-libbluray" # Blu-ray container support
           ];
           # make check runs fate tests that invoke the ffmpeg CLI; skip since
           # we disabled programs.
@@ -88,6 +156,7 @@
             pkgs.direnv
             pkgs.nix-direnv
             pkgs.gh
+            pkgs.dive
           ];
           buildInputs = [
             pkgs.ffmpeg-full.dev


### PR DESCRIPTION
## Summary

- Adds `libav-minimal` Nix derivation (derived from `pkgs.ffmpeg-headless.overrideAttrs`) with `libvpl` support and all programs disabled — used as the shared runtime base layer in both images and as `buildInputs` for the Go binary derivations
- Adds `packages.watcher-image` and `packages.worker-image` via `pkgs.dockerTools.streamLayeredImage`, sharing a common `baseContents = [ libav-minimal pkgs.cacert ]` base; the worker image additionally includes `intel-media-driver`, `vpl-gpu-rt`, and sets `LIBVA_DRIVERS_PATH` / `ONEVPL_SEARCH_PATH` in OCI Env metadata
- Adds `make build-images` Makefile target under a new `##@ Container Images` section that builds both images with `nix build --print-out-paths --no-link` and streams each result into `docker load`

## Test plan

- [x] Run `make build-images` in a Nix environment and confirm both `watcher:latest` and `worker:latest` images load without error (AC1)
- [x] Run `docker run --rm watcher:latest` with no config flag — confirm non-zero exit and a log line about missing configuration, not a panic (AC2)
- [x] Run `docker run --rm -e HATCHET_CLIENT_TOKEN= worker:latest` with no token — confirm non-zero exit and a log line about the missing variable (AC3)
- [x] Run `docker inspect watcher:latest worker:latest` and compare `RootFS.Layers` — confirm every layer digest in watcher is present in worker (AC4)
- [x] Run `docker run --rm worker:latest find /nix/store -name &#39;iHD_drv_video.so&#39; -o -name &#39;libmfx-gen.so&#39;` and confirm both are present; run `docker inspect worker:latest` and confirm `LIBVA_DRIVERS_PATH` and `ONEVPL_SEARCH_PATH` are in Env (AC5)
- [x] Run `docker run --rm watcher:latest find /nix/store -name &#39;iHD_drv_video.so&#39; -o -name &#39;libmfx-gen.so&#39;` and confirm neither is present (AC6)

**Notes on verification:**
- AC2/AC3: verified by running the containers directly; both exit 1 with the expected log lines.
- AC4: 23 of 25 watcher layers are present in worker. The 2 watcher-only layers are the watcher binary and customisation layer — expected to differ. All shared store-path layers (libav-minimal, cacert, glibc, etc.) have identical digests, confirming Nix content-addressing.
- AC5/AC6: verified via `docker export | tar tf -` since the images have no shell. Worker contains `iHD_drv_video.so` and `libmfx-gen.so` with `LIBVA_DRIVERS_PATH`/`ONEVPL_SEARCH_PATH` set; watcher has neither.

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)