### PR TITLE
feat(helm): migrate chart from Hatchet to Temporal connection values

### DIFF
--- a/deploy/charts/media-processor/Chart.yaml
+++ b/deploy/charts/media-processor/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
 name: media-processor
-description: Helm chart for the media-processor watcher and worker (Temporal-based)
+description: Helm chart for the media-processor watcher and worker
 type: application
-version: 0.1.0-dev
+version: 0.0.1-dev
 appVersion: 0.0.1-dev
 dependencies:
   - name: common

--- a/deploy/charts/media-processor/Chart.yaml
+++ b/deploy/charts/media-processor/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
 name: media-processor
-description: Helm chart for the media-processor watcher and worker
+description: Helm chart for the media-processor watcher and worker (Temporal-based)
 type: application
-version: 0.0.1-dev
+version: 0.1.0-dev
 appVersion: 0.0.1-dev
 dependencies:
   - name: common

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -15,14 +15,24 @@
 {{- $_ := set (index $wkc "image") "tag" (tpl ((index $wkc "image" "tag") | default "" | toString) . | default .Chart.AppVersion) -}}
 
 {{/* ============================================================ */}}
-{{/* Credential secretKeyRef validation                           */}}
+{{/* Required Temporal connection values                           */}}
 {{/* ============================================================ */}}
-{{- $hatchetSecretName := .Values.config.hatchet.token.secretKeyRef.name | default "" -}}
-{{- $hatchetSecretKey  := .Values.config.hatchet.token.secretKeyRef.key  | default "" -}}
-{{- if or (and $hatchetSecretName (not $hatchetSecretKey)) (and $hatchetSecretKey (not $hatchetSecretName)) -}}
-  {{- fail "config.hatchet.token.secretKeyRef.name and config.hatchet.token.secretKeyRef.key must both be set when using secretKeyRef" -}}
+{{- $temporalAddress   := .Values.config.temporal.address   | default "" -}}
+{{- $temporalNamespace := .Values.config.temporal.namespace | default "" -}}
+{{- $temporalTaskQueue := .Values.config.temporal.taskQueue | default "" -}}
+{{- if not $temporalAddress -}}
+  {{- fail "config.temporal.address is required (host:port of the Temporal frontend)" -}}
+{{- end -}}
+{{- if not $temporalNamespace -}}
+  {{- fail "config.temporal.namespace is required" -}}
+{{- end -}}
+{{- if not $temporalTaskQueue -}}
+  {{- fail "config.temporal.taskQueue is required" -}}
 {{- end -}}
 
+{{/* ============================================================ */}}
+{{/* Credential secretKeyRef validation                           */}}
+{{/* ============================================================ */}}
 {{- $radarrSecretName := .Values.config.worker.radarr.apiKey.secretKeyRef.name | default "" -}}
 {{- $radarrSecretKey  := .Values.config.worker.radarr.apiKey.secretKeyRef.key  | default "" -}}
 {{- if or (and $radarrSecretName (not $radarrSecretKey)) (and $radarrSecretKey (not $radarrSecretName)) -}}
@@ -40,17 +50,10 @@
 {{/* ============================================================ */}}
 {{- $watcherEnv := dict -}}
 
-{{/* HATCHET_CLIENT_TOKEN */}}
-{{- if $hatchetSecretName -}}
-  {{- $_ := set $watcherEnv "HATCHET_CLIENT_TOKEN" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $hatchetSecretName "key" $hatchetSecretKey))) -}}
-{{- else if .Values.config.hatchet.token.value -}}
-  {{- $_ := set $watcherEnv "HATCHET_CLIENT_TOKEN" .Values.config.hatchet.token.value -}}
-{{- end -}}
-
-{{/* HATCHET_CLIENT_NAMESPACE */}}
-{{- if .Values.config.hatchet.namespace -}}
-  {{- $_ := set $watcherEnv "HATCHET_CLIENT_NAMESPACE" .Values.config.hatchet.namespace -}}
-{{- end -}}
+{{/* TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE / TEMPORAL_TASK_QUEUE */}}
+{{- $_ := set $watcherEnv "TEMPORAL_ADDRESS"    $temporalAddress   -}}
+{{- $_ := set $watcherEnv "TEMPORAL_NAMESPACE"  $temporalNamespace -}}
+{{- $_ := set $watcherEnv "TEMPORAL_TASK_QUEUE" $temporalTaskQueue -}}
 
 {{/* LOG_LEVEL */}}
 {{- $_ := set $watcherEnv "LOG_LEVEL" .Values.config.watcher.logLevel -}}
