### PR TITLE
feat(logging): add structured slog logging to watcher and worker

### DIFF
--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -198,7 +199,11 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 		successOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr(scanStatusSuccess))
 		errorOpt := otelmetric.WithAttributes(mappingNameAttr(w.Name), statusAttr(scanStatusError))
 
-		var mappingErrs []error
+		var (
+			mappingErrs     []error
+			filesDiscovered int
+			jobsSubmitted   int
+		)
 
 		// Normalise the watch path to an absolute path once per entry so that watchRoot
 		// is always comparable to the absolute file paths produced inside the walk callback.
@@ -237,6 +242,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 			}
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
+			filesDiscovered++
 
 			if dispatchErr := dispatch(ctx, path, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories); dispatchErr != nil {
 				mappingErrs = append(mappingErrs, fmt.Errorf("dispatch workflow for %q (media type %v): %w", path, w.MediaType, dispatchErr))
@@ -244,6 +250,8 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)
 			} else {
 				instruments.dispatchesTotal.Add(ctx, 1, fileOpt)
+				jobsSubmitted++
+				slog.InfoContext(ctx, "dispatched workflow", slog.String("file", path), slog.String("watch", w.Name))
 			}
 
 			return nil
@@ -254,6 +262,12 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			mappingErrs = append(mappingErrs, fmt.Errorf("walk directory %q: %w", w.Path, err))
 		}
+
+		slog.InfoContext(ctx, "scan complete",
+			slog.String("watch", w.Name),
+			slog.Int("files_discovered", filesDiscovered),
+			slog.Int("jobs_submitted", jobsSubmitted),
+		)
 
 		duration := time.Since(start).Seconds()
 		instruments.scanDuration.Record(ctx, duration, mappingOpt)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -135,11 +135,13 @@ func run(ctx context.Context) error {
 		return err
 	}
 
+	hardwareDevicePath := os.Getenv("MEDIA_HARDWARE_DEVICE_PATH")
+
 	mediaWorkflow := media.NewMediaWorkflow(client, media.MediaWorkflowConfig{
 		OutputDir:             mediaOutputDir,
 		WatcherRoot:           os.Getenv("MEDIA_INPUT_ROOT"),
 		WebhookURL:            webhookClient.URL,
-		HardwareDevicePath:    os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"),
+		HardwareDevicePath:    hardwareDevicePath,
 		MeterProvider:         metricsProvider.MeterProvider(),
 		HighCardinalityLabels: os.Getenv("METRICS_HIGH_CARDINALITY_LABELS") == "true",
 		MinCropX:              minCropX,
@@ -160,11 +162,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("create Hatchet worker: %w", err)
 	}
 
-	startupAttrs := []any{slog.String("output_dir", mediaOutputDir)}
-	if hwDevice := os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"); hwDevice != "" {
-		startupAttrs = append(startupAttrs, slog.String("hardware_device", hwDevice))
-	}
-	slog.Info("connected to Hatchet, starting worker", startupAttrs...)
+	slog.InfoContext(ctx, "connected to Hatchet, starting worker", slog.String("output_dir", mediaOutputDir))
 
 	healthServer.SetReady()
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -160,7 +160,11 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("create Hatchet worker: %w", err)
 	}
 
