### PR TITLE
feat(watcher,workflows): write sentinel file for preserved sources

### DIFF
--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
@@ -241,7 +242,20 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				return nil
 			}
 
+			// Skip sentinel files (hidden .BASENAME.done markers).
+			base := filepath.Base(path)
+			if strings.HasPrefix(base, ".") && strings.HasSuffix(base, ".done") {
+				return nil
+			}
+
+			// Skip files whose processing sentinel already exists on disk.
+			sentinelPath := filepath.Join(filepath.Dir(path), "."+base+".done")
+			if _, statErr := os.Stat(sentinelPath); statErr == nil {
+				return nil
+			}
+
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)
+
 			filesDiscovered++
 
 			if dispatchErr := dispatch(ctx, path, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories); dispatchErr != nil {
@@ -250,7 +264,9 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				instruments.dispatchErrorsTotal.Add(ctx, 1, fileOpt)
 			} else {
 				instruments.dispatchesTotal.Add(ctx, 1, fileOpt)
+
 				jobsSubmitted++
+
 				slog.InfoContext(ctx, "dispatched workflow", slog.String("file", path), slog.String("watch", w.Name))
 			}
 

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -252,6 +252,10 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 			sentinelPath := filepath.Join(filepath.Dir(path), "."+base+".done")
 			if _, statErr := os.Stat(sentinelPath); statErr == nil {
 				return nil
+			} else if !os.IsNotExist(statErr) {
+				mappingErrs = append(mappingErrs, fmt.Errorf("scan sentinel %q for %q: %w", sentinelPath, path, statErr))
+
+				return nil
 			}
 
 			instruments.filesDiscoveredTotal.Add(ctx, 1, fileOpt)

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -773,3 +773,54 @@ func TestScan_RetainEmptyDirsForwardedToDispatch(t *testing.T) {
 		})
 	}
 }
+
+// TestScan_SkipsSentinelledFile verifies that a file is not dispatched when its
+// corresponding sentinel (.BASENAME.done) already exists in the same directory.
+func TestScan_SkipsSentinelledFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "movie.mkv"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".movie.mkv.done"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	var dispatched []string
+
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		dispatched = append(dispatched, fp)
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
+	assert.Empty(t, dispatched, "file with sentinel should not be dispatched")
+}
+
+// TestScan_SkipsSentinelFileItself verifies that a hidden .BASENAME.done sentinel file
+// is not dispatched as a media file even when no ignore patterns are configured.
+func TestScan_SkipsSentinelFileItself(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".movie.mkv.done"), []byte{}, 0o600))
+
+	cfg := &Config{
+		Watches: []WatchEntry{
+			{Name: "movies", Path: dir, MediaType: medialib.MovieType},
+		},
+	}
+
+	var dispatched []string
+
+	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool) error {
+		dispatched = append(dispatched, fp)
+		return nil
+	}
+
+	require.NoError(t, scan(t.Context(), cfg, noopInstruments(t), dispatch))
+	assert.Empty(t, dispatched, "sentinel file itself should not be dispatched")
+}

--- a/e2e/fixtures/watcher.yaml
+++ b/e2e/fixtures/watcher.yaml
@@ -9,3 +9,9 @@ watches:
     mediaType: show
     ignorePatterns:
       - \.tmp$
+  - name: preserve-source
+    path: /tmp/e2e-media-processor/downloads/preserve-source
+    mediaType: movie
+    preserveSource: true
+    ignorePatterns:
+      - \.tmp$