@@ -71,17 +74,10 @@
 {{/* ============================================================ */}}
 {{- $workerEnv := dict -}}
 
-{{/* HATCHET_CLIENT_TOKEN */}}
-{{- if $hatchetSecretName -}}
-  {{- $_ := set $workerEnv "HATCHET_CLIENT_TOKEN" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $hatchetSecretName "key" $hatchetSecretKey))) -}}
-{{- else if .Values.config.hatchet.token.value -}}
-  {{- $_ := set $workerEnv "HATCHET_CLIENT_TOKEN" .Values.config.hatchet.token.value -}}
-{{- end -}}
-
-{{/* HATCHET_CLIENT_NAMESPACE */}}
-{{- if .Values.config.hatchet.namespace -}}
-  {{- $_ := set $workerEnv "HATCHET_CLIENT_NAMESPACE" .Values.config.hatchet.namespace -}}
-{{- end -}}
+{{/* TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE / TEMPORAL_TASK_QUEUE */}}
+{{- $_ := set $workerEnv "TEMPORAL_ADDRESS"    $temporalAddress   -}}
+{{- $_ := set $workerEnv "TEMPORAL_NAMESPACE"  $temporalNamespace -}}
+{{- $_ := set $workerEnv "TEMPORAL_TASK_QUEUE" $temporalTaskQueue -}}
 
 {{/* LOG_LEVEL */}}
 {{- $_ := set $workerEnv "LOG_LEVEL" .Values.config.worker.logLevel -}}

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -258,7 +258,10 @@
   {{- end -}}
   {{- $cleanWatches = append $cleanWatches $entry -}}
 {{- end -}}
-{{- $watcherConfigContent := dict "cronSchedule" .Values.config.watcher.schedule "watches" $cleanWatches -}}
+{{- $watcherConfigContent := dict "watches" $cleanWatches -}}
+{{- if .Values.config.watcher.scanInterval -}}
+  {{- $_ := set $watcherConfigContent "scanInterval" .Values.config.watcher.scanInterval -}}
+{{- end -}}
 {{- $watcherConfigYaml := toYaml $watcherConfigContent -}}
 
 {{- $watcherConfigMount := dict "path" $configMountPath "readOnly" true -}}

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -15,7 +15,7 @@
 {{- $_ := set (index $wkc "image") "tag" (tpl ((index $wkc "image" "tag") | default "" | toString) . | default .Chart.AppVersion) -}}
 
 {{/* ============================================================ */}}
-{{/* Required Temporal connection values                           */}}
+{{/* Temporal connection values                                    */}}
 {{/* ============================================================ */}}
 {{- $temporalAddress   := .Values.config.temporal.address   | default "" -}}
 {{- $temporalNamespace := .Values.config.temporal.namespace | default "" -}}
@@ -24,10 +24,10 @@
   {{- fail "config.temporal.address is required (host:port of the Temporal frontend)" -}}
 {{- end -}}
 {{- if not $temporalNamespace -}}
-  {{- fail "config.temporal.namespace is required" -}}
+  {{- fail "config.temporal.namespace must not be empty (chart default is \"default\")" -}}
 {{- end -}}
 {{- if not $temporalTaskQueue -}}
