### PR TITLE
refactor(workflows,worker): tidy activity options and worker shutdown

### DIFF
--- a/cmd/worker/integration_test.go
+++ b/cmd/worker/integration_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"context"
 	"net"
 	"os"
 	"testing"
@@ -46,18 +45,16 @@ func TestWorkerConnectsToTemporal(t *testing.T) {
 	t.Setenv("SONARR_API_KEY", "test-key")
 	t.Setenv("HEALTH_ADDR", freeAddr(t))
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
+	interrupt := make(chan interface{}, 1)
 	done := make(chan error, 1)
 
 	go func() {
-		done <- run(ctx)
+		done <- run(t.Context(), interrupt)
 	}()
 
 	// If the worker fails to connect, run() returns quickly with an error.
-	// If it connects successfully, it blocks until the context is cancelled.
-	// Wait long enough to distinguish the two cases.
+	// If it connects successfully, it blocks until the interrupt channel
+	// receives. Wait long enough to distinguish the two cases.
 	const connectionWindow = 10 * time.Second
 
 	timer := time.NewTimer(connectionWindow)
@@ -65,11 +62,12 @@ func TestWorkerConnectsToTemporal(t *testing.T) {
 
 	select {
 	case err := <-done:
-		require.NoError(t, err, "worker exited before context was cancelled — connection likely failed")
+		require.NoError(t, err, "worker exited before interrupt was sent — connection likely failed")
 	case <-timer.C:
 		// Worker is still running after the window — connection succeeded.
 	}
 
-	cancel()
+	interrupt <- struct{}{}
+
 	require.NoError(t, <-done, "worker should shut down cleanly")
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -26,13 +26,13 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	if err := run(ctx); err != nil {
+	if err := run(ctx, worker.InterruptCh()); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context) error {
+func run(ctx context.Context, interruptCh <-chan interface{}) error {
 	logging.Setup(os.Getenv("LOG_LEVEL"))
 
 	taskQueue := os.Getenv("TEMPORAL_TASK_QUEUE")
@@ -161,22 +161,10 @@ func run(ctx context.Context) error {
 
 	activities.Register(w)
 
-	// Forward context cancellation (SIGINT/SIGTERM via signal.NotifyContext)
-	// onto the worker's interrupt channel. worker.Run starts the worker, blocks
-	// until the channel receives, and then performs a graceful Stop that drains
-	// in-flight activities.
-	interrupt := make(chan interface{}, 1)
-
-	go func() {
-		<-ctx.Done()
-
-		interrupt <- struct{}{}
-	}()
-
 	slog.InfoContext(ctx, "connected to Temporal, starting worker", slog.String("task_queue", taskQueue))
 	healthServer.SetReady()
 
-	if err := w.Run(interrupt); err != nil {
+	if err := w.Run(interruptCh); err != nil {
 		return fmt.Errorf("worker stopped: %w", err)
 	}
 

--- a/cmd/worker/run_test.go
+++ b/cmd/worker/run_test.go
@@ -15,7 +15,7 @@ import (
 func TestRun_MissingTaskQueue(t *testing.T) {
 	t.Setenv("TEMPORAL_TASK_QUEUE", "")
 
-	err := run(t.Context())
+	err := run(t.Context(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TEMPORAL_TASK_QUEUE")
 }

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
@@ -333,7 +334,7 @@ func TestMediaWorkflow_TranscodeHeartbeatTimeoutMatchesConfig(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	registerWorkflow(env, a)
+	a.Register(env)
 
 	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).Return(probeOut, nil).Once()

--- a/workflows/media/workflow.go
+++ b/workflows/media/workflow.go
@@ -2,10 +2,23 @@ package media
 
 import (
 	"errors"
+	"time"
 
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
+
+// defaultActivityOptions builds the StartToCloseTimeout/RetryPolicy pair used
+// by every activity in the workflow. The two parameters cover every variation
+// in use today: only the timeout and MaximumAttempts differ across call sites.
+// The transcode activity additionally sets HeartbeatTimeout on the returned
+// struct.
+func defaultActivityOptions(timeout time.Duration, attempts int32) workflow.ActivityOptions {
+	return workflow.ActivityOptions{
+		StartToCloseTimeout: timeout,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: attempts},
+	}
+}
 
 // MediaWorkflow processes one media file end-to-end. The body is straight-line
 // Go: probe, branch on validity, run the per-path activities. A defer block
@@ -44,10 +57,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		disconnected, cancel := workflow.NewDisconnectedContext(ctx)
 		defer cancel()
 
-		failureCtx := workflow.WithActivityOptions(disconnected, workflow.ActivityOptions{
-			StartToCloseTimeout: defaultFinalizeTimeout,
-			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: defaultMaxAttempts},
-		})
+		failureCtx := workflow.WithActivityOptions(disconnected, defaultActivityOptions(defaultFinalizeTimeout, defaultMaxAttempts))
 
 		notifyErr := workflow.ExecuteActivity(failureCtx, NotifyFailureActivityName, input, step, message).Get(failureCtx, nil)
 		if notifyErr != nil {
@@ -55,10 +65,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		}
 	}()
 
-	probeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: defaultProbeTimeout,
-		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: defaultMaxAttempts},
-	})
+	probeCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultProbeTimeout, defaultMaxAttempts))
 
 	var probe ProbeOutput
 	if err := workflow.ExecuteActivity(probeCtx, ProbeActivityName, input).Get(probeCtx, &probe); err != nil {
@@ -70,10 +77,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		// the invalid-files counter; Cleanup here is a near-no-op for the file
 		// (RunCleanup tolerates ErrNotExist) but still writes the .done
 		// sentinel when PreserveSource is set.
-		invalidCleanupCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-			StartToCloseTimeout: defaultFinalizeTimeout,
-			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: retryableMaxAttempts},
-		})
+		invalidCleanupCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
 
 		if err := workflow.ExecuteActivity(invalidCleanupCtx, CleanupActivityName, input).Get(invalidCleanupCtx, nil); err != nil {
 			return err
@@ -82,40 +86,29 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		return nil
 	}
 
