### PR TITLE
refactor(watcherconfig): consolidate validation tag/JSONSchema duplication

### DIFF
--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -98,14 +98,10 @@ func (c *CompiledRegexp) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// validMediaTypes is the authoritative list of medialib.MediaType values accepted in config.
-// It drives runtime validation; JSON Schema enum generation is handled by medialib.MediaType.JSONSchema.
-var validMediaTypes = []medialib.MediaType{medialib.MovieType, medialib.ShowType}
-
 // WatchEntryOutput describes the output destination for a watch entry.
 type WatchEntryOutput struct {
 	// Path is the filesystem path to the directory where processed files are written.
-	Path string `yaml:"path" jsonschema:"minLength=1" validate:"min=1"`
+	Path string `yaml:"path" jsonschema:"minLength=1"`
 	// RemotePath is the path by which the output directory is known to the arr service (Radarr/Sonarr).
 	// Set this when the worker and the arr service mount the output volume at different paths.
 	// When empty, no path translation is applied.
@@ -116,10 +112,10 @@ type WatchEntryOutput struct {
 // and carrying a human-readable name for identification.
 type WatchEntry struct {
 	// Name is a human-readable label for this watch entry, used in logs and metrics.
-	Name string `yaml:"name" jsonschema:"minLength=1" validate:"min=1"`
+	Name string `yaml:"name" jsonschema:"minLength=1"`
 	// WatchedPath is the filesystem path to the directory to watch. Relative paths are resolved
 	// against the watcher's working directory.
-	WatchedPath string `yaml:"watchedPath" jsonschema:"minLength=1" validate:"min=1"`
+	WatchedPath string `yaml:"watchedPath" jsonschema:"minLength=1"`
 	// MediaType indicates whether this directory contains movies or TV show episodes.
 	MediaType medialib.MediaType `yaml:"mediaType" validate:"mediatype"`
 	// IgnorePatterns is an optional list of Go regular expressions matched against the absolute

--- a/internal/watcherconfig/validate.go
+++ b/internal/watcherconfig/validate.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-playground/validator/v10"
 
@@ -114,6 +115,10 @@ func parseMinLength(tag string) (int, bool) {
 			panic(fmt.Sprintf("registerSchemaConstraints: invalid jsonschema minLength %q: %v", raw, err))
 		}
 
+		if n < 0 {
+			panic(fmt.Sprintf("registerSchemaConstraints: invalid jsonschema minLength %q: must be >= 0", raw))
+		}
+
 		return n, true
 	}
 
@@ -121,15 +126,18 @@ func parseMinLength(tag string) (int, bool) {
 }
 
 // makeMinLengthStructValidator returns a struct-level validator that reports an
-// error for each rule whose corresponding string field is shorter than the
-// configured minimum. The reported tag is "min" so downstream error messages
-// match what go-playground/validator would emit for `validate:"min=N"`.
+// error for each rule whose corresponding string field has fewer characters
+// (Unicode code points) than the configured minimum. JSON Schema's minLength
+// counts characters per RFC 8259, not bytes, so multibyte strings must be
+// measured by rune count to keep runtime validation aligned with the schema.
+// The reported tag is "min" so downstream error messages match what
+// go-playground/validator would emit for `validate:"min=N"`.
 func makeMinLengthStructValidator(rules []minLengthRule) validator.StructLevelFunc {
 	return func(sl validator.StructLevel) {
 		current := sl.Current()
 		for _, rule := range rules {
 			value := current.Field(rule.fieldIndex)
-			if value.Len() < rule.min {
+			if utf8.RuneCountInString(value.String()) < rule.min {
 				sl.ReportError(value.Interface(), rule.fieldName, rule.fieldName, "min", strconv.Itoa(rule.min))
 			}
 		}

--- a/internal/watcherconfig/validate.go
+++ b/internal/watcherconfig/validate.go
@@ -1,29 +1,137 @@
 package watcherconfig
 
 import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
 	"github.com/go-playground/validator/v10"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
 )
 
-// NewValidator returns a validator configured with the mediatype validator for MediaType values.
+// NewValidator returns a validator configured with the mediatype validator and with
+// runtime length-constraint rules derived from `jsonschema:"minLength=N"` tags on
+// the watcher config struct types.
 func NewValidator() *validator.Validate {
 	v := validator.New(validator.WithRequiredStructEnabled())
 	if err := v.RegisterValidation("mediatype", validateMediaType); err != nil {
 		panic("failed to register validation \"mediatype\": " + err.Error())
 	}
 
+	registerSchemaConstraints(v, Config{}, WatchEntry{}, WatchEntryOutput{})
+
 	return v
 }
 
-// validateMediaType checks that the field value is one of the values in validMediaTypes.
+// validateMediaType checks that the field value is one of medialib.AllMediaTypes.
 func validateMediaType(fl validator.FieldLevel) bool {
 	mt := medialib.MediaType(fl.Field().String())
-	for _, valid := range validMediaTypes {
+	for _, valid := range medialib.AllMediaTypes() {
 		if mt == valid {
 			return true
 		}
 	}
 
 	return false
+}
+
+// registerSchemaConstraints scans each struct type for `jsonschema:"minLength=N"` tags
+// on string fields and installs a struct-level validator on v that enforces those
+// minimum-length rules at runtime. Malformed tags panic at registration time so
+// configuration errors fail fast rather than silently allowing invalid values.
+func registerSchemaConstraints(v *validator.Validate, types ...any) {
+	for _, t := range types {
+		rules := extractMinLengthRules(reflect.TypeOf(t))
+		if len(rules) == 0 {
+			continue
+		}
+
+		v.RegisterStructValidation(makeMinLengthStructValidator(rules), t)
+	}
+}
+
+// minLengthRule captures a single `minLength=N` constraint extracted from a
+// jsonschema struct tag.
+type minLengthRule struct {
+	fieldIndex int
+	fieldName  string
+	min        int
+}
+
+// extractMinLengthRules walks the fields of a struct type and returns one rule
+// per string field tagged `jsonschema:"...minLength=N..."`. It panics on a
+// malformed minLength value so misconfigured tags surface at startup.
+func extractMinLengthRules(t reflect.Type) []minLengthRule {
+	if t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("registerSchemaConstraints: %s is not a struct", t))
+	}
+
+	var rules []minLengthRule
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if field.Type.Kind() != reflect.String {
+			continue
+		}
+
+		minLen, ok := parseMinLength(field.Tag.Get("jsonschema"))
+		if !ok {
+			continue
+		}
+
+		rules = append(rules, minLengthRule{
+			fieldIndex: i,
+			fieldName:  field.Name,
+			min:        minLen,
+		})
+	}
+
+	return rules
+}
+
+// parseMinLength extracts the minLength=N value from a comma-separated jsonschema
+// tag. It returns (0, false) when no minLength option is present and panics when
+// the option is present but malformed.
+func parseMinLength(tag string) (int, bool) {
+	if tag == "" {
+		return 0, false
+	}
+
+	const prefix = "minLength="
+
+	for _, part := range strings.Split(tag, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.HasPrefix(part, prefix) {
+			continue
+		}
+
+		raw := strings.TrimPrefix(part, prefix)
+
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			panic(fmt.Sprintf("registerSchemaConstraints: invalid jsonschema minLength %q: %v", raw, err))
+		}
+
+		return n, true
+	}
+
+	return 0, false
+}
+
+// makeMinLengthStructValidator returns a struct-level validator that reports an
+// error for each rule whose corresponding string field is shorter than the
+// configured minimum. The reported tag is "min" so downstream error messages
+// match what go-playground/validator would emit for `validate:"min=N"`.
+func makeMinLengthStructValidator(rules []minLengthRule) validator.StructLevelFunc {
+	return func(sl validator.StructLevel) {
+		current := sl.Current()
+		for _, rule := range rules {
+			value := current.Field(rule.fieldIndex)
+			if value.Len() < rule.min {
+				sl.ReportError(value.Interface(), rule.fieldName, rule.fieldName, "min", strconv.Itoa(rule.min))
+			}
+		}
+	}
 }

--- a/internal/watcherconfig/validate_test.go
+++ b/internal/watcherconfig/validate_test.go
@@ -118,6 +118,34 @@ func TestParseMinLength_PanicsOnMalformed(t *testing.T) {
 	})
 }
 
