### PR TITLE
refactor(watcher,workflows): replace positional-arg-soup with request structs

### DIFF
--- a/cmd/watcher/integration_test.go
+++ b/cmd/watcher/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/sdk/client"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	mediatypes "github.com/solidDoWant/media-processor/workflows/media/types"
 )
 
 // TestWatcher_ConnectsToTemporal verifies that the watcher successfully connects to a
@@ -86,12 +87,20 @@ func TestMultiWatcherDedup_OnlyOneWorkflowPerFile(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "movie.mkv")
 	require.NoError(t, os.WriteFile(filePath, []byte{}, 0o600))
 
+	input := mediatypes.MediaInput{
+		FilePath:    filePath,
+		MediaType:   medialib.MovieType,
+		MappingName: "movies",
+		WatchRoot:   "/watch",
+		OutputPath:  "/out",
+	}
+
 	require.NoError(t,
-		dispatch(t.Context(), filePath, medialib.MovieType, "movies", false, "/watch", false, "/out", ""),
+		dispatch(t.Context(), input),
 		"first dispatch should succeed",
 	)
 
-	err = dispatch(t.Context(), filePath, medialib.MovieType, "movies", false, "/watch", false, "/out", "")
+	err = dispatch(t.Context(), input)
 	require.ErrorIs(t, err, errWorkflowAlreadyStarted, "second dispatch should be deduplicated")
 
 	wfID := workflowID(filePath)

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/client"
 
-	"github.com/solidDoWant/media-processor/pkg/medialib"
 	mediatypes "github.com/solidDoWant/media-processor/workflows/media/types"
 )
 
@@ -28,11 +27,8 @@ import (
 // loop counts it as neither a dispatch nor a dispatch error.
 var errWorkflowAlreadyStarted = errors.New("workflow already started")
 
-// dispatchFunc submits a workflow run for the given absolute file path, media type, mapping name,
-// whether to preserve the source file after processing, the watch root directory, whether to
-// retain empty parent directories after source-file deletion, the absolute output directory path,
-// and the arr-side remote output path prefix (empty means no translation).
-type dispatchFunc func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool, outputPath string, outputRemotePath string) error
+// dispatchFunc submits a workflow run for the given media input.
+type dispatchFunc func(ctx context.Context, input mediatypes.MediaInput) error
 
 // scanInstruments holds all Prometheus collectors used during scan. Collectors
 // are registered once at startup and reused across every scan invocation.