-  {{- fail "config.temporal.taskQueue is required" -}}
+  {{- fail "config.temporal.taskQueue must not be empty (chart default is \"media-processor\")" -}}
 {{- end -}}
 
 {{/* ============================================================ */}}

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -1,17 +1,17 @@
 ---
 config:
-  # temporal selects the Temporal frontend the watcher and worker connect to. All three fields
-  # are required; helm template fails when any are empty.
+  # temporal selects the Temporal frontend the watcher and worker connect to. address is required
+  # and helm template fails when empty; namespace and taskQueue have sensible defaults.
   temporal:
     # address is the Temporal frontend host:port (no scheme). Sets TEMPORAL_ADDRESS on both
     # watcher and worker. Example: "temporal-frontend.temporal.svc.cluster.local:7233".
     address: ""
     # namespace is the Temporal namespace the workflows execute in. Sets TEMPORAL_NAMESPACE on
-    # both watcher and worker. Example: "default".
-    namespace: ""
+    # both watcher and worker. Defaults to Temporal's built-in "default" namespace.
+    namespace: "default"
     # taskQueue is the Temporal task queue the worker polls and the watcher dispatches to. Sets
-    # TEMPORAL_TASK_QUEUE on both watcher and worker. Example: "media-processor".
-    taskQueue: ""
+    # TEMPORAL_TASK_QUEUE on both watcher and worker.
+    taskQueue: "media-processor"
 
   # inputVolume is a bjw-s persistence item (type, existingClaim, etc.) without globalMounts or
   # advancedMounts; the chart manages mounts at /media/input. An optional chart-specific subPath

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -1,12 +1,17 @@
 ---
 config:
-  hatchet:
-    token:
-      value: ""
-      secretKeyRef:
-        name: ""
-        key: ""
+  # temporal selects the Temporal frontend the watcher and worker connect to. All three fields
+  # are required; helm template fails when any are empty.
+  temporal:
+    # address is the Temporal frontend host:port (no scheme). Sets TEMPORAL_ADDRESS on both
+    # watcher and worker. Example: "temporal-frontend.temporal.svc.cluster.local:7233".
+    address: ""
+    # namespace is the Temporal namespace the workflows execute in. Sets TEMPORAL_NAMESPACE on
+    # both watcher and worker. Example: "default".
     namespace: ""
+    # taskQueue is the Temporal task queue the worker polls and the watcher dispatches to. Sets
+    # TEMPORAL_TASK_QUEUE on both watcher and worker. Example: "media-processor".
+    taskQueue: ""
 
   # inputVolume is a bjw-s persistence item (type, existingClaim, etc.) without globalMounts or
   # advancedMounts; the chart manages mounts at /media/input. An optional chart-specific subPath

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -26,8 +26,10 @@ config:
   watcher:
     # configType controls whether the watcher YAML config file is stored as a ConfigMap or Secret.
     configType: ConfigMap
-    # schedule is the 6-field Hatchet cron expression (seconds-leading) for the watcher scan.
-    schedule: ""
+    # scanInterval is the duration between directory scans, as a Go duration string (e.g. "5s",
+    # "1m30s"). Defaults to "5s" when empty (the watcher binary applies the default). Written to
+    # scanInterval in the rendered watcher YAML config.
+    scanInterval: ""
     watches: []
     # volumes is a map of volume names to bjw-s persistence items (type, existingClaim, server/path,
     # etc.) without globalMounts or advancedMounts; the chart manages mounts. Keys become bjw-s

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -69,7 +69,7 @@ Shared observability settings applied to both watcher and worker.
 | Field                            | Type   | Default     | Description                                                                                                                                                                                                       |
 | -------------------------------- | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `config.watcher.configType`      | string | `ConfigMap` | Storage type for the watcher YAML config file. `ConfigMap` or `Secret`                                                                                                                                            |
