### PR TITLE
refactor(workflows): unify activity registration between worker and tests

### DIFF
--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -66,14 +66,14 @@ type Registrar interface {
 // in tests). The slice literals below are the single source of truth for the
 // (name, function) pairs the worker and tests register.
 func (a *Activities) Register(r Registrar) {
-	workflows := []struct {
+	workflowEntries := []struct {
 		name string
 		fn   any
 	}{
 		{MediaWorkflowName, a.MediaWorkflow},
 	}
 
-	activities := []struct {
+	activityEntries := []struct {
 		name string
 		fn   any
 	}{
@@ -85,12 +85,12 @@ func (a *Activities) Register(r Registrar) {
 		{NotifyFailureActivityName, a.NotifyFailure},
 	}
 
-	for _, wf := range workflows {
-		r.RegisterWorkflowWithOptions(wf.fn, workflow.RegisterOptions{Name: wf.name})
+	for _, workflowEntry := range workflowEntries {
+		r.RegisterWorkflowWithOptions(workflowEntry.fn, workflow.RegisterOptions{Name: workflowEntry.name})
 	}
 
-	for _, act := range activities {
-		r.RegisterActivityWithOptions(act.fn, activity.RegisterOptions{Name: act.name})
+	for _, activityEntry := range activityEntries {
+		r.RegisterActivityWithOptions(activityEntry.fn, activity.RegisterOptions{Name: activityEntry.name})
 	}
 }
 

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/sdk/client"
 	contribtally "go.temporal.io/sdk/contrib/tally"
 	"go.temporal.io/sdk/temporal"
-	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
@@ -53,16 +52,46 @@ func NewActivities(cfg MediaWorkflowConfig, radarrClient, sonarrClient medialib.
 	}, nil
 }
 
-// Register attaches the workflow function and the six activities to the given
-// Temporal worker.
-func (a *Activities) Register(w worker.Worker) {
-	w.RegisterWorkflowWithOptions(a.MediaWorkflow, workflow.RegisterOptions{Name: MediaWorkflowName})
-	w.RegisterActivityWithOptions(a.Probe, activity.RegisterOptions{Name: ProbeActivityName})
-	w.RegisterActivityWithOptions(a.DetectCrop, activity.RegisterOptions{Name: DetectCropActivityName})
-	w.RegisterActivityWithOptions(a.Transcode, activity.RegisterOptions{Name: TranscodeActivityName})
-	w.RegisterActivityWithOptions(a.Notify, activity.RegisterOptions{Name: NotifyActivityName})
-	w.RegisterActivityWithOptions(a.Cleanup, activity.RegisterOptions{Name: CleanupActivityName})
-	w.RegisterActivityWithOptions(a.NotifyFailure, activity.RegisterOptions{Name: NotifyFailureActivityName})
+// Registrar is the subset of registration methods that both worker.Worker and
+// *testsuite.TestWorkflowEnvironment expose. Accepting this interface lets the
+// production worker and the workflow test environment share one registration
+// list, so adding or renaming an activity only requires editing Register.
+type Registrar interface {
+	RegisterWorkflowWithOptions(w any, options workflow.RegisterOptions)
+	RegisterActivityWithOptions(a any, options activity.RegisterOptions)
+}
+
+// Register attaches the workflow function and the activities to the given
+// Temporal registrar (a worker.Worker in production, a TestWorkflowEnvironment
+// in tests). The slice literals below are the single source of truth for the
+// (name, function) pairs the worker and tests register.
+func (a *Activities) Register(r Registrar) {
+	workflows := []struct {
+		name string
+		fn   any
+	}{
+		{MediaWorkflowName, a.MediaWorkflow},
+	}
+
+	activities := []struct {
+		name string
+		fn   any
+	}{
+		{ProbeActivityName, a.Probe},
+		{DetectCropActivityName, a.DetectCrop},
+		{TranscodeActivityName, a.Transcode},
+		{NotifyActivityName, a.Notify},
+		{CleanupActivityName, a.Cleanup},
+		{NotifyFailureActivityName, a.NotifyFailure},
+	}
+
+	for _, wf := range workflows {
+		r.RegisterWorkflowWithOptions(wf.fn, workflow.RegisterOptions{Name: wf.name})
+	}
+
+	for _, act := range activities {
+		r.RegisterActivityWithOptions(act.fn, activity.RegisterOptions{Name: act.name})
+	}
 }
 
 // Probe is the Temporal activity that wraps RunProbe. Per-run metrics

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -9,26 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
-	"go.temporal.io/sdk/workflow"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 	"github.com/solidDoWant/media-processor/pkg/webhook"
 )
-
-// registerWorkflow wires the workflow + six activities into the test
-// environment. Mirrors Activities.Register, which targets a real worker.Worker.
-func registerWorkflow(env *testsuite.TestWorkflowEnvironment, a *Activities) {
-	env.RegisterWorkflowWithOptions(a.MediaWorkflow, workflow.RegisterOptions{Name: MediaWorkflowName})
-	env.RegisterActivityWithOptions(a.Probe, activity.RegisterOptions{Name: ProbeActivityName})
-	env.RegisterActivityWithOptions(a.DetectCrop, activity.RegisterOptions{Name: DetectCropActivityName})
-	env.RegisterActivityWithOptions(a.Transcode, activity.RegisterOptions{Name: TranscodeActivityName})
-	env.RegisterActivityWithOptions(a.Notify, activity.RegisterOptions{Name: NotifyActivityName})
-	env.RegisterActivityWithOptions(a.Cleanup, activity.RegisterOptions{Name: CleanupActivityName})
-	env.RegisterActivityWithOptions(a.NotifyFailure, activity.RegisterOptions{Name: NotifyFailureActivityName})
-}
 
 func newWorkflowActivities(t *testing.T) *Activities {
 	t.Helper()
@@ -47,7 +33,7 @@ func newWorkflowActivities(t *testing.T) *Activities {
 func TestMediaWorkflow_ValidPath_RunsAllActivitiesInOrder(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
 	cropOut := DetectCropOutput{}
@@ -69,7 +55,7 @@ func TestMediaWorkflow_ValidPath_RunsAllActivitiesInOrder(t *testing.T) {
 func TestMediaWorkflow_InvalidPath_SkipsTranscodeAndCallsCleanup(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 		Return(ProbeOutput{IsValidMedia: false}, nil).Once()
@@ -89,7 +75,7 @@ func TestMediaWorkflow_InvalidPath_SkipsTranscodeAndCallsCleanup(t *testing.T) {
 func TestMediaWorkflow_TranscodeFailureFiresFailureWebhook(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).Return(probeOut, nil).Once()
@@ -117,7 +103,7 @@ func TestMediaWorkflow_TranscodeFailureFiresFailureWebhook(t *testing.T) {
 func TestMediaWorkflow_ProbeFailureFiresFailureWebhook(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 		Return(ProbeOutput{}, errors.New("probe failed")).Once()
@@ -143,7 +129,7 @@ func TestMediaWorkflow_ProbeFailureFiresFailureWebhook(t *testing.T) {
 func TestMediaWorkflow_NotifyAndCleanupRetry(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).Return(probeOut, nil).Once()
@@ -188,7 +174,7 @@ func TestMediaWorkflow_NotifyAndCleanupRetry(t *testing.T) {
 func TestMediaWorkflow_NonRetryableInputErrorOnNotifyDoesNotRetry(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
-	registerWorkflow(env, newWorkflowActivities(t))
+	newWorkflowActivities(t).Register(env)
 
 	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).Return(probeOut, nil).Once()
@@ -264,7 +250,7 @@ func TestMediaWorkflow_NonRetryableActivitiesFailOnFirstError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			suite := &testsuite.WorkflowTestSuite{}
 			env := suite.NewTestWorkflowEnvironment()
-			registerWorkflow(env, newWorkflowActivities(t))
+			newWorkflowActivities(t).Register(env)
 
 			attempts := 0
 			test.setupMocks(env, &attempts)


### PR DESCRIPTION
Fixes #166

## Summary

- Introduce a `Registrar` interface in `workflows/media/activities.go` that captures `RegisterWorkflowWithOptions` / `RegisterActivityWithOptions` — both `worker.Worker` (production) and `*testsuite.TestWorkflowEnvironment` (tests) satisfy it.
- `Activities.Register` now takes that interface and drives registration from a single in-function table of `(name, fn)` pairs.
- Drops the parallel `registerWorkflow` helper in `media_test.go`; the seven test sites now call `a.Register(env)` directly.

Adding or renaming an activity now means editing one list.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] `make test-integration` passes (Docker available)