+// TestParseMinLength_PanicsOnNegative verifies that a negative minLength value
+// panics; otherwise the rule would silently never fire (value.Len() < -1 is
+// always false), defeating the source-of-truth contract.
+func TestParseMinLength_PanicsOnNegative(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		parseMinLength("minLength=-1")
+	})
+}
+
+// TestRegisterSchemaConstraints_CountsRunesNotBytes verifies that minLength is
+// measured by Unicode code point count (matching JSON Schema semantics) rather
+// than byte count, so multibyte strings are not accepted as longer than they are.
+func TestRegisterSchemaConstraints_CountsRunesNotBytes(t *testing.T) {
+	t.Parallel()
+
+	type sample struct {
+		Field string `jsonschema:"minLength=3"`
+	}
+
+	v := validator.New(validator.WithRequiredStructEnabled())
+	registerSchemaConstraints(v, sample{})
+
+	assert.Error(t, v.Struct(sample{Field: "éé"}), "two-rune string should fail minLength=3 even though it is 4 bytes")
+	assert.NoError(t, v.Struct(sample{Field: "ééé"}), "three-rune string should pass minLength=3")
+}
+
 // TestParseMinLength_NoMinLengthOption verifies that a tag without a minLength
 // option returns ok=false rather than producing a rule.
 func TestParseMinLength_NoMinLengthOption(t *testing.T) {

--- a/internal/watcherconfig/validate_test.go
+++ b/internal/watcherconfig/validate_test.go
@@ -1,0 +1,143 @@
+package watcherconfig
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewValidator_MinLengthRulesEnforced verifies that the runtime length
+// constraints registered from `jsonschema:"minLength=N"` tags reject empty
+// values for the watcher config string fields.
+func TestNewValidator_MinLengthRulesEnforced(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		errFunc require.ErrorAssertionFunc // defaults to require.NoError
+	}{
+		{
+			name: "valid config passes",
+			cfg: Config{
+				ScanInterval: DefaultScanInterval,
+				Watches: []WatchEntry{
+					{Name: "movies", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+				},
+			},
+		},
+		{
+			name: "empty Name is rejected",
+			cfg: Config{
+				ScanInterval: DefaultScanInterval,
+				Watches: []WatchEntry{
+					{Name: "", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+				},
+			},
+			errFunc: require.Error,
+		},
+		{
+			name: "empty WatchedPath is rejected",
+			cfg: Config{
+				ScanInterval: DefaultScanInterval,
+				Watches: []WatchEntry{
+					{Name: "movies", WatchedPath: "", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+				},
+			},
+			errFunc: require.Error,
+		},
+		{
+			name: "empty Output.Path is rejected",
+			cfg: Config{
+				ScanInterval: DefaultScanInterval,
+				Watches: []WatchEntry{
+					{Name: "movies", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: ""}},
+				},
+			},
+			errFunc: require.Error,
+		},
+	}
+
+	v := NewValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			errFunc := tt.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, v.Struct(tt.cfg))
+		})
+	}
+}
+
+// TestRegisterSchemaConstraints_EmptyStringRule verifies that a struct with a
+// `jsonschema:"minLength=N"` tag has its rule applied at runtime by the helper.
+func TestRegisterSchemaConstraints_EmptyStringRule(t *testing.T) {
+	t.Parallel()
+
+	type sample struct {
+		Field string `jsonschema:"minLength=3"`
+	}
+
+	v := validator.New(validator.WithRequiredStructEnabled())
+	registerSchemaConstraints(v, sample{})
+
+	assert.NoError(t, v.Struct(sample{Field: "abc"}))
+	assert.Error(t, v.Struct(sample{Field: "ab"}))
+	assert.Error(t, v.Struct(sample{Field: ""}))
+}
+
+// TestRegisterSchemaConstraints_IgnoresNonStringFields verifies that the helper
+// only applies length rules to string fields (other types' tags are ignored).
+func TestRegisterSchemaConstraints_IgnoresNonStringFields(t *testing.T) {
+	t.Parallel()
+
+	type sample struct {
+		Field int `jsonschema:"minLength=5"`
+	}
+
+	v := validator.New(validator.WithRequiredStructEnabled())
+	registerSchemaConstraints(v, sample{})
+
+	assert.NoError(t, v.Struct(sample{Field: 0}))
+}
+
+// TestParseMinLength_PanicsOnMalformed verifies that a non-numeric minLength
+// value panics so misconfigured tags surface at validator construction time.
+func TestParseMinLength_PanicsOnMalformed(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		parseMinLength("minLength=abc")
+	})
+}
+
+// TestParseMinLength_NoMinLengthOption verifies that a tag without a minLength
+// option returns ok=false rather than producing a rule.
+func TestParseMinLength_NoMinLengthOption(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tag  string
+	}{
+		{name: "empty tag", tag: ""},
+		{name: "unrelated option", tag: "format=regex"},
+		{name: "multiple unrelated options", tag: "format=regex,description=foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, ok := parseMinLength(tt.tag)
+			assert.False(t, ok)
+		})
+	}
+}

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -21,11 +21,24 @@ const (
 	ShowType MediaType = "show"
 )
 
