### PR TITLE
chore(dev): replace Hatchet dev compose stack with self-hosted Temporal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /bin/
 .claude/tasks/
-.env.hatchet
 .direnv
 e2e/testdata/cache/
 result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,12 @@ media-processor/
 - Vet: `make vet`
 - Lint: `make lint` (or `make lint-fix` to auto-apply fixes)
 - Unit tests: `make test`
-- Integration tests: `make test-integration` (starts a local Hatchet via `make hatchet-up` and runs `-tags=integration`)
+- Integration tests: `make test-integration` (starts a local Temporal via `make temporal-up` and runs `-tags=integration`)
 - E2E tests: `make test-e2e` (requires Docker; first run downloads ~700 MB BBB fixture)
 - Benchmarks: `make benchmark`
 - Generate watcher JSON schema: `make generate-schema` (writes `schemas/watcher.schema.json`)
-- Update Go modules + sync Hatchet image tags: `make update-dependencies`
-- Local Hatchet dev stack: `make hatchet-up` / `make hatchet-down` / `make hatchet-token`
+- Update Go modules and refresh vendor hashes in flake.nix: `make update-dependencies`
+- Local Temporal dev stack: `make temporal-up` / `make temporal-down`
 
 ## Dev Tools
 
@@ -85,7 +85,7 @@ All required tools (`go`, `golangci-lint`, etc.) are provided by `flake.nix`. If
 - For non-error fields in table tests, use the concrete expected type (e.g. `expected Config`) and assert with `assert.Equal`.
 - Do not reference acceptance criteria IDs (e.g. "AC3", "AC4") in test comments or names — they are only meaningful within the issue/PR context. Write descriptions of the actual behavior being verified instead.
 - Separate test cases that require fundamentally different setup into their own test functions.
-- Integration tests that require external services (e.g. a running Hatchet server) belong in files with a `//go:build integration` build tag. Skip with `t.Skip(...)` if required env vars are absent. Run via `make test-integration`.
+- Integration tests that require external services (e.g. a running Temporal server) belong in files with a `//go:build integration` build tag. Skip with `t.Skip(...)` if required env vars are absent. Run via `make test-integration`.
 - Always use `t.Context()` (not `context.Background()`) when a test needs a context. It is automatically cancelled when the test finishes, preventing resource leaks.
 - Loop iteration variable names must be the full singular form of the collection name. For example, use `service` when ranging over `services`, `entry` when ranging over `entries`, `category` when ranging over `categories`. Single-letter names (`s`, `v`, `f`, `k`) and shortened names (`cat` for `category`, `svc` for `service`) are not allowed unless the collection itself uses that short name (e.g. `cat` is fine when ranging over `cats`).
 

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,9 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: update-dependencies
-update-dependencies: ## Update Go module dependencies and sync Hatchet Docker image versions.
+update-dependencies: ## Update Go module dependencies and refresh vendor hashes in flake.nix.
 	go get -u ./...
 	go mod tidy