--- a/e2e/preserve_source_test.go
+++ b/e2e/preserve_source_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPreserveSourceSentinel verifies the sentinel-file mechanism for the
+// preserve-source watch mapping. It writes a plain-text file (not valid media),
+// waits for the probe step to reject it and the record_invalid step to write the
+// sentinel, then confirms the watcher does not dispatch it a second time.
+func TestPreserveSourceSentinel(t *testing.T) {
+	srcFile := filepath.Join(downloadsDir, "preserve-source", "not-a-video.txt")
+	sentinelFile := filepath.Join(downloadsDir, "preserve-source", ".not-a-video.txt.done")
+
+	require.NoError(t, os.WriteFile(srcFile, []byte("not media"), 0o644), "write dummy source file")
+
+	// Wait for the worker to process the file (probe rejects it, record_invalid
+	// writes the sentinel).
+	sentinelCtx, sentinelCancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer sentinelCancel()
+
+	err := pollUntil(sentinelCtx, 10*time.Second, func() error {
+		_, statErr := os.Stat(sentinelFile)
+		return statErr
+	})
+	require.NoError(t, err, "sentinel file was not created within the timeout")
+
+	// Capture the current dispatch and scan counts for this mapping.
+	filter := map[string]string{"mapping_name": "preserve-source"}
+	dispatchCount := fetchMetrics(t, watcherMetricsAddr).sum("watcher_dispatches_total", filter)
+	scanCount := fetchMetrics(t, watcherMetricsAddr).sum("watcher_scans_total", filter)
+
+	// Wait for at least one more complete scan after the sentinel exists.
+	scanCtx, scanCancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer scanCancel()
+
+	err = pollUntil(scanCtx, 5*time.Second, func() error {
+		current := fetchMetrics(t, watcherMetricsAddr).sum("watcher_scans_total", filter)
+		if current > scanCount {
+			return nil
+		}
+
+		return fmt.Errorf("scan count not yet advanced (current=%.0f, baseline=%.0f)", current, scanCount)
+	})
+	require.NoError(t, err, "watcher did not complete a follow-up scan within the timeout")
+
+	// Dispatch count must not have increased — the sentinel prevented re-dispatch.
+	newDispatchCount := fetchMetrics(t, watcherMetricsAddr).sum("watcher_dispatches_total", filter)
+	assert.Equal(t, dispatchCount, newDispatchCount, "watcher should not re-dispatch a file whose sentinel exists")
+}

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -22,6 +22,7 @@ func resetDirs() error {
 	for _, dir := range []string{
 		filepath.Join(downloadsDir, "radarr"),
 		filepath.Join(downloadsDir, "sonarr"),
+		filepath.Join(downloadsDir, "preserve-source"),
 		filepath.Join(processedDir, "radarr"),
 		filepath.Join(processedDir, "radarr-library"),
 		filepath.Join(processedDir, "sonarr"),

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -153,10 +153,12 @@ func NewMediaWorkflow(
 	// StartedAt is set here (not inside RunProbe) so existing RunProbe tests are unaffected.
 	probeTask := wf.NewTask("probe", func(ctx hatchet.Context, input MediaInput) (steps.ProbeOutput, error) {
 		start := time.Now()
+
 		slog.InfoContext(ctx, "processing file", slog.String("file", input.FilePath))
 
 		out, err := steps.RunProbe(ctx, input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 		logStepResult(ctx, "probe", input.FilePath, start, err)
+
 		if err != nil {
 			return out, err
 		}
@@ -183,11 +185,13 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			wrappedErr := fmt.Errorf("get probe output: %w", err)
 			logStepResult(ctx, "detectcrop", input.FilePath, start, wrappedErr)
+
 			return steps.DetectCropOutput{}, wrappedErr
 		}
 
 		crop, err := steps.RunDetectCrop(ctx, input.FilePath, probe.VideoWidth, probe.VideoHeight, cfg.MinCropX, cfg.MinCropY)
 		logStepResult(ctx, "detectcrop", input.FilePath, start, err)
+
 		if err != nil {
 			return steps.DetectCropOutput{}, err
 		}
@@ -206,6 +210,7 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			wrappedErr := fmt.Errorf("get probe output: %w", err)
 			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+
 			return steps.TranscodeOutput{}, wrappedErr
 		}
 
@@ -213,6 +218,7 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(detectcropTask, &detectcrop); err != nil {
 			wrappedErr := fmt.Errorf("get detectcrop output: %w", err)
 			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+
 			return steps.TranscodeOutput{}, wrappedErr
 		}
 
@@ -220,6 +226,7 @@ func NewMediaWorkflow(
 		if err != nil {
 			wrappedErr := fmt.Errorf("get arr library for artwork: %w", err)
 			logStepResult(ctx, "transcode", input.FilePath, start, wrappedErr)
+
 			return steps.TranscodeOutput{}, wrappedErr
 		}
 
@@ -229,6 +236,7 @@ func NewMediaWorkflow(
 		}
 
 		logStepResult(ctx, "transcode", input.FilePath, start, err)
+
 		return out, err
 	}, hatchet.WithParents(probeTask, detectcropTask), skipIfInvalid, hatchet.WithExecutionTimeout(cfg.TranscodeTimeout))
 
@@ -244,6 +252,7 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
 			wrappedErr := fmt.Errorf("get transcode output: %w", err)
 			logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
+
 			return struct{}{}, wrappedErr
 		}
 
@@ -263,25 +272,30 @@ func NewMediaWorkflow(
 		if err := library.ImportByFilePath(ctx, importPath); err != nil {
 			wrappedErr := fmt.Errorf("notify library: %w", err)
 			logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
+
 			return struct{}{}, wrappedErr
 		}
 
 		logStepResult(ctx, "notify", input.FilePath, start, nil)
+
 		return struct{}{}, nil
 	}, hatchet.WithParents(probeTask, transcodeTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
-	// cleanup: delete the original source file after successful processing, unless
-	// PreserveSource is set on the originating watch entry.
-	cleanupTask := wf.NewTask("cleanup", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
+	// finalize: write a sentinel or delete the source file after successful processing.
+	// When PreserveSource is true, writes a .BASENAME.done sentinel so the watcher
+	// skips the file on subsequent scans. When false, deletes the source file.
+	finalizeTask := wf.NewTask("finalize", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
 		start := time.Now()
 
+		var err error
 		if input.PreserveSource {
-			logStepResult(ctx, "cleanup", input.FilePath, start, nil)
-			return struct{}{}, nil
+			err = steps.WriteSentinel(input.FilePath)
+		} else {
+			err = steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
 		}
 
-		err := steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
-		logStepResult(ctx, "cleanup", input.FilePath, start, err)
+		logStepResult(ctx, "finalize", input.FilePath, start, err)
+
 		return struct{}{}, err
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
@@ -294,6 +308,7 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(probeTask, &probe); err != nil {
 			wrappedErr := fmt.Errorf("get probe output for metrics: %w", err)
 			logStepResult(ctx, "record_metrics", input.FilePath, start, wrappedErr)
+
 			return struct{}{}, wrappedErr
 		}
 
@@ -301,6 +316,7 @@ func NewMediaWorkflow(
 		if err := ctx.ParentOutput(transcodeTask, &transcode); err != nil {
 			wrappedErr := fmt.Errorf("get transcode output for metrics: %w", err)
 			logStepResult(ctx, "record_metrics", input.FilePath, start, wrappedErr)
+
 			return struct{}{}, wrappedErr
 		}
 
@@ -326,16 +342,28 @@ func NewMediaWorkflow(
 		recorder.RecordRun(ctx, input, probe, transcode, mediaInfo, hardwareAccelerated, totalElapsed)
 
 		logStepResult(ctx, "record_metrics", input.FilePath, start, nil)
-		return struct{}{}, nil
-	}, hatchet.WithParents(probeTask, transcodeTask, notifyTask, cleanupTask), skipIfInvalid)
 
-	// record_invalid: increment the invalid-files counter when probe determines the file
-	// is not valid media. Skipped when the file is valid (i.e. the inverse of skipIfInvalid).
+		return struct{}{}, nil
+	}, hatchet.WithParents(probeTask, transcodeTask, notifyTask, finalizeTask), skipIfInvalid)
+
+	// record_invalid: increment the invalid-files counter and then write a sentinel or
+	// delete the source file when probe determines the file is not valid media.
+	// Skipped when the file is valid (i.e. the inverse of skipIfInvalid).
 	_ = wf.NewTask("record_invalid", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
 		start := time.Now()
+
 		recorder.RecordInvalidFile(ctx, input.MediaType, input.MappingName)
-		logStepResult(ctx, "record_invalid", input.FilePath, start, nil)
-		return struct{}{}, nil
+
+		var err error
+		if input.PreserveSource {
+			err = steps.WriteSentinel(input.FilePath)
+		} else {
+			err = steps.RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+		}
+
+		logStepResult(ctx, "record_invalid", input.FilePath, start, err)
+
+		return struct{}{}, err
 	}, hatchet.WithParents(probeTask),
 		hatchet.WithSkipIf(hatchet.ParentCondition(probeTask, "output.is_valid_media == true")))
 
@@ -344,6 +372,7 @@ func NewMediaWorkflow(
 		start := time.Now()
 		err := steps.NotifyWorkflowFailure(ctx, ctx.StepRunErrors(), MediaWorkflowName, input.FilePath, webhookClient)
 		logStepResult(ctx, "onfailure", input.FilePath, start, err)
+
 		return struct{}{}, err
 	})
 
@@ -355,6 +384,7 @@ func logStepResult(ctx context.Context, stepName, filePath string, start time.Ti
 		slog.ErrorContext(ctx, "step failed", slog.String("step", stepName), slog.String("file", filePath), slog.Any("error", err))
 		return
 	}
+
 	slog.InfoContext(ctx, "step complete", slog.String("step", stepName), slog.String("file", filePath), slog.Duration("elapsed", time.Since(start)))
 }
 