+// AllMediaTypes returns the canonical list of valid MediaType values. It is the
+// single source of truth shared by runtime validation and JSON Schema generation.
+func AllMediaTypes() []MediaType {
+	return []MediaType{MovieType, ShowType}
+}
+
 // JSONSchema returns a JSON Schema for MediaType restricting values to the valid types.
 func (MediaType) JSONSchema() *jsonschema.Schema {
+	all := AllMediaTypes()
+
+	enum := make([]any, len(all))
+	for i, mt := range all {
+		enum[i] = string(mt)
+	}
+
 	return &jsonschema.Schema{
 		Type:        "string",
-		Enum:        []any{string(MovieType), string(ShowType)},
+		Enum:        enum,
 		Description: "Whether the watched directory contains movies (\"movie\") or TV show episodes (\"show\").",
 	}
 }


### PR DESCRIPTION
Fixes #181.

## Summary

Consolidate the validate-tag / jsonschema-tag duplication in `internal/watcherconfig` so each constraint lives in exactly one place.

- Dropped `validate:"min=1"` from `Path`, `Name`, `WatchedPath`. A new `registerSchemaConstraints` helper in `internal/watcherconfig/validate.go` walks the watcher config struct types via reflection at validator construction time, extracts `jsonschema:"minLength=N"` constraints from string fields, and installs equivalent struct-level validators on the validator. Net effect: same runtime check, single source of truth (the `jsonschema` tag).
- Removed the `validMediaTypes` package var. Added `medialib.AllMediaTypes()` as the canonical list, used by both `MediaType.JSONSchema()` (for the schema enum) and `validateMediaType` (for runtime).
- Kept the `JSONSchema()` overrides on `MediaType`, `Interval`, and `CompiledRegexp` — they describe on-disk shapes that differ from Go shapes.
- Left `validate:"gt=0"` on `ScanInterval` alone; `Interval.UnmarshalYAML` already enforces positivity, but UnmarshalYAML is not one of the three locations the issue calls out.

## Schema diff

`make generate-schema` produces a byte-identical `schemas/watcher.schema.json` (verified with `git diff schemas/`).

## Tests added

- `TestNewValidator_MinLengthRulesEnforced` — confirms empty `Name`, `WatchedPath`, and `Output.Path` are rejected by the validator returned from `NewValidator()`.
- `TestRegisterSchemaConstraints_EmptyStringRule` — confirms a sample struct with `jsonschema:"minLength=3"` rejects shorter values.
- `TestRegisterSchemaConstraints_IgnoresNonStringFields` — non-string fields are skipped.
- `TestParseMinLength_PanicsOnMalformed` — non-numeric `minLength=` panics at registration time so misconfigured tags surface fast.
- `TestParseMinLength_NoMinLengthOption` — tags without a `minLength` option return ok=false.

## Test plan

- [x] `make build`
- [x] `make test`
- [x] `make lint`
- [x] `make generate-schema` produces no diff in `schemas/watcher.schema.json`
- [x] Existing `cmd/watcher/config_test.go` cases for empty/missing `name`, `watchedPath`, `output.path`, and invalid `mediaType` still fail config loading.