@@ -147,24 +143,13 @@ func workflowID(absFilePath string) string {
 // conflict fires, the dispatch returns errWorkflowAlreadyStarted so the scan loop
 // can suppress both the dispatch and dispatch-error counters for that file.
 func newTemporalDispatch(c client.Client, taskQueue string) dispatchFunc {
-	return func(ctx context.Context, filePath string, mediaType medialib.MediaType, mappingName string, preserveSource bool, watchRoot string, retainEmptyDirs bool, outputPath string, outputRemotePath string) error {
+	return func(ctx context.Context, input mediatypes.MediaInput) error {
 		options := client.StartWorkflowOptions{
-			ID:                                       workflowID(filePath),
+			ID:                                       workflowID(input.FilePath),
 			TaskQueue:                                taskQueue,
 			WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 			WorkflowIDConflictPolicy:                 enums.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
 			WorkflowExecutionErrorWhenAlreadyStarted: true,
-		}
-
-		input := mediatypes.MediaInput{
-			FilePath:               filePath,
-			MediaType:              mediaType,
-			MappingName:            mappingName,
-			PreserveSource:         preserveSource,
-			WatchRoot:              watchRoot,
-			RetainEmptyDirectories: retainEmptyDirs,
-			OutputPath:             outputPath,
-			OutputRemotePath:       outputRemotePath,
 		}
 
 		if _, err := c.ExecuteWorkflow(ctx, options, mediatypes.MediaWorkflowName, input); err != nil {
@@ -323,7 +308,16 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 			filesDiscovered++
 
-			dispatchErr := dispatch(ctx, path, w.MediaType, w.Name, w.PreserveSource, absWatchRoot, w.RetainEmptyDirectories, absOutputPath, outputRemotePath)
+			dispatchErr := dispatch(ctx, mediatypes.MediaInput{
+				FilePath:               path,
+				MediaType:              w.MediaType,
+				MappingName:            w.Name,
+				PreserveSource:         w.PreserveSource,
+				WatchRoot:              absWatchRoot,
+				RetainEmptyDirectories: w.RetainEmptyDirectories,
+				OutputPath:             absOutputPath,
+				OutputRemotePath:       outputRemotePath,
+			})
 
 			switch {
 			case dispatchErr == nil:

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/solidDoWant/media-processor/internal/watcherconfig"
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	mediatypes "github.com/solidDoWant/media-processor/workflows/media/types"
 )
 
 // noopInstruments returns a scanInstruments registered against a private throwaway registry.
@@ -187,8 +188,8 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 
 	var calls []call
 
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, mn string, _ bool, _ string, _ bool, _ string, _ string) error {
-		calls = append(calls, call{fp, mt, mn})
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		calls = append(calls, call{input.FilePath, input.MediaType, input.MappingName})
 		return nil
 	}
 
@@ -218,8 +219,8 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -245,7 +246,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 
 	var count int
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	dispatch := func(_ context.Context, _ mediatypes.MediaInput) error {
 		count++
 		return errors.New("simulated dispatch failure")
 	}
@@ -272,7 +273,7 @@ func TestScan_ContextCancellationStopsWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately before scan starts
 
-	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	err := scan(ctx, cfg, noopInstruments(t), func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	})
 	assert.ErrorIs(t, err, context.Canceled)
@@ -296,8 +297,8 @@ func TestScan_MultipleWatchEntries(t *testing.T) {
 	}
 
 	dispatched := make(map[string]medialib.MediaType) // path → media type
-	dispatch := func(_ context.Context, fp string, mt medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched[fp] = mt
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched[input.FilePath] = input.MediaType
 		return nil
 	}
 
@@ -323,7 +324,7 @@ func TestScan_MetricsPresenceAfterScan(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -351,7 +352,7 @@ func TestScan_SuccessCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -378,7 +379,7 @@ func TestScan_ErrorCounterIncrements(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return errors.New("simulated dispatch failure")
 	})
 
@@ -406,7 +407,7 @@ func TestScan_DurationObservedPerMapping(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -444,7 +445,7 @@ func TestScan_LastSuccessfulScanSetOnSuccess(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -471,7 +472,7 @@ func TestScan_FilesDiscoveredCounter(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -501,7 +502,7 @@ func TestScan_DispatchesTotalCounter(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return nil
 	}))
 
@@ -533,8 +534,8 @@ func TestScan_IgnorePatternSkipsMatchingFile(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -562,8 +563,8 @@ func TestScan_IgnorePatternPrunesMatchingDirectory(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -589,8 +590,8 @@ func TestScan_NonMatchingFileDispatchedWithIgnorePatterns(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -614,7 +615,7 @@ func TestScan_DispatchErrorsCounter(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	_ = scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return errors.New("temporal unavailable")
 	})
 
@@ -646,7 +647,7 @@ func TestScan_AlreadyStartedNotCountedAsDispatchOrError(t *testing.T) {
 	}
 
 	instruments, reg := newTestInstruments(t)
-	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
+	require.NoError(t, scan(t.Context(), cfg, instruments, func(_ context.Context, _ mediatypes.MediaInput) error {
 		return errWorkflowAlreadyStarted
 	}))
 
@@ -709,8 +710,8 @@ func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {
 
 			var dispatched bool
 
-			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, ps bool, _ string, _ bool, _ string, _ string) error {
-				gotPreserveSource = ps
+			dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+				gotPreserveSource = input.PreserveSource
 				dispatched = true
 
 				return nil
@@ -741,8 +742,8 @@ func TestScan_WatchRootForwardedToDispatch(t *testing.T) {
 
 	var dispatched bool
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, wr string, _ bool, _ string, _ string) error {
-		gotWatchRoot = wr
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		gotWatchRoot = input.WatchRoot
 		dispatched = true
 
 		return nil
@@ -783,8 +784,8 @@ func TestScan_RetainEmptyDirsForwardedToDispatch(t *testing.T) {
 
 			var dispatched bool
 
-			dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, red bool, _ string, _ string) error {
-				gotRetainEmptyDirs = red
+			dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+				gotRetainEmptyDirs = input.RetainEmptyDirectories
 				dispatched = true
 
 				return nil
@@ -814,8 +815,8 @@ func TestScan_SkipsSentinelledFile(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -839,8 +840,8 @@ func TestScan_SkipsSentinelFileItself(t *testing.T) {
 
 	var dispatched []string
 
-	dispatch := func(_ context.Context, fp string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, _ string) error {
-		dispatched = append(dispatched, fp)
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		dispatched = append(dispatched, input.FilePath)
 		return nil
 	}
 
@@ -867,8 +868,8 @@ func TestScan_OutputPathForwardedToDispatch(t *testing.T) {
 
 	var dispatched bool
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, op string, _ string) error {
-		gotOutputPath = op
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		gotOutputPath = input.OutputPath
 		dispatched = true
 
 		return nil
@@ -900,8 +901,8 @@ func TestScan_OutputRemotePathForwardedToDispatch(t *testing.T) {
 
 	var dispatched bool
 
-	dispatch := func(_ context.Context, _ string, _ medialib.MediaType, _ string, _ bool, _ string, _ bool, _ string, orp string) error {
-		gotOutputRemotePath = orp
+	dispatch := func(_ context.Context, input mediatypes.MediaInput) error {
+		gotOutputRemotePath = input.OutputRemotePath
 		dispatched = true
 
 		return nil

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -191,7 +191,18 @@ func (a *Activities) Transcode(ctx context.Context, input MediaInput, probe Prob
 		activity.RecordHeartbeat(ctx, p)
 	}
 
-	out, err := RunTranscode(ctx, input.FilePath, probe, cropOut.Crop, outputPath, input.WatchRoot, a.cfg.HardwareDevicePath, a.cfg.H265CRF, a.cfg.ProgressLogInterval, heartbeat, library)
+	out, err := RunTranscode(ctx, TranscodeRequest{
+		FilePath:            input.FilePath,
+		Probe:               probe,
+		CropParams:          cropOut.Crop,
+		OutputDir:           outputPath,
+		WatcherRoot:         input.WatchRoot,
+		HardwareDevicePath:  a.cfg.HardwareDevicePath,
+		H265CRF:             a.cfg.H265CRF,
+		ProgressLogInterval: a.cfg.ProgressLogInterval,
+		Heartbeat:           heartbeat,
+		Library:             library,
+	})
 	logStepResult(ctx, "transcode", input.FilePath, start, err)
 
 	if err != nil {

--- a/workflows/media/transcode.go
+++ b/workflows/media/transcode.go
@@ -148,42 +148,71 @@ func codecName(c ffmpeg.Codec) string {
 	}
 }
 
-// RunTranscode transcodes filePath into outputDir, writing to a temp file named
+// TranscodeRequest is the input to RunTranscode.
+type TranscodeRequest struct {
+	// FilePath is the absolute path of the source media file to transcode.
+	FilePath string
+	// Probe is the output of RunProbe for FilePath.
+	Probe ProbeOutput
+	// CropParams is the crop region to apply, or nil for no cropping.
+	// When non-nil and the selected video codec would be CodecCopy, the codec
+	// is promoted to CodecH265 so the crop filter can be applied.
+	CropParams *ffmpeg.CropParams
+	// OutputDir is the directory the final .mkv is written into.
+	OutputDir string
+	// WatcherRoot is the root directory that the watcher monitors. When non-empty,
+	// the subdirectory of FilePath relative to WatcherRoot is mirrored under OutputDir,
+	// preserving the download client's directory structure. When empty, the output is
+	// written flat into OutputDir.
+	WatcherRoot string
+	// HardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
+	// an empty string uses the libav default (auto-select).
+	HardwareDevicePath string
+	// H265CRF is the constant-quality value for H.265 encoders. 0 means use the
+	// encoder's built-in default; valid explicit values are 1–51 (lower = higher
+	// quality). For libx265 this is the CRF; for hevc_nvenc it is the CQ value;
+	// for hevc_qsv and hevc_vaapi it is the global_quality (ICQ) value. Values
+	// outside 1–51 are silently ignored and the encoder default is used.
+	H265CRF int
+	// ProgressLogInterval controls how often a progress log line is emitted during
+	// transcoding. Zero disables progress logging.
+	ProgressLogInterval time.Duration
+	// Heartbeat, when non-nil, is invoked from the progress-consumer goroutine on
+	// every FFmpeg progress tick AND on every ProgressLogInterval ticker tick (so
+	// the copy/remux path, which produces no FFmpeg progress packets, still
+	// signals liveness within HeartbeatTimeout). The activity wrapper supplies a
+	// callback that forwards to activity.RecordHeartbeat so a stalled worker is
+	// detected via the configured Temporal HeartbeatTimeout. Tests pass nil.
+	// Heartbeat is only invoked when ProgressLogInterval > 0, since the progress
+	// goroutine that drives it is gated on that interval.
+	Heartbeat func(ffmpeg.Progress)
+	// Library is the arr library used to fetch poster artwork. When nil, no fetch
+	// is attempted and transcoding proceeds without an embedded attachment, and
+	// ArtworkFetchSkipped is not set. When non-nil and the fetch yields no
+	// embeddable image, transcoding proceeds without an embedded attachment and
+	// ArtworkFetchSkipped is set to true.
+	Library medialib.ArrLibrary
+}
+
+// RunTranscode transcodes req.FilePath into req.OutputDir, writing to a temp file named
 // "._<stem>.mkv.tmp" and atomically renaming it to "<stem>.mkv" on success.
 // The output always carries a .mkv extension to match the forced MKV container.
 // Writing directly to the output directory avoids a cross-filesystem copy and
 // guarantees the rename is atomic on Linux (same directory).
-// probe is the output of RunProbe for filePath.
-// cropParams is the crop region to apply, or nil for no cropping.
-// When cropParams is non-nil and videoCodec would be CodecCopy, the codec is
-// promoted to CodecH265 so the crop filter can be applied.
-// watcherRoot is the root directory that the watcher monitors. When non-empty,
-// the subdirectory of filePath relative to watcherRoot is mirrored under outputDir,
-// preserving the download client's directory structure. When empty, the output is
-// written flat into outputDir (no subdirectory).
-// hardwareDevicePath is the device path passed to CreateHardwareDeviceContext;
-// an empty string uses the libav default (auto-select).
-// h265CRF is the constant-quality value for H.265 encoders. 0 means use the
-// encoder's built-in default; valid explicit values are 1–51 (lower = higher
-// quality). For libx265 this is the CRF; for hevc_nvenc it is the CQ value;
-// for hevc_qsv and hevc_vaapi it is the global_quality (ICQ) value. Values
-// outside 1–51 are silently ignored and the encoder default is used.
-// progressLogInterval controls how often a progress log line is emitted during
-// transcoding. Zero disables progress logging.
-// heartbeat, when non-nil, is invoked from the progress-consumer goroutine on
-// every FFmpeg progress tick AND on every progressLogInterval ticker tick (so
-// the copy/remux path, which produces no FFmpeg progress packets, still
-// signals liveness within HeartbeatTimeout). The activity wrapper supplies a
-// callback that forwards to activity.RecordHeartbeat so a stalled worker is
-// detected via the configured Temporal HeartbeatTimeout. Tests pass nil.
-// heartbeat is only invoked when progressLogInterval &gt; 0, since the progress
-// goroutine that drives it is gated on that interval.
-// library is the arr library used to fetch poster artwork. When nil, no fetch
-// is attempted and transcoding proceeds without an embedded attachment, and
-// ArtworkFetchSkipped is not set. When non-nil and the fetch yields no
-// embeddable image, transcoding proceeds without an embedded attachment and
-// ArtworkFetchSkipped is set to true.
-func RunTranscode(ctx context.Context, filePath string, probe ProbeOutput, cropParams *ffmpeg.CropParams, outputDir string, watcherRoot string, hardwareDevicePath string, h265CRF int, progressLogInterval time.Duration, heartbeat func(ffmpeg.Progress), library medialib.ArrLibrary) (TranscodeOutput, error) {
+func RunTranscode(ctx context.Context, req TranscodeRequest) (TranscodeOutput, error) {
+	var (
+		filePath            = req.FilePath
+		probe               = req.Probe
+		cropParams          = req.CropParams
+		outputDir           = req.OutputDir
+		watcherRoot         = req.WatcherRoot
+		hardwareDevicePath  = req.HardwareDevicePath
+		h265CRF             = req.H265CRF
+		progressLogInterval = req.ProgressLogInterval
+		heartbeat           = req.Heartbeat
+		library             = req.Library
+	)
+
 	transcodeStart := time.Now()
 
 	srcInfo, err := os.Stat(filePath)

--- a/workflows/media/transcode_test.go
+++ b/workflows/media/transcode_test.go
@@ -611,7 +611,11 @@ func TestRunTranscode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputPath, outputDir := tt.setup(t)
 
-			out, err := RunTranscode(t.Context(), inputPath, tt.probe, nil, outputDir, "", "", 0, 0, nil, nil)
+			out, err := RunTranscode(t.Context(), TranscodeRequest{
+				FilePath:  inputPath,
+				Probe:     tt.probe,
+				OutputDir: outputDir,
+			})
 
 			tt.errFunc(t, err)
 
@@ -646,7 +650,12 @@ func TestRunTranscode_WatcherRoot_SubdirIsPreservedInOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, 0, nil, nil)
+	out, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:    inputPath,
+		Probe:       probe,
+		OutputDir:   outputDir,
+		WatcherRoot: watcherRoot,
+	})
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "my-media-item", "video.mkv")
@@ -677,7 +686,12 @@ func TestRunTranscode_WatcherRoot_FlatInputProducesFlatOutput(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	out, err := RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, 0, nil, nil)
+	out, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:    inputPath,
+		Probe:       probe,
+		OutputDir:   outputDir,
+		WatcherRoot: watcherRoot,
+	})
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(outputDir, "video.mkv")
@@ -706,7 +720,12 @@ func TestRunTranscode_WatcherRoot_InputOutsideWatcherRootReturnsError(t *testing
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	_, err = RunTranscode(t.Context(), inputPath, probe, nil, outputDir, watcherRoot, "", 0, 0, nil, nil)
+	_, err = RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:    inputPath,
+		Probe:       probe,
+		OutputDir:   outputDir,
+		WatcherRoot: watcherRoot,
+	})
 	require.Error(t, err, "input outside watcherRoot should return an error")
 
 	entries, readErr := os.ReadDir(outputDir)
@@ -741,7 +760,12 @@ func withRecordingLogger(t *testing.T) *recordingHandler {
 func TestRunTranscode_ProgressLogging_EmitsLinesAtInterval(t *testing.T) {
 	handler := withRecordingLogger(t)
 
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), progressProbe(), nil, t.TempDir(), "", "", 0, 50*time.Millisecond, nil, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:            copyTestVideo(t),
+		Probe:               progressProbe(),
+		OutputDir:           t.TempDir(),
+		ProgressLogInterval: 50 * time.Millisecond,
+	})
 	require.NoError(t, err)
 
 	assert.Eventually(t,
@@ -770,7 +794,11 @@ func TestRunTranscode_ProgressLogging_EmitsLinesAtInterval(t *testing.T) {
 func TestRunTranscode_ProgressLogging_NoLinesWhenDisabled(t *testing.T) {
 	handler := withRecordingLogger(t)
 
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), progressProbe(), nil, t.TempDir(), "", "", 0, 0, nil, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:  copyTestVideo(t),
+		Probe:     progressProbe(),
+		OutputDir: t.TempDir(),
+	})
 	require.NoError(t, err)
 
 	assert.Empty(t, handler.progressRecords(), "expected no progress log lines when interval is zero")
@@ -780,7 +808,12 @@ func TestRunTranscode_ProgressLogging_FinalLineEmittedOnCompletion(t *testing.T)
 	handler := withRecordingLogger(t)
 
 	// Interval longer than the transcode so no tick fires; the final log on done must appear.
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), progressProbe(), nil, t.TempDir(), "", "", 0, time.Hour, nil, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:            copyTestVideo(t),
+		Probe:               progressProbe(),
+		OutputDir:           t.TempDir(),
+		ProgressLogInterval: time.Hour,
+	})
 	require.NoError(t, err)
 
 	// The goroutine emits its final log after RunTranscode returns; poll briefly for it.
@@ -806,7 +839,13 @@ func TestRunTranscode_Heartbeat_InvokedOnProgressTicks(t *testing.T) {
 		ticks = append(ticks, p)
 	}
 
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), progressProbe(), nil, t.TempDir(), "", "", 0, 50*time.Millisecond, heartbeat, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:            copyTestVideo(t),
+		Probe:               progressProbe(),
+		OutputDir:           t.TempDir(),
+		ProgressLogInterval: 50 * time.Millisecond,
+		Heartbeat:           heartbeat,
+	})
 	require.NoError(t, err)
 
 	// Poll for the final synthetic 100% tick. Real progress ticks land first
@@ -862,7 +901,13 @@ func TestRunTranscode_Heartbeat_FiresOnCopyRemuxPathWithoutProgressPackets(t *te
 	// Small interval so the ticker is guaranteed to fire at least once
 	// during the copy. The Temporal SDK throttles heartbeats internally,
 	// so calling the callback frequently is harmless.
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), copyProbe, nil, t.TempDir(), "", "", 0, time.Millisecond, heartbeat, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:            copyTestVideo(t),
+		Probe:               copyProbe,
+		OutputDir:           t.TempDir(),
+		ProgressLogInterval: time.Millisecond,
+		Heartbeat:           heartbeat,
+	})
 	require.NoError(t, err)
 
 	// The final 100% tick is dispatched by the goroutine on `done`, which
@@ -902,7 +947,12 @@ func TestRunTranscode_Heartbeat_NotInvokedWhenProgressDisabled(t *testing.T) {
 		called = true
 	}
 
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), progressProbe(), nil, t.TempDir(), "", "", 0, 0, heartbeat, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:  copyTestVideo(t),
+		Probe:     progressProbe(),
+		OutputDir: t.TempDir(),
+		Heartbeat: heartbeat,
+	})
 	require.NoError(t, err)
 
 	assert.False(t, called, "heartbeat must not be invoked when progress logging is disabled (interval == 0)")
