### PR TITLE
test(e2e): update fixtures for per-watch-entry output config

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -129,16 +129,10 @@ services:
       HATCHET_CLIENT_HOST_PORT: hatchet-engine:7070
       METRICS_ADDR: ":9090"
       HEALTH_ADDR: ":9091"
-      MEDIA_OUTPUT_DIR: /tmp/e2e-media-processor/processed-output
-      MEDIA_INPUT_ROOT: /tmp/e2e-media-processor/downloads
       RADARR_URL: http://radarr:7878
       RADARR_API_KEY: e2e-radarr-api-key-e2e
       SONARR_URL: http://sonarr:8989
       SONARR_API_KEY: e2e-sonarr-api-key-e2e
-      RADARR_LOCAL_PATH_PREFIX: /tmp/e2e-media-processor/downloads/radarr
-      RADARR_REMOTE_PATH_PREFIX: /downloads
-      SONARR_LOCAL_PATH_PREFIX: /tmp/e2e-media-processor/downloads/sonarr
-      SONARR_REMOTE_PATH_PREFIX: /downloads
       MEDIA_H265_CRF: "51"
     depends_on:
       hatchet-engine:


### PR DESCRIPTION
## Summary

- Removes `MEDIA_OUTPUT_DIR`, `MEDIA_INPUT_ROOT`, `RADARR_LOCAL_PATH_PREFIX`, `RADARR_REMOTE_PATH_PREFIX`, `SONARR_LOCAL_PATH_PREFIX`, and `SONARR_REMOTE_PATH_PREFIX` from the `worker` service in `e2e/docker-compose.yml`
- `e2e/fixtures/watcher.yaml` was already updated in commit `580fa14` (sub-issue #123) and required no further changes

## Test plan

- [x] `make test-e2e` — all E2E tests pass (`TestRadarrHappyPath`, `TestSonarrHappyPath`); exit code 0

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)