### PR TITLE
refactor(workflows): drop stepError wrapper and multi-step error map

### DIFF
--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -134,8 +134,8 @@ func workflowID(absFilePath string) string {
 // scenarios:
 //   - A previously failed workflow can be retried on the next tick.
 //   - A previously completed workflow can run again when an operator removes both the
-//     source file and its sentinel and re-adds the file (the parent issue #131's
-//     stated equivalent of today's `WithRunKey` semantics).
+//     source file and its sentinel and re-adds the file; AllowDuplicate lets Temporal
+//     start a fresh run under the same WorkflowID.
 //
 // The conflict policy controls behaviour when a run for this WorkflowID is currently
 // in progress. Fail makes Temporal reject the duplicate, and

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -308,17 +308,12 @@ func (a *Activities) Cleanup(ctx context.Context, input MediaInput) error {
 
 // NotifyFailure sends the configured failure webhook for a workflow that
 // returned an error. Invoked from the workflow's defer block on any non-nil
-// return; the failed step name and error message are sourced from the
-// stepError that the workflow body returned.
+// return; the failed step name comes from temporal.ActivityError.ActivityType()
+// and the message from the wrapped activity error.
 func (a *Activities) NotifyFailure(ctx context.Context, input MediaInput, failedStep, failureMsg string) error {
 	start := time.Now()
 
-	stepErrors := map[string]string{}
-	if failedStep != "" {
-		stepErrors[failedStep] = failureMsg
-	}
-
-	err := NotifyWorkflowFailure(ctx, stepErrors, MediaWorkflowName, input.FilePath, a.webhookClient)
+	err := NotifyWorkflowFailure(ctx, failedStep, failureMsg, MediaWorkflowName, input.FilePath, a.webhookClient)
 	logStepResult(ctx, "notify_failure", input.FilePath, start, err)
 
 	return err

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -109,7 +109,7 @@ func TestMediaWorkflow_TranscodeFailureFiresFailureWebhook(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.Error(t, env.GetWorkflowError(), "workflow should propagate the activity failure")
-	assert.Equal(t, "transcode", seenStep)
+	assert.Equal(t, TranscodeActivityName, seenStep)
 	assert.Contains(t, seenMessage, "ffmpeg blew up")
 	env.AssertExpectations(t)
 }
@@ -134,7 +134,7 @@ func TestMediaWorkflow_ProbeFailureFiresFailureWebhook(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.Error(t, env.GetWorkflowError())
-	assert.Equal(t, "probe", seenStep)
+	assert.Equal(t, ProbeActivityName, seenStep)
 }
 
 // TestMediaWorkflow_NotifyAndCleanupRetry verifies that the notify and cleanup
@@ -221,7 +221,7 @@ func TestMediaWorkflow_NonRetryableActivitiesFailOnFirstError(t *testing.T) {
 	}{
 		{
 			name:        "probe is invoked exactly once on failure (no retries)",
-			failingStep: "probe",
+			failingStep: ProbeActivityName,
 			setupMocks: func(env *testsuite.TestWorkflowEnvironment, attempts *int) {
 				env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 					Return(func(_ context.Context, _ MediaInput) (ProbeOutput, error) {
@@ -232,7 +232,7 @@ func TestMediaWorkflow_NonRetryableActivitiesFailOnFirstError(t *testing.T) {
 		},
 		{
 			name:        "detectcrop is invoked exactly once on failure (no retries)",
-			failingStep: "detectcrop",
+			failingStep: DetectCropActivityName,
 			setupMocks: func(env *testsuite.TestWorkflowEnvironment, attempts *int) {
 				env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 					Return(ProbeOutput{IsValidMedia: true, VideoWidth: 1920, VideoHeight: 1080}, nil).Once()
@@ -245,7 +245,7 @@ func TestMediaWorkflow_NonRetryableActivitiesFailOnFirstError(t *testing.T) {
 		},
 		{
 			name:        "transcode is invoked exactly once on failure (no retries)",
-			failingStep: "transcode",
+			failingStep: TranscodeActivityName,
 			setupMocks: func(env *testsuite.TestWorkflowEnvironment, attempts *int) {
 				env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 					Return(ProbeOutput{IsValidMedia: true, VideoWidth: 1920, VideoHeight: 1080}, nil).Once()

--- a/workflows/media/onfailure.go
+++ b/workflows/media/onfailure.go
@@ -2,35 +2,20 @@ package media
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
-	"strings"
 
 	"github.com/solidDoWant/media-processor/pkg/webhook"
 )
 
-// NotifyWorkflowFailure sends an aggregated failure notification to webhookClient.
-// stepErrors is the map returned by ctx.StepRunErrors() in an OnFailure handler.
+// NotifyWorkflowFailure sends a single-step failure notification to webhookClient.
+// step is the failing activity name; errMsg is the underlying error message.
 // workflowName is included in the webhook payload; filePath is the file being processed.
-// Returns nil (no-op) when stepErrors is empty.
-func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, workflowName, filePath string, webhookClient *webhook.Client) error {
-	if len(stepErrors) == 0 {
-		slog.InfoContext(ctx, "no step errors, skipping failure notification", slog.String("file", filePath))
+// Returns nil (no-op) when step is empty.
+func NotifyWorkflowFailure(ctx context.Context, step, errMsg, workflowName, filePath string, webhookClient *webhook.Client) error {
+	if step == "" {
+		slog.InfoContext(ctx, "no step error, skipping failure notification", slog.String("file", filePath))
 		return nil
-	}
-
-	steps := make([]string, 0, len(stepErrors))
-	for stepName := range stepErrors {
-		steps = append(steps, stepName)
-	}
-
-	sort.Strings(steps)
-
-	errs := make([]error, 0, len(stepErrors))
-	for _, stepName := range steps {
-		errs = append(errs, fmt.Errorf("%s: %s", stepName, stepErrors[stepName]))
 	}
 
 	if webhookClient.URL == "" {
@@ -41,8 +26,8 @@ func NotifyWorkflowFailure(ctx context.Context, stepErrors map[string]string, wo
 	if err := webhookClient.NotifyFailure(ctx, webhook.FailureEvent{
 		Workflow: workflowName,
 		FilePath: filePath,
-		Step:     strings.Join(steps, ", "),
-		Err:      errors.Join(errs...),
+		Step:     step,
+		Err:      fmt.Errorf("%s: %s", step, errMsg),
 	}); err != nil {
 		return fmt.Errorf("notify failure: %w", err)
 	}

--- a/workflows/media/onfailure_test.go
+++ b/workflows/media/onfailure_test.go
@@ -15,42 +15,27 @@ import (
 func TestNotifyWorkflowFailure(t *testing.T) {
 	tests := []struct {
 		name       string
-		stepErrors map[string]string
+		step       string
+		errMsg     string
 		wantCalled bool
 		wantStep   string
 		wantErrMsg string
 		errFunc    require.ErrorAssertionFunc
 	}{
 		{
-			name:       "empty step errors is a no-op",
-			stepErrors: map[string]string{},
-			wantCalled: false,
-			errFunc:    require.NoError,
-		},
-		{
-			name:       "nil step errors is a no-op",
-			stepErrors: nil,
+			name:       "empty step is a no-op",
+			step:       "",
+			errMsg:     "",
 			wantCalled: false,
 			errFunc:    require.NoError,
 		},
 		{
 			name:       "single step error sends correct payload",
-			stepErrors: map[string]string{"transcode": "ffmpeg exited with code 1"},
+			step:       "transcode",
+			errMsg:     "ffmpeg exited with code 1",
 			wantCalled: true,
 			wantStep:   "transcode",
 			wantErrMsg: "transcode: ffmpeg exited with code 1",
-			errFunc:    require.NoError,
-		},
-		{
-			name: "multiple step errors are sorted and joined deterministically",
-			stepErrors: map[string]string{
-				"lookup":    "not found",
-				"transcode": "disk full",
-				"cleanup":   "permission denied",
-			},
-			wantCalled: true,
-			wantStep:   "cleanup, lookup, transcode",
-			wantErrMsg: "cleanup: permission denied\nlookup: not found\ntranscode: disk full",
 			errFunc:    require.NoError,
 		},
 	}
@@ -70,7 +55,7 @@ func TestNotifyWorkflowFailure(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			client := &webhook.Client{URL: srv.URL}
-			err := NotifyWorkflowFailure(t.Context(), tt.stepErrors, "TestWorkflow", "/media/file.mkv", client)
+			err := NotifyWorkflowFailure(t.Context(), tt.step, tt.errMsg, "TestWorkflow", "/media/file.mkv", client)
 
 			tt.errFunc(t, err)
 			assert.Equal(t, tt.wantCalled, called, "webhook server call expectation")
@@ -92,7 +77,7 @@ func TestNotifyWorkflowFailure_WebhookErrorPropagates(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &webhook.Client{URL: srv.URL}
-	err := NotifyWorkflowFailure(t.Context(), map[string]string{"lookup": "not found"}, "TestWorkflow", "/media/file.mkv", client)
+	err := NotifyWorkflowFailure(t.Context(), "lookup", "not found", "TestWorkflow", "/media/file.mkv", client)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "notify failure")
 }

--- a/workflows/media/workflow.go
+++ b/workflows/media/workflow.go
@@ -7,20 +7,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-// stepError wraps an activity error with the step name where it originated.
-// The workflow's failure-webhook defer extracts the step + underlying error
-// via errors.As, removing the need for a mutable shared variable straddling
-// the workflow body and the defer. The wrapped form ("step: message") also
-// surfaces directly in the Temporal Web UI's workflow-failure pane.
-type stepError struct {
-	step string
-	err  error
-}
-
-func (e *stepError) Error() string { return e.step + ": " + e.err.Error() }
-
-func (e *stepError) Unwrap() error { return e.err }
-
 // MediaWorkflow processes one media file end-to-end. The body is straight-line
 // Go: probe, branch on validity, run the per-path activities. A defer block
 // invokes the failure-webhook activity when the workflow returns an error.
@@ -47,9 +33,9 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 
 		step, message := "unknown", err.Error()
 
-		var sErr *stepError
-		if errors.As(err, &sErr) {
-			step, message = sErr.step, sErr.err.Error()
+		var actErr *temporal.ActivityError
+		if errors.As(err, &actErr) {
+			step = actErr.ActivityType().Name
 		}
 
 		// The workflow's context is cancelled when the workflow returns an
@@ -76,7 +62,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 
 	var probe ProbeOutput
 	if err := workflow.ExecuteActivity(probeCtx, ProbeActivityName, input).Get(probeCtx, &probe); err != nil {
-		return &stepError{step: "probe", err: err}
+		return err
 	}
 
 	if !probe.IsValidMedia {
@@ -90,7 +76,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		})
 
 		if err := workflow.ExecuteActivity(invalidCleanupCtx, CleanupActivityName, input).Get(invalidCleanupCtx, nil); err != nil {
-			return &stepError{step: "cleanup", err: err}
+			return err
 		}
 
 		return nil
@@ -103,7 +89,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 
 	var crop DetectCropOutput
 	if err := workflow.ExecuteActivity(cropCtx, DetectCropActivityName, input, probe).Get(cropCtx, &crop); err != nil {
-		return &stepError{step: "detectcrop", err: err}
+		return err
 	}
 
 	transcodeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
@@ -113,7 +99,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 
 	var transcode TranscodeOutput
 	if err := workflow.ExecuteActivity(transcodeCtx, TranscodeActivityName, input, probe, crop).Get(transcodeCtx, &transcode); err != nil {
-		return &stepError{step: "transcode", err: err}
+		return err
 	}
 
 	notifyCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
@@ -122,7 +108,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 	})
 
 	if err := workflow.ExecuteActivity(notifyCtx, NotifyActivityName, input, transcode).Get(notifyCtx, nil); err != nil {
-		return &stepError{step: "notify", err: err}
+		return err
 	}
 
 	cleanupCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
@@ -131,7 +117,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 	})
 
 	if err := workflow.ExecuteActivity(cleanupCtx, CleanupActivityName, input).Get(cleanupCtx, nil); err != nil {
-		return &stepError{step: "cleanup", err: err}
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #165

## Summary

The straight-line media workflow returns at most one step error, so the surrounding plumbing (`NotifyWorkflowFailure(stepErrors map[string]string ...)` with sort + multi-line join, the `stepError` wrapper struct, the single-entry-map construction in `Activities.NotifyFailure`) was carrying water for a Hatchet-shaped multi-step model that no caller can produce.

This PR replaces it with the canonical Temporal pattern: `errors.As` against `*temporal.ActivityError`, whose `ActivityType().Name` returns the registered activity name.

- `NotifyWorkflowFailure(ctx, step, errMsg, workflowName, filePath, client)` — single-step signature; empty step is a no-op
- `Activities.NotifyFailure` now passes step + message straight through (no map)
- `workflow.go` defer extracts step via `errors.As(err, &actErr *temporal.ActivityError)` and `actErr.ActivityType().Name`
- `stepError` struct, `Error()`/`Unwrap()` methods, and every `&stepError{step: ..., err: err}` literal are gone — workflow body returns plain `err`
- Dead "multiple step errors are sorted and joined deterministically" test case removed from `onfailure_test.go`
- Stale `WithRunKey` / parent-issue comment in `cmd/watcher/watcher.go` rephrased to describe the AllowDuplicate semantics directly

## Behavior change call-out

The webhook payload's `step` value is now the registered activity name (e.g. `"Transcode"`) rather than the hand-written lowercase literal (`"transcode"`) that the wrapper used to inject. The payload schema (the `step` key) is unchanged. AC5 explicitly prescribes sourcing the value from `temporal.ActivityError.ActivityType()`. Confirmed `lgtm` on the issue plan before implementing.

## Test plan

- [x] `make fmt` clean
- [x] `make vet` clean
- [x] `make test` passes (workflows/media tests cover updated step-name extraction; activity unit tests cover the new single-step `NotifyWorkflowFailure` signature)
- [x] `make lint` (golangci-lint) clean
- [x] `make build` produces watcher + worker binaries
- [x] `grep -rn "stepError" workflows/` → no matches (AC3)
- [x] `grep -n "WithRunKey\|#131" cmd/watcher/watcher.go` → no matches (AC4)