--- a/workflows/media/media.go
+++ b/workflows/media/media.go
@@ -300,7 +300,7 @@ func NewMediaWorkflow(
 	}, hatchet.WithParents(probeTask, notifyTask), skipIfInvalid, hatchet.WithRetries(defaultTaskRetries))
 
 	// record_metrics: record per-run OTel observations for valid-media completions.
-	// Runs after cleanup so total_duration_seconds covers the full probe→cleanup span.
+	// Runs after finalize so total_duration_seconds covers the full probe→finalize span.
 	_ = wf.NewTask("record_metrics", func(ctx hatchet.Context, input MediaInput) (struct{}, error) {
 		start := time.Now()
 

--- a/workflows/steps/cleanup.go
+++ b/workflows/steps/cleanup.go
@@ -9,6 +9,19 @@ import (
 	"path/filepath"
 )
 
+// WriteSentinel creates a zero-byte hidden sentinel file alongside filePath to
+// mark it as processed, preventing the watcher from re-dispatching it.
+// The sentinel path is .BASENAME.done in the same directory (e.g. /dl/movie.mkv
+// → /dl/.movie.mkv.done). The write is idempotent.
+func WriteSentinel(filePath string) error {
+	sentinelPath := filepath.Join(filepath.Dir(filePath), "."+filepath.Base(filePath)+".done")
+	if err := os.WriteFile(sentinelPath, nil, 0o644); err != nil {
+		return fmt.Errorf("write sentinel: %w", err)
+	}
+
+	return nil
+}
+
 // RunCleanup deletes the original source file after successful processing and,
 // unless retainEmptyDirs is true, removes any parent directories that become
 // empty as a result, stopping at watchRoot.

--- a/workflows/steps/cleanup_test.go
+++ b/workflows/steps/cleanup_test.go
@@ -9,6 +9,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWriteSentinel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fileName     string
+		wantSentinel string
+	}{
+		{
+			name:         "standard file name",
+			fileName:     "movie.mkv",
+			wantSentinel: ".movie.mkv.done",
+		},
+		{
+			name:         "file without extension",
+			fileName:     "movie",
+			wantSentinel: ".movie.done",
+		},
+		{
+			name:         "file with multiple dots",
+			fileName:     "movie.2024.mkv",
+			wantSentinel: ".movie.2024.mkv.done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			filePath := filepath.Join(dir, tt.fileName)
+			expectedSentinel := filepath.Join(dir, tt.wantSentinel)
+
+			require.NoError(t, WriteSentinel(filePath))
+
+			_, statErr := os.Stat(expectedSentinel)
+			assert.NoError(t, statErr, "sentinel file should exist at %s", expectedSentinel)
+		})
+	}
+}
+
+func TestWriteSentinel_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "movie.mkv")
+
+	require.NoError(t, WriteSentinel(filePath))
+	require.NoError(t, WriteSentinel(filePath), "second call should not error")
+
+	_, statErr := os.Stat(filepath.Join(dir, ".movie.mkv.done"))
+	assert.NoError(t, statErr, "sentinel should still exist after second write")
+}
+
 func TestRunCleanup(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/workflows/steps/detectcrop.go
+++ b/workflows/steps/detectcrop.go
@@ -47,6 +47,7 @@ func RunDetectCrop(ctx context.Context, filePath string, inputW, inputH, minCrop
 	if result == nil {
 		logAttrs = append(logAttrs, slog.String("skip_reason", "below pixel threshold"))
 	}
+
 	slog.DebugContext(ctx, "crop detection complete", logAttrs...)
 
 	return result, nil

--- a/workflows/steps/transcode.go
+++ b/workflows/steps/transcode.go
@@ -403,6 +403,7 @@ func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropP
 				case <-done:
 					if transcodeSucceeded {
 						latest.PercentComplete = 100
+
 						logProgress()
 					}
 

--- a/workflows/steps/transcode_test.go
+++ b/workflows/steps/transcode_test.go
@@ -731,6 +731,7 @@ func withRecordingLogger(t *testing.T) *recordingHandler {
 
 	handler := &recordingHandler{}
 	orig := slog.Default()
+
 	slog.SetDefault(slog.New(handler))
 	t.Cleanup(func() { slog.SetDefault(orig) })
 


### PR DESCRIPTION
## Summary

- Adds `WriteSentinel` helper to `workflows/steps/cleanup.go` that creates a zero-byte hidden `.BASENAME.done` file alongside the source file.
- Renames the `cleanup` workflow step to `finalize`: writes the sentinel when `preserveSource: true`, or deletes the source file when `false` (unchanged behavior).
- Updates `record_invalid` to write the sentinel (or delete the file) when probe rejects a file as not valid media, depending on `preserveSource`.
- Adds two skip conditions to the watcher's `WalkDir` callback: skip sentinel files themselves, and skip files whose sentinel already exists.
- Adds E2E fixture and test (`TestPreserveSourceSentinel`) covering the invalid-media sentinel path, re-dispatch prevention, and sentinel self-skip.
- Fixes pre-existing `wsl_v5` lint failures in the edited files.

## Test plan

- [x] `make build` passes
- [x] `make lint` passes (fixed pre-existing `wsl_v5` issues in touched files)
- [x] `make test` passes (unit tests for `WriteSentinel` added to `cleanup_test.go`)
- [x] `make test-e2e` — requires Docker; `TestPreserveSourceSentinel` covers AC2, AC3, AC4

**Note on E2E**: the Docker daemon is unavailable in this environment (iptables not available in nested container). The E2E suite must be run manually or in CI.

Fixes #118