-	cropCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: a.cfg.DetectCropTimeout,
-		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: defaultMaxAttempts},
-	})
+	cropCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(a.cfg.DetectCropTimeout, defaultMaxAttempts))
 
 	var crop DetectCropOutput
 	if err := workflow.ExecuteActivity(cropCtx, DetectCropActivityName, input, probe).Get(cropCtx, &crop); err != nil {
 		return err
 	}
 
-	transcodeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: a.cfg.TranscodeTimeout,
-		HeartbeatTimeout:    transcodeHeartbeatTimeout(a.cfg.ProgressLogInterval),
-		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: defaultMaxAttempts},
-	})
+	transcodeOpts := defaultActivityOptions(a.cfg.TranscodeTimeout, defaultMaxAttempts)
+	transcodeOpts.HeartbeatTimeout = transcodeHeartbeatTimeout(a.cfg.ProgressLogInterval)
+	transcodeCtx := workflow.WithActivityOptions(ctx, transcodeOpts)
 
 	var transcode TranscodeOutput
 	if err := workflow.ExecuteActivity(transcodeCtx, TranscodeActivityName, input, probe, crop).Get(transcodeCtx, &transcode); err != nil {
 		return err
 	}
 
-	notifyCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: defaultFinalizeTimeout,
-		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: retryableMaxAttempts},
-	})
+	notifyCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
 
 	if err := workflow.ExecuteActivity(notifyCtx, NotifyActivityName, input, transcode).Get(notifyCtx, nil); err != nil {
 		return err
 	}
 
-	cleanupCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: defaultFinalizeTimeout,
-		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: retryableMaxAttempts},
-	})
+	cleanupCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
 
 	if err := workflow.ExecuteActivity(cleanupCtx, CleanupActivityName, input).Get(cleanupCtx, nil); err != nil {
 		return err


### PR DESCRIPTION
Fixes #168.

## Summary

Two coherent idiomaticity fixes plus one drive-by repair:

- **B2** (`workflows/media/workflow.go`): introduce a `defaultActivityOptions(timeout, attempts)` factory and replace all seven inline `workflow.ActivityOptions{...}` literals. The transcode call site composes `HeartbeatTimeout` (added by #176) on top of the factory's return value, avoiding a third parameter that six callers would pass `0` for.
- **B5** (`cmd/worker/main.go`): drop the goroutine that bridged `ctx.Done()` onto a private interrupt channel; pass `worker.InterruptCh()` to `w.Run` directly. `run()` now takes the interrupt channel as a parameter so the integration test can inject its own.
- **Drive-by fix** (`workflows/media/media_test.go`): repair a build break introduced by #176 — `TestMediaWorkflow_TranscodeHeartbeatTimeoutMatchesConfig` referenced an undefined `registerWorkflow(env, a)` helper and used `activity.GetInfo` without importing the `activity` package. `go vet` failed on master. Replaced the call with `a.Register(env)` (matching the unified registration introduced by #175) and added the missing import. Kept as its own commit so it can be cherry-picked back if a separate fix PR is preferred.

No operator-visible behaviour change: every metric, env var, log line, and webhook payload that exists today still exists.

## Test plan

- [x] `make fmt`
- [x] `make vet`
- [x] `make lint`
- [x] `make test` (all packages green)
- [x] `make test-integration` — `TestWorkerConnectsToTemporal` exercises the new injected-interrupt path; passes against a local Temporal stack
- [x] `make build`