@@ -920,7 +970,12 @@ func TestRunTranscode_ProgressLogging_CopyPathReports100Percent(t *testing.T) {
 		AudioStreams: []AudioStreamInfo{audioStreamInfo(1, "und", 2)},
 	}
 
-	_, err := RunTranscode(t.Context(), copyTestVideo(t), copyProbe, nil, t.TempDir(), "", "", 0, time.Hour, nil, nil)
+	_, err := RunTranscode(t.Context(), TranscodeRequest{
+		FilePath:            copyTestVideo(t),
+		Probe:               copyProbe,
+		OutputDir:           t.TempDir(),
+		ProgressLogInterval: time.Hour,
+	})
 	require.NoError(t, err)
 
 	assert.Eventually(t,


### PR DESCRIPTION
Fixes #169.

## Summary

- `dispatchFunc` now takes `mediatypes.MediaInput` directly (was 9 positional parameters); `newTemporalDispatch` and `scan` updated accordingly. The `medialib` import in `cmd/watcher/watcher.go` is no longer needed.
- New `TranscodeRequest` struct in `workflows/media/transcode.go`, with the same 10 fields previously passed positionally. `RunTranscode` reads them via local aliases at the top of the body so the rest of the function is unchanged. Per-field doc comments were migrated from the old function header onto the struct.
- All `dispatchFunc` mocks in `cmd/watcher/watcher_test.go` and the call sites in `cmd/watcher/integration_test.go` and `workflows/media/transcode_test.go` updated to the struct shape.
- `Activities.Transcode` builds a `TranscodeRequest` from `MediaInput` + activity config.

F2 (drop the multiple-step-errors test in `onfailure_test.go`) was already done by the A2 sub-issue (#174); no action needed.

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues
- [x] `make test-integration` — all integration tests pass (Docker available)