-	@HATCHET_VERSION=$$(go list -m github.com/hatchet-dev/hatchet | awk '{print $$2}'); \
-	sed -i "s|ghcr\.io/hatchet-dev/hatchet/\([^:]*\):v[0-9][0-9.]*|ghcr.io/hatchet-dev/hatchet/\1:$${HATCHET_VERSION}|g" \
-		docker-compose.yml \
-		e2e/docker-compose.yml
 	@update_vendor_hash() { \
 	    var=$${1}VendorHash fake="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; \
 	    sed -i "s|$$var[[:space:]]*=[[:space:]]*\"sha256-[^\"]*\"|$$var = \"$$fake\"|" flake.nix; \
@@ -71,8 +67,11 @@ test: fmt vet ## Run tests.
 	go test -race -count=1 $(TEST_TAG_FLAGS) ./...
 
 .PHONY: test-integration
-test-integration: hatchet-up ## Run integration tests against a local Hatchet server (starts server, generates token).
-	env $$(cat $(HATCHET_ENV_FILE)) go test -v -race -count=1 -tags=integration ./...
+test-integration: temporal-up ## Run integration tests against the local Temporal server (starts the server first).
+	TEMPORAL_ADDRESS=localhost:7233 \
+	TEMPORAL_NAMESPACE=default \
+	TEMPORAL_TASK_QUEUE=media-processor-test \
+	go test -v -race -count=1 -tags=integration ./...
 
 .PHONY: test-e2e
 test-e2e: build-images ## Run end-to-end tests (requires Docker; downloads ~700 MB BBB fixture on first run).
@@ -171,40 +170,11 @@ clean: ## Clean up all build artifacts and loaded container images.
 
 ##@ Local Dev
 
-HATCHET_ENV_FILE := .env.hatchet
+.PHONY: temporal-up
+temporal-up: ## Start the local Temporal dev stack (server + Postgres + Web UI).
+	docker compose up -d --wait
+	@echo "Temporal is ready. gRPC: localhost:7233  Web UI: http://localhost:8080  Namespace: default"
 
-.PHONY: hatchet-up
-hatchet-up: ## Start Hatchet local dev server and generate API token (written to .env.hatchet).
-	docker compose up -d
-	@echo "Waiting for Hatchet setup-config to complete..."
-	@docker wait media-processor-setup-config-1
-	@if [ ! -f $(HATCHET_ENV_FILE) ]; then $(MAKE) hatchet-token; fi
-	@echo "Hatchet is ready. Dashboard: http://localhost:8080 (admin@example.com / Admin123!!)"
-	@echo "Run 'source $(HATCHET_ENV_FILE)' to load HATCHET_CLIENT_TOKEN into your current shell."
-
-.PHONY: hatchet-down
-hatchet-down: ## Stop Hatchet local dev server.
-	docker compose down
-
-.PHONY: hatchet-token
-hatchet-token: ## Generate a new Hatchet API token and write it to .env.hatchet.
-	@echo "Generating Hatchet API token..."
-	@TENANT_ID=$$(docker compose exec -T postgres \
-		psql -U hatchet -d hatchet -t -c \
-		"SELECT id FROM \"Tenant\" WHERE slug = 'default' LIMIT 1" \
-		2>/dev/null | tr -d ' \n'); \
-	if [ -z "$$TENANT_ID" ]; then \
-		echo "Error: could not query tenant ID — is Hatchet running? Try: make hatchet-up" >&2; \
-		exit 1; \
-	fi; \
-	TOKEN=$$(docker compose run --no-deps --rm -T setup-config \
-		/hatchet/hatchet-admin token create \
-		--config /hatchet/config \
-		--tenant-id "$$TENANT_ID" \
-		2>/dev/null | tr -d '\r\n'); \
-	if [ -z "$$TOKEN" ]; then \
-		echo "Error: token generation failed" >&2; \
-		exit 1; \
-	fi; \
-	printf 'HATCHET_CLIENT_TOKEN=%s\nHATCHET_CLIENT_TLS_STRATEGY=none\n' "$$TOKEN" > $(HATCHET_ENV_FILE); \
-	echo "Token written to $(HATCHET_ENV_FILE)"
+.PHONY: temporal-down
+temporal-down: ## Stop the local Temporal dev stack and remove volumes/networks.
+	docker compose down -v --remove-orphans

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -129,25 +129,34 @@ func workflowID(absFilePath string) string {
 }
 
 // newTemporalDispatch returns a dispatchFunc that calls ExecuteWorkflow on the given
-// Temporal client with a deterministic WorkflowID and AllowDuplicate reuse policy.
+// Temporal client with a deterministic WorkflowID, AllowDuplicate reuse policy, and
+// Fail conflict policy.
 //
-// AllowDuplicate is the right fit for the watcher's three reuse scenarios:
-//   - A currently-running workflow with the same ID is rejected by Temporal regardless
-//     of policy, giving free multi-watcher dedup.
+// The reuse policy controls behaviour when the previous run for this WorkflowID has
+// already closed; AllowDuplicate is the right fit for the watcher's two re-run
+// scenarios:
 //   - A previously failed workflow can be retried on the next tick.
 //   - A previously completed workflow can run again when an operator removes both the
 //     source file and its sentinel and re-adds the file (the parent issue #131's
 //     stated equivalent of today's `WithRunKey` semantics).
 //
-// When Temporal returns WorkflowExecutionAlreadyStarted (the running-duplicate case),
-// the dispatch returns errWorkflowAlreadyStarted so the scan loop can suppress both
-// the dispatch and dispatch-error counters for that file.
+// The conflict policy controls behaviour when a run for this WorkflowID is currently
+// in progress. Fail makes Temporal reject the duplicate, and
+// WorkflowExecutionErrorWhenAlreadyStarted opts the Go SDK out of its default
+// "swallow the error and attach to the existing run" behaviour so the rejection
+// propagates as serviceerror.WorkflowExecutionAlreadyStarted. Without both, every
+// duplicate dispatch from a peer watcher would silently be counted as a fresh
+// dispatch, over-counting dispatchesTotal under multi-watcher conditions. When the
+// conflict fires, the dispatch returns errWorkflowAlreadyStarted so the scan loop
+// can suppress both the dispatch and dispatch-error counters for that file.
 func newTemporalDispatch(c client.Client, taskQueue string) dispatchFunc {
 	return func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool, outputPath string, outputRemotePath string) error {
 		options := client.StartWorkflowOptions{
-			ID:                    workflowID(filePath),
-			TaskQueue:             taskQueue,
-			WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			ID:                                       workflowID(filePath),
+			TaskQueue:                                taskQueue,
+			WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIDConflictPolicy:                 enums.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+			WorkflowExecutionErrorWhenAlreadyStarted: true,
 		}
 
 		input := mediatypes.MediaInput{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,101 +1,58 @@
 services:
   postgres:
-    image: postgres:18
-    command: postgres -c 'max_connections=1000'
+    image: postgres:16
     restart: always
-    hostname: postgres
     environment:
-      POSTGRES_USER: hatchet
-      POSTGRES_PASSWORD: hatchet
-      POSTGRES_DB: hatchet
+      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: temporal
+      POSTGRES_DB: temporal
     ports:
       - "5435:5432"
     volumes:
-      - hatchet_postgres_data:/var/lib/postgresql
+      - temporal_postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
-      interval: 10s
-      timeout: 10s
-      retries: 5
-      start_period: 10s
+      test: ["CMD-SHELL", "pg_isready -d temporal -U temporal"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
-  migration:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:v0.83.37
-    command: /hatchet/hatchet-migrate
+  temporal:
+    # auto-setup boots schema migrations and creates the `default` namespace
+    # on first start, so no separate migration/admin step is needed.
+    image: temporalio/auto-setup:1.27.2
+    restart: on-failure
     environment:
-      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
+      DB: postgres12
+      DB_PORT: 5432
+      POSTGRES_USER: temporal
+      POSTGRES_PWD: temporal
+      POSTGRES_SEEDS: postgres
+      BIND_ON_IP: 0.0.0.0
+    ports:
+      - "7233:7233"
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "tctl", "--address", "temporal:7233", "cluster", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
 
-  setup-config:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:v0.83.37
-    command: >
-      /hatchet/hatchet-admin quickstart
-      --skip certs
-      --generated-config-dir /hatchet/config
-      --overwrite=false
+  temporal-ui:
+    image: temporalio/ui:2.36.0
+    restart: on-failure
     environment:
-      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
-      SERVER_MSGQUEUE_KIND: postgres
-      SERVER_AUTH_COOKIE_DOMAIN: "localhost:8080"
-      SERVER_AUTH_COOKIE_INSECURE: "t"
-      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
-      SERVER_GRPC_INSECURE: "t"
-      SERVER_GRPC_BROADCAST_ADDRESS: "localhost:7077"
-      SERVER_DEFAULT_ENGINE_VERSION: "V1"
-      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: "hatchet-engine:7070"
-    volumes:
-      - hatchet_certs:/hatchet/certs
-      - hatchet_config:/hatchet/config
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_CORS_ORIGINS: http://localhost:8080
+      TEMPORAL_DEFAULT_NAMESPACE: default
+    ports:
+      - "8080:8080"
     depends_on:
-      migration:
-        condition: service_completed_successfully
-      postgres:
+      temporal:
         condition: service_healthy
-
-  hatchet-engine:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:v0.83.37
-    command: /hatchet/hatchet-engine --config /hatchet/config
-    restart: on-failure
-    ports:
-      - "7077:7070"
-    environment:
-      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
-      SERVER_MSGQUEUE_KIND: postgres
-      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
-      SERVER_GRPC_INSECURE: "t"
-    volumes:
-      - hatchet_certs:/hatchet/certs
-      - hatchet_config:/hatchet/config
-    depends_on:
-      setup-config:
-        condition: service_completed_successfully
-      migration:
-        condition: service_completed_successfully
-
-  hatchet-dashboard:
-    # Default admin credentials (created by setup-config quickstart):
-    #   URL:      http://localhost:8080
-    #   Email:    admin@example.com
-    #   Password: Admin123!!
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:v0.83.37
-    command: sh ./entrypoint.sh --config /hatchet/config
-    restart: on-failure
-    ports:
-      - "8080:80"
-    environment:
-      DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
-    volumes:
-      - hatchet_certs:/hatchet/certs
-      - hatchet_config:/hatchet/config
-    depends_on:
-      setup-config:
-        condition: service_completed_successfully
-      migration:
-        condition: service_completed_successfully
 
 volumes:
-  hatchet_postgres_data:
-  hatchet_config:
-  hatchet_certs:
+  temporal_postgres_data:

--- a/flake.nix
+++ b/flake.nix
@@ -218,11 +218,6 @@
           # and MFXCreateSession fails with MFX_ERR_DEVICE_FAILED (-9).
           ONEVPL_SEARCH_PATH = "${pkgs.vpl-gpu-rt}/lib";
           shellHook = ''
-            if [ -f .env.hatchet ]; then
-              # shellcheck disable=SC1091
-              source .env.hatchet
-            fi
-
             # Start Docker daemon if not already running
             DOCKER_SOCK="/tmp/docker.sock"
             export DOCKER_HOST="unix://$DOCKER_SOCK"


### PR DESCRIPTION
Fixes #134.

## Summary

- Replace the Hatchet docker-compose stack with self-hosted Temporal: `postgres` + `temporalio/auto-setup:1.27.2` + `temporalio/ui:2.36.0`. UI on `http://localhost:8080`, gRPC on `localhost:7233`, namespace `default`.
- Replace `make hatchet-up` / `hatchet-down` / `hatchet-token` with `make temporal-up` / `temporal-down`. No token bootstrap needed for self-hosted single-namespace dev. `temporal-up` blocks on healthchecks via `docker compose up -d --wait`; `temporal-down` runs `docker compose down -v --remove-orphans` so volumes/networks are removed cleanly.
- Update `make test-integration` to depend on `temporal-up` and export `TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=default TEMPORAL_TASK_QUEUE=media-processor-test` inline.
- Drop the Hatchet image-tag `sed` from `update-dependencies`, the `.env.hatchet` source from `flake.nix` `shellHook`, and the `.env.hatchet` entry from `.gitignore`. Delete the stale `.env.hatchet` file.

A pre-existing watcher dedup bug surfaced when running `make test-integration` end-to-end against the new stack for the first time. Fixed in a separate commit on this branch — `newTemporalDispatch` now sets `WorkflowIDConflictPolicy=FAIL` (so Temporal 1.24+ surfaces the conflict) and `WorkflowExecutionErrorWhenAlreadyStarted=true` (so the Go SDK propagates it instead of silently attaching to the existing run). Without it, `dispatchesTotal` over-counted under multi-watcher conditions; functional dedup was already preserved.

Out of scope per parent issue #131's Non-Goals: e2e suite stack, Helm chart, broader docs sweep — all tracked in separate sub-issues.

## Test plan

- [x] `make temporal-up` brings up postgres + temporal + temporal-ui; all three become healthy.
- [x] `curl http://localhost:8080/api/v1/namespaces` returns the registered namespaces, including `default`.
- [x] `make test-integration` passes against the new stack with no `HATCHET_*` env vars and no Hatchet container.
- [x] `make temporal-down` followed by `docker ps -aq --filter name=media-processor`, `docker volume ls -q --filter name=temporal`, `docker network ls -q --filter name=media-processor` — all empty.
- [x] `grep -ri hatchet Makefile docker-compose.yml flake.nix .gitignore` — no matches.
- [x] `make test` (unit tests) passes.
- [x] `make fmt vet` clean.
- Note: `make lint` reports two pre-existing `wsl_v5` warnings in `pkg/ffmpeg/stream_video.go` on the branch base; not introduced by this PR.