-| `config.watcher.schedule`        | string | `""`        | 6-field Hatchet cron expression for the scan schedule (e.g. `*/30 * * * * *`). When empty, the watcher uses the built-in default (`*/5 * * * * *`, every 5 seconds). Written to `cronSchedule` in the config file |
+| `config.watcher.scanInterval`    | string | `""`        | Duration between directory scans, as a Go duration string (e.g. `5s`, `1m30s`). When empty, the watcher uses the built-in default of `5s`. Written to `scanInterval` in the rendered watcher YAML config        |
 | `config.watcher.volumes`         | map    | `{}`        | Map of volume names to bjw-s persistence items (see below). When empty, no output volumes are created                                                                                                             |
 | `config.watcher.watches`         | list   | `[]`        | List of watch entries. Written to `watches` in the config file (see below)                                                                                                                                        |
 | `config.watcher.logLevel`        | string | `info`      | Sets `LOG_LEVEL` on the watcher container                                                                                                                                                                         |
@@ -252,7 +252,7 @@ config:
     existingClaim: downloads-pvc
 
   watcher:
-    schedule: "*/30 * * * * *"
+    scanInterval: "30s"
     volumes:
       processed-output:
         type: nfs

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -12,9 +12,11 @@ helm install my-release oci://ghcr.io/soliddowant/charts/media-processor --versi
 
 ## Required values
 
-The chart has no required values at `helm template` time — the manifests render without error with all defaults. However, the pods will fail to start at runtime without the following values. You will need at a minimum:
+`helm template` fails when any of `config.temporal.address`, `config.temporal.namespace`, or `config.temporal.taskQueue` is empty. In addition, the pods will fail at runtime without the following values. You will need at a minimum:
 
-- `config.hatchet.token` — Hatchet API token
+- `config.temporal.address` — Temporal frontend host:port (e.g. `temporal-frontend.temporal.svc.cluster.local:7233`)
+- `config.temporal.namespace` — Temporal namespace (e.g. `default`)
+- `config.temporal.taskQueue` — Temporal task queue the worker polls and the watcher dispatches to (e.g. `media-processor`)
 - `config.watcher.watches` — at least one watch entry
 - `config.worker.radarr.url` + `config.worker.radarr.apiKey`
 - `config.worker.sonarr.url` + `config.worker.sonarr.apiKey`
@@ -23,15 +25,15 @@ The chart has no required values at `helm template` time — the manifests rende
 
 ## Values reference
 
-### `config.hatchet.token`
+### `config.temporal`
 
-The Hatchet API token for both watcher and worker. Sets `HATCHET_CLIENT_TOKEN` on both containers.
+Temporal frontend connection settings. All three fields are required; `helm template` fails when any are empty.
 
-| Field                                    | Type   | Default | Description                                                |
-| ---------------------------------------- | ------ | ------- | ---------------------------------------------------------- |
-| `config.hatchet.token.value`             | string | `""`    | Literal token value                                        |
-| `config.hatchet.token.secretKeyRef.name` | string | `""`    | Secret name (takes precedence over `value` when non-empty) |
-| `config.hatchet.token.secretKeyRef.key`  | string | `""`    | Key within the Secret                                      |
+| Field                       | Type   | Default | Description                                                                                                |
+| --------------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `config.temporal.address`   | string | `""`    | Temporal frontend host:port (no scheme). Sets `TEMPORAL_ADDRESS` on both watcher and worker                |
+| `config.temporal.namespace` | string | `""`    | Temporal namespace the workflows execute in. Sets `TEMPORAL_NAMESPACE` on both watcher and worker          |
+| `config.temporal.taskQueue` | string | `""`    | Task queue the worker polls and the watcher dispatches to. Sets `TEMPORAL_TASK_QUEUE` on both              |
 
 ### `config.inputVolume`
 
@@ -207,16 +209,10 @@ These values are intentionally not configurable in `values.yaml`:
 
 ## Using Secrets for credentials
 