-	slog.Info("connected to Hatchet, starting worker")
+	startupAttrs := []any{slog.String("output_dir", mediaOutputDir)}
+	if hwDevice := os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"); hwDevice != "" {
+		startupAttrs = append(startupAttrs, slog.String("hardware_device", hwDevice))
+	}
+	slog.Info("connected to Hatchet, starting worker", startupAttrs...)
 
 	healthServer.SetReady()
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -135,13 +135,11 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	hardwareDevicePath := os.Getenv("MEDIA_HARDWARE_DEVICE_PATH")
-
 	mediaWorkflow := media.NewMediaWorkflow(client, media.MediaWorkflowConfig{
 		OutputDir:             mediaOutputDir,
 		WatcherRoot:           os.Getenv("MEDIA_INPUT_ROOT"),
 		WebhookURL:            webhookClient.URL,
-		HardwareDevicePath:    hardwareDevicePath,
+		HardwareDevicePath:    os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"),
 		MeterProvider:         metricsProvider.MeterProvider(),
 		HighCardinalityLabels: os.Getenv("METRICS_HIGH_CARDINALITY_LABELS") == "true",
 		MinCropX:              minCropX,

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -349,9 +349,9 @@ func NewMediaWorkflow(
 func logStepResult(ctx context.Context, stepName, filePath string, start time.Time, err error) {
 	if err != nil {
 		slog.ErrorContext(ctx, "step failed", slog.String("step", stepName), slog.String("file", filePath), slog.Any("error", err))
-	} else {
-		slog.InfoContext(ctx, "step complete", slog.String("step", stepName), slog.String("file", filePath), slog.Duration("elapsed", time.Since(start)))
+		return
 	}
+	slog.InfoContext(ctx, "step complete", slog.String("step", stepName), slog.String("file", filePath), slog.Duration("elapsed", time.Since(start)))
 }
 
 // getArrLibrary returns the LibraryClient corresponding to mediaType, using

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -3,6 +3,7 @@
 package media
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -148,8 +149,10 @@ func NewMediaWorkflow(
 	// StartedAt is set here (not inside RunProbe) so existing RunProbe tests are unaffected.
 	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (steps.ProbeOutput, error) {
 		start := time.Now()
+		slog.InfoContext(ctx, "processing file", slog.String("file", input.FilePath))
 
 		out, err := steps.RunProbe(ctx, input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		logStepResult(ctx, "probe", input.FilePath, start, err)
 		if err != nil {
 			return out, err
 		}
@@ -170,12 +173,17 @@ func NewMediaWorkflow(
 	// cfg.MinCropX and cfg.MinCropY are passed directly; defaults are applied by the
 	// caller (cmd/worker) via parseCropThreshold before constructing MediaWorkflowConfig.
 	detectcropTask := wf.NewTask("detectcrop", func(ctx hatchet.Context, input MediaInput) (steps.DetectCropOutput, error) {
+		start := time.Now()
+
 		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
-			return steps.DetectCropOutput{}, fmt.Errorf("get probe output: %w", err)
+			wrappedErr := fmt.Errorf("get probe output: %w", err)
+			logStepResult(ctx, "detectcrop", input.FilePath, start, wrappedErr)
+			return steps.DetectCropOutput{}, wrappedErr
 		}
 
 		crop, err := steps.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, cfg.MinCropX, cfg.MinCropY)
+		logStepResult(ctx, "detectcrop", input.FilePath, start, err)
 		if err != nil {
 			return steps.DetectCropOutput{}, err
 		}
@@ -188,19 +196,27 @@ func NewMediaWorkflow(
 	// directory (rather than the system temp dir) means the rename is always within the
 	// same filesystem, so it is guaranteed to be atomic on Linux.
 	transcodeTask := wf.NewTask("transcode", func(ctx hatchet.Context, input MediaInput) (steps.TranscodeOutput, error) {
+		start := time.Now()
+
 		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
-			return steps.TranscodeOutput{}, fmt.Errorf("get probe output: %w", err)
+			wrappedErr := fmt.Errorf("get probe output: %w", err)
+			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+			return steps.TranscodeOutput{}, wrappedErr
 		}
 
 		var detectcrop steps.DetectCropOutput
 		if err := ctx.ParentOutput(detectcropTask, &detectcrop); err != nil {
-			return steps.TranscodeOutput{}, fmt.Errorf("get detectcrop output: %w", err)
+			wrappedErr := fmt.Errorf("get detectcrop output: %w", err)
+			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+			return steps.TranscodeOutput{}, wrappedErr
 		}
 
 		library, err := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
 		if err != nil {
-			return steps.TranscodeOutput{}, fmt.Errorf("get arr library for artwork: %w", err)
+			wrappedErr := fmt.Errorf("get arr library for artwork: %w", err)
+			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+			return steps.TranscodeOutput{}, wrappedErr
 		}
 
 		out, err := steps.RunTranscode(ctx, input.FilePath, probe, detectcrop.Crop, cfg.OutputDir, cfg.WatcherRoot, cfg.HardwareDevicePath, cfg.H265CRF, library)
@@ -208,6 +224,7 @@ func NewMediaWorkflow(
 			recorder.RecordArtworkFetchSkipped(ctx)
 		}
 
+		logStepResult(ctx, "transcode", input.FilePath, start, err)
 		return out, err
 	}, hatchet.WithParents(probeTask, detectcropTask), skipIfInvalid, hatchet.WithExecutionTimeout(cfg.TranscodeTimeout))
 
@@ -217,13 +234,18 @@ func NewMediaWorkflow(
 	// by .mkv, so that the path points to the actual transcoded file as seen by the arr
 	// service (via the LocalPathPrefix/RemotePathPrefix translation in ImportByFilePath).
 	notifyTask := wf.NewTask("notify", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+		start := time.Now()
+
 		var transcode steps.TranscodeOutput
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
-			return struct{}{}, fmt.Errorf("get transcode output: %w", err)
+			wrappedErr := fmt.Errorf("get transcode output: %w", err)
+			logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
+			return struct{}{}, wrappedErr
 		}
 
 		library, err := getArrLibrary(input.MediaType, radarrClient, sonarrClient)
 		if err != nil {
+			logStepResult(ctx, "notify", input.FilePath, start, err)
 			return struct{}{}, err
 		}
 
@@ -235,33 +257,47 @@ func NewMediaWorkflow(
 		importPath := filepath.Join(filepath.Dir(input.FilePath), mkvBase)
 
 		if err := library.ImportByFilePath(ctx, importPath); err != nil {
-			return struct{}{}, fmt.Errorf("notify library: %w", err)
+			wrappedErr := fmt.Errorf("notify library: %w", err)
+			logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
+			return struct{}{}, wrappedErr
 		}
 
+		logStepResult(ctx, "notify", input.FilePath, start, nil)
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// cleanup: delete the original source file after successful processing, unless
 	// PreserveSource is set on the originating watch entry.
 	cleanupTask := wf.NewTask("cleanup", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+		start := time.Now()
+
 		if input.PreserveSource {
+			logStepResult(ctx, "cleanup", input.FilePath, start, nil)
 			return struct{}{}, nil
 		}
 
-		return struct{}{}, steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		err := steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		logStepResult(ctx, "cleanup", input.FilePath, start, err)
+		return struct{}{}, err
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// record_metrics: record per-run OTel observations for valid-media completions.
 	// Runs after cleanup so total_duration_seconds covers the full probe→cleanup span.
 	_ = wf.NewTask("record_metrics", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+		start := time.Now()
+
 		var probe steps.ProbeOutput
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
-			return struct{}{}, fmt.Errorf("get probe output for metrics: %w", err)
+			wrappedErr := fmt.Errorf("get probe output for metrics: %w", err)
+			logStepResult(ctx, "record_metrics", input.FilePath, start, wrappedErr)
+			return struct{}{}, wrappedErr
 		}
 
 		var transcode steps.TranscodeOutput
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
-			return struct{}{}, fmt.Errorf("get transcode output for metrics: %w", err)
+			wrappedErr := fmt.Errorf("get transcode output for metrics: %w", err)
+			logStepResult(ctx, "record_metrics", input.FilePath, start, wrappedErr)
+			return struct{}{}, wrappedErr
 		}
 
 		var mediaInfo medialib.MediaInfo
@@ -285,23 +321,37 @@ func NewMediaWorkflow(
 		totalElapsed := time.Since(probe.StartedAt)
 		recorder.RecordRun(ctx, input, probe, transcode, mediaInfo, hardwareAccelerated, totalElapsed)
 
+		logStepResult(ctx, "record_metrics", input.FilePath, start, nil)
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask, notifyTask, cleanupTask), skipIfInvalid)
 
 	// record_invalid: increment the invalid-files counter when probe determines the file
 	// is not valid media. Skipped when the file is valid (i.e. the inverse of skipIfInvalid).
 	_ = wf.NewTask("record_invalid", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+		start := time.Now()
 		recorder.RecordInvalidFile(ctx, input.MediaType, input.MappingName)
+		logStepResult(ctx, "record_invalid", input.FilePath, start, nil)
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask),
 		hatchet.WithSkipIf(hatchet.ParentCondition(probeTask, "output.is_valid_media == true")))
 
 	// OnFailure: send a single aggregated failure notification to the configured webhook.
 	wf.OnFailure(func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
-		return struct{}{}, steps.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), MediaWorkflowName, input.FilePath, webhookClient)
+		start := time.Now()
+		err := steps.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), MediaWorkflowName, input.FilePath, webhookClient)
+		logStepResult(ctx, "onfailure", input.FilePath, start, err)
+		return struct{}{}, err
 	})
 
 	return wf
+}
+
+func logStepResult(ctx context.Context, stepName, filePath string, start time.Time, err error) {
+	if err != nil {
+		slog.ErrorContext(ctx, "step failed", slog.String("step", stepName), slog.String("file", filePath), slog.Any("error", err))
+	} else {
+		slog.InfoContext(ctx, "step complete", slog.String("step", stepName), slog.String("file", filePath), slog.Duration("elapsed", time.Since(start)))
+	}
 }
 
 // getArrLibrary returns the LibraryClient corresponding to mediaType, using

--- a/workflows/steps/detectcrop.go
+++ b/workflows/steps/detectcrop.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/solidDoWant/media-processor/pkg/ffmpeg"
 )
