### PR TITLE
fix(ffmpeg): emit progress updates for copy streams

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -65,8 +65,17 @@ func (css *copyStreamState) setOutputStream(out *astiav.Stream) { css.outStream 
 func (css *copyStreamState) setupEncoder(_ HWAccel, _ *astiav.FormatContext) error { return nil }
 func (css *copyStreamState) encoderContext() *astiav.CodecContext                  { return nil }
 
-func (css *copyStreamState) processPacket(packet *astiav.Packet, outputFmt *astiav.FormatContext, _ chan<- Progress, _ int64) error {
-	return remuxPacket(packet, css.inStream, css.outStream, outputFmt)
+func (css *copyStreamState) processPacket(packet *astiav.Packet, outputFmt *astiav.FormatContext, progressCh chan<- Progress, totalDuration int64) error {
+	if err := remuxPacket(packet, css.inStream, css.outStream, outputFmt); err != nil {
+		return err
+	}
+
+	css.frames++
+	if progressCh != nil {
+		sendProgress(progressCh, css.frames, packet, css.outStream, totalDuration)
+	}
+
+	return nil
 }
 
 func (css *copyStreamState) flush(_ *astiav.FormatContext, _ chan<- Progress, _ int64) error {

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -402,10 +402,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 					}
 				case <-done:
 					if transcodeSucceeded {
-						if !hasUpdate {
-							latest.PercentComplete = 100
-						}
-
+						latest.PercentComplete = 100
 						logProgress()
 					}
 


### PR DESCRIPTION
## Summary

- `copyStreamState.processPacket` discarded `progressCh` and `totalDuration`, so remux-only jobs (e.g. H.264/H.265 already in MKV) produced no progress log lines at all during the transcode.
- Also unconditionally forces `PercentComplete` to 100 on the final completion log line, so any successful transcode always reports 100% — not just ones that happened to never receive a progress update.

## Changes

- `pkg/ffmpeg/stream.go`: name the previously-ignored `progressCh`/`totalDuration` params in `copyStreamState.processPacket`, increment `css.frames`, and call `sendProgress` after each successful `remuxPacket`.
- `workflows/steps/transcode.go`: remove the `!hasUpdate` guard on the final log — always set 100% when `transcodeSucceeded`.

## Test plan

- [x] `make test` passes (all existing progress-logging tests green, including `TestRunTranscode_ProgressLogging_CopyPathReports100Percent`)
- [x] No new tests modified; pre-existing test for this exact behavior already exercised the fix

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)