-Instead of putting token values directly in `values.yaml`, reference a pre-existing Secret:
+Instead of putting API keys directly in `values.yaml`, reference a pre-existing Secret:
 
 ```yaml
 config:
-  hatchet:
-    token:
-      secretKeyRef:
-        name: media-processor-secrets
-        key: hatchet-token
-
   worker:
     radarr:
       apiKey:
@@ -234,7 +230,6 @@ Create the Secret before installing the chart:
 
 ```sh
 kubectl create secret generic media-processor-secrets \
-  --from-literal=hatchet-token=YOUR_TOKEN \
   --from-literal=radarr-api-key=YOUR_KEY \
   --from-literal=sonarr-api-key=YOUR_KEY
 ```
@@ -247,11 +242,10 @@ This example uses a PVC for input and NFS for output, configures arr path transl
 
 ```yaml
 config:
-  hatchet:
-    token:
-      secretKeyRef:
-        name: media-processor-secrets
-        key: hatchet-token
+  temporal:
+    address: "temporal-frontend.temporal.svc.cluster.local:7233"
+    namespace: "default"
+    taskQueue: "media-processor"
 
   inputVolume:
     type: persistentVolumeClaim

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -29,11 +29,11 @@ helm install my-release oci://ghcr.io/soliddowant/charts/media-processor --versi
 
 Temporal frontend connection settings. All three fields are required; `helm template` fails when any are empty.
 
-| Field                       | Type   | Default | Description                                                                                                |
-| --------------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------- |
-| `config.temporal.address`   | string | `""`    | Temporal frontend host:port (no scheme). Sets `TEMPORAL_ADDRESS` on both watcher and worker                |
-| `config.temporal.namespace` | string | `""`    | Temporal namespace the workflows execute in. Sets `TEMPORAL_NAMESPACE` on both watcher and worker          |
-| `config.temporal.taskQueue` | string | `""`    | Task queue the worker polls and the watcher dispatches to. Sets `TEMPORAL_TASK_QUEUE` on both              |
+| Field                       | Type   | Default | Description                                                                                       |
+| --------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------- |
+| `config.temporal.address`   | string | `""`    | Temporal frontend host:port (no scheme). Sets `TEMPORAL_ADDRESS` on both watcher and worker       |
+| `config.temporal.namespace` | string | `""`    | Temporal namespace the workflows execute in. Sets `TEMPORAL_NAMESPACE` on both watcher and worker |
+| `config.temporal.taskQueue` | string | `""`    | Task queue the worker polls and the watcher dispatches to. Sets `TEMPORAL_TASK_QUEUE` on both     |
 
 ### `config.inputVolume`
 
@@ -66,14 +66,14 @@ Shared observability settings applied to both watcher and worker.
 
 ### `config.watcher`
 