@@ -26,6 +27,7 @@ type DetectCropOutput struct {
 // each axis.
 func RunDetectCrop(ctx context.Context, filePath string, inputW, inputH, minCropX, minCropY int) (*ffmpeg.CropParams, error) {
 	if minCropX == -1 && minCropY == -1 {
+		slog.DebugContext(ctx, "crop detection skipped", slog.String("file", filePath), slog.String("reason", "both axes disabled"))
 		return nil, nil
 	}
 
@@ -34,7 +36,20 @@ func RunDetectCrop(ctx context.Context, filePath string, inputW, inputH, minCrop
 		return nil, err
 	}
 
-	return applyCropThresholds(detected, inputW, inputH, minCropX, minCropY), nil
+	result := applyCropThresholds(detected, inputW, inputH, minCropX, minCropY)
+
+	logAttrs := []any{
+		slog.String("file", filePath),
+		slog.Int("detected_w", detected.W), slog.Int("detected_h", detected.H),
+		slog.Int("detected_x", detected.X), slog.Int("detected_y", detected.Y),
+		slog.Bool("applied", result != nil),
+	}
+	if result == nil {
+		logAttrs = append(logAttrs, slog.String("skip_reason", "below pixel threshold"))
+	}
+	slog.DebugContext(ctx, "crop detection complete", logAttrs...)
+
+	return result, nil
 }
 
 // applyCropThresholds returns a pointer to detected when the crop exceeds the

--- a/workflows/steps/onfailure.go
+++ b/workflows/steps/onfailure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 // Returns nil (no-op) when stepErrors is empty.
 func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, workflowName, filePath string, webhookClient *webhook.Client) error {
 	if len(stepErrors) == 0 {
+		slog.InfoContext(ctx, "no step errors, skipping failure notification", slog.String("file", filePath))
 		return nil
 	}
 
@@ -31,6 +33,11 @@ func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, wo
 		errs = append(errs, fmt.Errorf("%s: %s", stepName, stepErrors[stepName]))
 	}
 
