### PR TITLE
fix(worker): validate MEDIA_HARDWARE_DEVICE_PATH at startup

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -141,8 +141,13 @@ func run(ctx context.Context, interruptCh <-chan interface{}) error {
 		return err
 	}
 
+	hardwareDevicePath := os.Getenv("MEDIA_HARDWARE_DEVICE_PATH")
+	if err := validateHardwareDevicePath(hardwareDevicePath); err != nil {
+		return err
+	}
+
 	activities, err := media.NewActivities(media.MediaWorkflowConfig{
-		HardwareDevicePath:    os.Getenv("MEDIA_HARDWARE_DEVICE_PATH"),
+		HardwareDevicePath:    hardwareDevicePath,
 		HighCardinalityLabels: highCardinalityLabels,
 		MinCropX:              minCropX,
 		MinCropY:              minCropY,
@@ -236,4 +241,36 @@ func parseTimeout(envVar string, defaultVal time.Duration) (time.Duration, error
 	}
 
 	return d, nil
+}
+
+// validateHardwareDevicePath rejects paths that exist but are not character
+// devices and paths that do not exist at all, surfacing typos like
+// "/dev/dri/render128" (missing D) before any workflow is dispatched.
+//
+// MEDIA_HARDWARE_DEVICE_PATH is overloaded: QSV/VAAPI take a filesystem path,
+// but NVENC takes a CUDA ordinal string like "0" or "1" (see
+// docs/hardware-acceleration.md). The backend is auto-selected at activity
+// time from the encoders FFmpeg exposes, so we cannot tell at startup which
+// interpretation will apply — a value that parses as a non-negative decimal
+// integer is treated as the ordinal form and skipped rather than rejected as
+// a missing file.
+func validateHardwareDevicePath(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	if _, err := strconv.ParseUint(path, 10, 32); err == nil {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("MEDIA_HARDWARE_DEVICE_PATH %q: %w", path, err)
+	}
+
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return fmt.Errorf("MEDIA_HARDWARE_DEVICE_PATH %q is not a character device", path)
+	}
+
+	return nil
 }

--- a/cmd/worker/run_test.go
+++ b/cmd/worker/run_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -113,6 +115,80 @@ func TestWorkerStopTimeoutFallsBackToTranscodeTimeout(t *testing.T) {
 	got, err = parseTimeout("WORKER_STOP_TIMEOUT", overriddenTranscodeTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, overriddenTranscodeTimeout, got)
+}
+
+func TestValidateHardwareDevicePath(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupPath     func(t *testing.T) string
+		errSubstrings []string
+		errFunc       require.ErrorAssertionFunc
+	}{
+		{
+			name:      "empty path skips check",
+			setupPath: func(*testing.T) string { return "" },
+		},
+		{
+			name:      "cuda ordinal zero is accepted without stat",
+			setupPath: func(*testing.T) string { return "0" },
+		},
+		{
+			name:      "cuda ordinal nonzero is accepted without stat",
+			setupPath: func(*testing.T) string { return "1" },
+		},
+		{
+			name: "missing path errors and names the path",
+			setupPath: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "renderD128")
+			},
+			errSubstrings: []string{"MEDIA_HARDWARE_DEVICE_PATH", "renderD128"},
+			errFunc:       require.Error,
+		},
+		{
+			name: "regular file errors with not a character device",
+			setupPath: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "regular")
+				f, err := os.Create(p)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				return p
+			},
+			errSubstrings: []string{"MEDIA_HARDWARE_DEVICE_PATH", "not a character device"},
+			errFunc:       require.Error,
+		},
+		{
+			name: "valid character device is accepted",
+			setupPath: func(t *testing.T) string {
+				const devNull = "/dev/null"
+
+				info, err := os.Stat(devNull)
+				if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+					t.Skipf("requires /dev/null as a character device on the test host (stat err=%v); rerun on a Unix host where /dev/null is a char device", err)
+				}
+
+				return devNull
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errFunc := test.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			err := validateHardwareDevicePath(test.setupPath(t))
+			errFunc(t, err)
+
+			if err != nil {
+				for _, errSubstring := range test.errSubstrings {
+					assert.Contains(t, err.Error(), errSubstring)
+				}
+			}
+		})
+	}
 }
 
 func TestParseTimeout(t *testing.T) {


### PR DESCRIPTION
Fixes #183

## Summary
- Add `validateHardwareDevicePath` to `cmd/worker/main.go` and call it in `run()` before constructing the activity config, so a typo like `MEDIA_HARDWARE_DEVICE_PATH=/dev/dri/render128` is rejected at startup instead of after a workflow has already been dispatched.
- Skip the path check when the value parses as a non-negative decimal integer — `MEDIA_HARDWARE_DEVICE_PATH` is overloaded and NVENC takes a CUDA ordinal (`"0"`, `"1"`, ...) per `docs/hardware-acceleration.md:25`. We can't tell which backend FFmpeg will pick at startup, so the integer form is treated as "not a path" rather than rejected as a missing file.
- Empty values still skip the check, preserving today's library auto-select behaviour.

## Test plan
- [x] `make build`
- [x] `make test` (new `TestValidateHardwareDevicePath` covers empty, two ordinal forms, missing path, regular file, and `/dev/null` char device)
- [x] `make lint`