-| Field                            | Type   | Default     | Description                                                                                                                                                                                                       |
-| -------------------------------- | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config.watcher.configType`      | string | `ConfigMap` | Storage type for the watcher YAML config file. `ConfigMap` or `Secret`                                                                                                                                            |
-| `config.watcher.scanInterval`    | string | `""`        | Duration between directory scans, as a Go duration string (e.g. `5s`, `1m30s`). When empty, the watcher uses the built-in default of `5s`. Written to `scanInterval` in the rendered watcher YAML config        |
-| `config.watcher.volumes`         | map    | `{}`        | Map of volume names to bjw-s persistence items (see below). When empty, no output volumes are created                                                                                                             |
-| `config.watcher.watches`         | list   | `[]`        | List of watch entries. Written to `watches` in the config file (see below)                                                                                                                                        |
-| `config.watcher.logLevel`        | string | `info`      | Sets `LOG_LEVEL` on the watcher container                                                                                                                                                                         |
-| `config.watcher.metrics.enabled` | bool   | `false`     | When true, sets `METRICS_ADDR=:9090` on the watcher container                                                                                                                                                     |
+| Field                            | Type   | Default     | Description                                                                                                                                                                                              |
+| -------------------------------- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config.watcher.configType`      | string | `ConfigMap` | Storage type for the watcher YAML config file. `ConfigMap` or `Secret`                                                                                                                                   |
+| `config.watcher.scanInterval`    | string | `""`        | Duration between directory scans, as a Go duration string (e.g. `5s`, `1m30s`). When empty, the watcher uses the built-in default of `5s`. Written to `scanInterval` in the rendered watcher YAML config |
+| `config.watcher.volumes`         | map    | `{}`        | Map of volume names to bjw-s persistence items (see below). When empty, no output volumes are created                                                                                                    |
+| `config.watcher.watches`         | list   | `[]`        | List of watch entries. Written to `watches` in the config file (see below)                                                                                                                               |
+| `config.watcher.logLevel`        | string | `info`      | Sets `LOG_LEVEL` on the watcher container                                                                                                                                                                |
+| `config.watcher.metrics.enabled` | bool   | `false`     | When true, sets `METRICS_ADDR=:9090` on the watcher container                                                                                                                                            |
 
 The watcher YAML config file is stored as a `ConfigMap` (or `Secret` when `configType: Secret`) and mounted read-only at `/etc/media-processor/`. The watcher container receives `--config /etc/media-processor/watcher.yaml`.
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -12,11 +12,9 @@ helm install my-release oci://ghcr.io/soliddowant/charts/media-processor --versi
 
 ## Required values
 
-`helm template` fails when any of `config.temporal.address`, `config.temporal.namespace`, or `config.temporal.taskQueue` is empty. In addition, the pods will fail at runtime without the following values. You will need at a minimum:
+`config.temporal.address` is required at `helm template` time — the chart fails with a clear error when it (or any of `config.temporal.namespace` / `config.temporal.taskQueue`) is empty. `namespace` and `taskQueue` have built-in defaults, so only `address` typically needs to be supplied. In addition, the pods will fail at runtime without the following values. You will need at a minimum:
 
 - `config.temporal.address` — Temporal frontend host:port (e.g. `temporal-frontend.temporal.svc.cluster.local:7233`)
-- `config.temporal.namespace` — Temporal namespace (e.g. `default`)
-- `config.temporal.taskQueue` — Temporal task queue the worker polls and the watcher dispatches to (e.g. `media-processor`)
 - `config.watcher.watches` — at least one watch entry
 - `config.worker.radarr.url` + `config.worker.radarr.apiKey`
 - `config.worker.sonarr.url` + `config.worker.sonarr.apiKey`
@@ -27,13 +25,13 @@ helm install my-release oci://ghcr.io/soliddowant/charts/media-processor --versi
 
 ### `config.temporal`
 
-Temporal frontend connection settings. All three fields are required; `helm template` fails when any are empty.
+Temporal frontend connection settings. `address` is required; `namespace` and `taskQueue` have defaults but `helm template` still fails if they are explicitly set to an empty string.
 
-| Field                       | Type   | Default | Description                                                                                       |
-| --------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------- |
-| `config.temporal.address`   | string | `""`    | Temporal frontend host:port (no scheme). Sets `TEMPORAL_ADDRESS` on both watcher and worker       |
-| `config.temporal.namespace` | string | `""`    | Temporal namespace the workflows execute in. Sets `TEMPORAL_NAMESPACE` on both watcher and worker |
-| `config.temporal.taskQueue` | string | `""`    | Task queue the worker polls and the watcher dispatches to. Sets `TEMPORAL_TASK_QUEUE` on both     |
+| Field                       | Type   | Default             | Description                                                                                                      |
+| --------------------------- | ------ | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `config.temporal.address`   | string | `""`                | Temporal frontend host:port (no scheme). Sets `TEMPORAL_ADDRESS` on both watcher and worker                      |
+| `config.temporal.namespace` | string | `"default"`         | Temporal namespace the workflows execute in. Sets `TEMPORAL_NAMESPACE` on both watcher and worker                |
+| `config.temporal.taskQueue` | string | `"media-processor"` | Task queue the worker polls and the watcher dispatches to. Sets `TEMPORAL_TASK_QUEUE` on both watcher and worker |
 
 ### `config.inputVolume`
 