+	if webhookClient.URL == "" {
+		slog.InfoContext(ctx, "no webhook URL configured, skipping failure notification", slog.String("file", filePath))
+		return nil
+	}
+
 	if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
 		Workflow: workflowName,
 		FilePath: filePath,
@@ -39,6 +46,8 @@ func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, wo
 	}); err != nil {
 		return fmt.Errorf("notify failure: %w", err)
 	}
+
+	slog.InfoContext(ctx, "failure notification sent", slog.String("file", filePath))
 
 	return nil
 }

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -191,9 +191,9 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		videoCodec = ffmpeg.CodecH265
 	}
 
-	slog.DebugContext(ctx, "encoder selected",
+	slog.DebugContext(ctx, "video codec selected",
 		slog.String("video_codec", codecName(videoCodec)),
-		slog.Bool("hardware_accel_configured", hardwareDevicePath != ""),
+		slog.Bool("hardware_device_configured", hardwareDevicePath != ""),
 	)
 
 	audioExclude := nonEnglishAudioIndices(probe.AudioStreams)

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -191,6 +191,11 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 		videoCodec = ffmpeg.CodecH265
 	}
 
+	slog.DebugContext(ctx, "encoder selected",
+		slog.String("video_codec", codecName(videoCodec)),
+		slog.Bool("hardware_accel_configured", hardwareDevicePath != ""),
+	)
+
 	audioExclude := nonEnglishAudioIndices(probe.AudioStreams)
 	excludeIndices := append(audioExclude, nonEnglishSubtitleIndices(probe.SubtitleStreams)...)
 


### PR DESCRIPTION
## Summary

- Add `INFO` scan-summary and per-file dispatch logs to the watcher scan loop (`cmd/watcher/watcher.go`)
- Add `INFO` probe-start log and per-step success/failure logging via a `logStepResult` helper across all workflow task closures (`workflows/media/media.go`)
- Add `DEBUG` encoder-selection log in `RunTranscode` (`workflows/steps/transcode.go`)
- Add `DEBUG` crop-detection-complete log in `RunDetectCrop` (`workflows/steps/detectcrop.go`)
- Add `INFO` webhook-outcome logs in `NotifyWorkflowFailure` (`workflows/steps/onfailure.go`)
- Expand the worker startup `slog.Info` with `output_dir` and optional `hardware_device` attrs (`cmd/worker/main.go`)

## Test plan

- [x] `go test ./workflows/steps/...` passes (all existing step tests green)
- [x] All modified packages compile cleanly (`go build ./cmd/... ./workflows/...`)
- [x] Pre-existing `cockroachdb/errors` typecheck failure in lint/test is unrelated to this PR (confirmed by verifying it fails on `master` too)

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)