### PR TITLE
refactor(workflows): extract MediaWorkflowName and MediaInput into FFmpeg-free types package

### DIFF
--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -15,7 +15,7 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
-	"github.com/solidDoWant/media-processor/workflows/media"
+	mediatypes "github.com/solidDoWant/media-processor/workflows/media/types"
 )
 
 func mappingNameAttr(name string) attribute.KeyValue {
@@ -128,8 +128,8 @@ func NewScanWorkflow(client *hatchet.Client, cfg *Config, mp otelmetric.MeterPro
 			dispatch := func(dispatchCtx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool) error {
 				_, err := client.RunNoWait(
 					dispatchCtx,
-					media.MediaWorkflowName,
-					media.MediaInput{
+					mediatypes.MediaWorkflowName,
+					mediatypes.MediaInput{
 						FilePath:               filePath,
 						MediaType:              mediaType,
 						MappingName:            mappingName,

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -16,11 +16,15 @@ import (
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/pkg/webhook"
+	mediatypes "github.com/solidDoWant/media-processor/workflows/media/types"
 	"github.com/solidDoWant/media-processor/workflows/steps"
 )
 
+// MediaWorkflowName re-exports the constant from the types package for callers that
+// import workflows/media directly.
+const MediaWorkflowName = mediatypes.MediaWorkflowName
+
 const (
-	MediaWorkflowName = "Media"
 	// defaultTaskRetries is the number of retry attempts for retriable workflow steps.
 	defaultTaskRetries = 3
 
@@ -78,15 +82,9 @@ type MediaWorkflowConfig struct {
 	H265CRF int
 }
 
-// MediaInput is the workflow's trigger payload.
-type MediaInput struct {
-	FilePath               string             `json:"file_path"`
-	MediaType              medialib.MediaType `json:"media_type"`
-	MappingName            string             `json:"mapping_name"`
-	PreserveSource         bool               `json:"preserve_source,omitempty"`
-	WatchRoot              string             `json:"watch_root,omitempty"`
-	RetainEmptyDirectories bool               `json:"retain_empty_directories,omitempty"`
-}
+// MediaInput is an alias for the shared input type so existing callers within this
+// package do not need to be updated.
+type MediaInput = mediatypes.MediaInput
 
 // NewMediaWorkflow returns a Hatchet workflow that transcodes a media file (movie or TV
 // episode) to the standard format, moves it to the output directory, and notifies the

--- a/workflows/media/types/types.go
+++ b/workflows/media/types/types.go
@@ -1,0 +1,18 @@
+// Package types defines the shared workflow name and input payload for the media
+// processing workflow. It is intentionally free of CGO and FFmpeg dependencies so
+// that cmd/watcher can import it without pulling in libav shared libraries.
+package types
+
+import "github.com/solidDoWant/media-processor/pkg/medialib"
+
+const MediaWorkflowName = "Media"
+
+// MediaInput is the workflow's trigger payload.
+type MediaInput struct {
+	FilePath               string             `json:"file_path"`
+	MediaType              medialib.MediaType `json:"media_type"`
+	MappingName            string             `json:"mapping_name"`
+	PreserveSource         bool               `json:"preserve_source,omitempty"`
+	WatchRoot              string             `json:"watch_root,omitempty"`
+	RetainEmptyDirectories bool               `json:"retain_empty_directories,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Introduces `workflows/media/types` containing only `MediaWorkflowName` and `MediaInput` — no CGO or FFmpeg imports.
- `cmd/watcher` now imports `workflows/media/types` directly instead of `workflows/media`, breaking the transitive `go-astiav` / `pkg/ffmpeg` / `pkg/ffprobe` dependency chain.
- `workflows/media` re-exports `MediaWorkflowName` as a constant and `MediaInput` as a type alias so no callers within that package need updating.

## Acceptance criteria

- [x] `go list -deps ./cmd/watcher/...` no longer includes `github.com/asticode/go-astiav`, `pkg/ffmpeg`, or `pkg/ffprobe`
- [x] `CGO_ENABLED=0 go build ./cmd/watcher/...` succeeds without errors
- [x] `go list -deps ./cmd/worker/...` still includes those packages (no regression)
- [ ] `nix build .#watcher-image` closure does not contain `libav-minimal` — follows from AC1 but requires nix build infrastructure to verify; cannot run in this environment (no nix daemon available)

## Test plan

- All unit tests pass (`make test`)
- `go list -deps ./cmd/watcher/... | grep -E 'go-astiav|pkg/ffmpeg|pkg/ffprobe'` returns empty
- `CGO_ENABLED=0 go build ./cmd/watcher/...` exits 0
- `go list -deps ./cmd/worker/... | grep -E 'go-astiav|pkg/ffmpeg|pkg/ffprobe'` returns all three packages

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)