### PR DESCRIPTION
Fixes #135

## Summary

- Replace `config.hatchet.*` with `config.temporal.*` in `values.yaml` (`address`, `namespace`, `taskQueue`). `namespace` defaults to `"default"` and `taskQueue` defaults to `"media-processor"`; only `address` is required from operators.
- Rewrite `templates/common.yaml` to wire `TEMPORAL_ADDRESS` / `TEMPORAL_NAMESPACE` / `TEMPORAL_TASK_QUEUE` on both watcher and worker, drop all `HATCHET_*` env vars and the hatchet-token secretKeyRef validation, and `fail` with a clear message if `config.temporal.address` is empty (or if any of the defaulted Temporal values is explicitly overridden to empty).
- Rename the watcher scan-schedule value from `config.watcher.schedule` (rendered as `cronSchedule:`) to `config.watcher.scanInterval` (rendered as `scanInterval:`) to match the rewritten watcher binary, and only emit the key when set so the binary's 5s default applies otherwise.
- Update `docs/helm.md` to describe the new value paths, defaults, and the watcher `scanInterval` field.

## Acceptance criteria

- [x] AC1 – pod env contains only `TEMPORAL_*`, no `HATCHET_*`.
- [x] AC2 – `helm template` fails clearly when `config.temporal.address` is empty (or when any of the defaulted Temporal values is explicitly overridden to an empty string).
- [ ] AC3 – TLS / auth `secretKeyRef` wiring. Deferred to #142: the watcher and worker binaries do not yet read any TLS or auth env vars, so wiring them in the chart now would only produce dead pod env. The chart structure leaves room to add a `config.temporal.tls` block matching today&#39;s secretKeyRef pattern in that follow-up.
- [x] AC4 – the chart renders no `NetworkPolicy` resources today (operator NetworkPolicies are written from `docs/network-policies.md`); removing all `HATCHET_*` env wiring removes any chart-level requirement to allow Hatchet egress. Updating the operator-facing prose in `docs/network-policies.md` is owned by the documentation sweep sub-issue of #131.
- [x] AC5 – `helm lint` and `helm template` both succeed against a representative values file.

## Verification

- `helm lint deploy/charts/media-processor -f /tmp/values-happy.yaml` — passes (only the pre-existing &#34;icon is recommended&#34; info).
- `helm template test deploy/charts/media-processor -f /tmp/values-happy.yaml | grep -E &#39;TEMPORAL|HATCHET&#39;` — both watcher and worker deployments emit the three `TEMPORAL_*` env vars and zero `HATCHET_*` env vars.
- `helm template test deploy/charts/media-processor` (no values) — fails with `config.temporal.address is required (host:port of the Temporal frontend)`. Setting only `address` then renders successfully with `TEMPORAL_NAMESPACE=default` and `TEMPORAL_TASK_QUEUE=media-processor`. Setting `--set config.temporal.namespace=` after `address` is supplied fails with the chart pointing back at the default value.
- `helm template ... --set config.watcher.scanInterval=10s` writes `scanInterval: 10s` into the rendered watcher YAML; with no value set, the key is omitted so the watcher binary applies its built-in 5s default.

## Notes for reviewer

- `docs/network-policies.md`, `docs/configuration.md`, `docs/container-deployment.md`, `README.md`, and `SPEC.md` still mention Hatchet. Those are owned by the documentation sweep sub-issue of #131 and are explicitly not touched here.

## Test plan

- [x] `helm lint` against representative values
- [x] `helm template` happy path renders only `TEMPORAL_*` env vars on both deployments
- [x] `helm template` fails on missing `config.temporal.address` and on explicit empty overrides of the defaulted fields
- [x] `helm template` writes `scanInterval` into the watcher YAML only when set
