### PR TITLE
fix(ffmpeg): read packet pts before WriteInterleavedFrame consumes it

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -66,13 +66,18 @@ func (css *copyStreamState) setupEncoder(_ HWAccel, _ *astiav.FormatContext) err
 func (css *copyStreamState) encoderContext() *astiav.CodecContext                  { return nil }
 
 func (css *copyStreamState) processPacket(packet *astiav.Packet, outputFmt *astiav.FormatContext, progressCh chan<- Progress, totalDuration int64) error {
-	if err := remuxPacket(packet, css.inStream, css.outStream, outputFmt); err != nil {
-		return err
-	}
+	packet.RescaleTs(css.inStream.TimeBase(), css.outStream.TimeBase())
+	packet.SetStreamIndex(css.outStream.Index())
 
 	css.frames++
+	// sendProgress must read packet.Pts() before WriteInterleavedFrame, which
+	// takes ownership of the packet and zeroes its fields.
 	if progressCh != nil {
 		sendProgress(progressCh, css.frames, packet, css.outStream, totalDuration)
+	}
+
+	if err := outputFmt.WriteInterleavedFrame(packet); err != nil {
+		return fmt.Errorf("ffmpeg: writing remuxed packet for stream %d: %w", css.outStream.Index(), err)
 	}
 
 	return nil
@@ -111,18 +116,6 @@ func (css *copyStreamState) receiveAndWritePackets(encCtx *astiav.CodecContext, 
 
 		encPkt.Unref()
 	}
-}
-
-// remuxPacket copies a packet directly to the output without decoding/encoding.
-func remuxPacket(packet *astiav.Packet, inStream, outStream *astiav.Stream, outputFmt *astiav.FormatContext) error {
-	packet.RescaleTs(inStream.TimeBase(), outStream.TimeBase())
-	packet.SetStreamIndex(outStream.Index())
-
-	if err := outputFmt.WriteInterleavedFrame(packet); err != nil {
-		return fmt.Errorf("ffmpeg: writing remuxed packet for stream %d: %w", outStream.Index(), err)
-	}
-
-	return nil
 }
 
 // sendProgress emits a non-blocking progress update on ch.

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -181,7 +181,7 @@ func TestTranscode_HWAccelAuto(t *testing.T) {
 // received on the provided channel.
 func TestTranscode_ProgressChannel(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "out.mkv")
-	progressCh := make(chan ffmpeg.Progress, 256)
+	progressCh := make(chan ffmpeg.Progress, 4096)
 
 	err := ffmpeg.NewTranscode(testVideoPath, output).
 		ToVideoCodec(ffmpeg.CodecH265).
@@ -203,6 +203,23 @@ func TestTranscode_ProgressChannel(t *testing.T) {
 		assert.GreaterOrEqual(t, p.FramesProcessed, int64(1))
 		assert.GreaterOrEqual(t, p.PercentComplete, float64(0))
 		assert.LessOrEqual(t, p.PercentComplete, float64(100))
+	}
+
+	// After progress has reached a substantial fraction of the file, no
+	// subsequent update should report 0% — that indicates the sender read
+	// pts from a packet whose data had already been consumed (e.g. by
+	// av_interleaved_write_frame, which takes ownership of the packet).
+	maxSeen := 0.0
+	for _, p := range updates {
+		if p.PercentComplete > maxSeen {
+			maxSeen = p.PercentComplete
+		}
+
+		if maxSeen >= 50 {
+			assert.NotEqual(t, float64(0), p.PercentComplete,
+				"progress dropped back to 0%% after reaching %.2f%% (frames=%d) — likely reading pts from a consumed packet",
+				maxSeen, p.FramesProcessed)
+		}
 	}
 }
 

--- a/pkg/ffmpeg/transcode_test.go
+++ b/pkg/ffmpeg/transcode_test.go
@@ -210,15 +210,15 @@ func TestTranscode_ProgressChannel(t *testing.T) {
 	// pts from a packet whose data had already been consumed (e.g. by
 	// av_interleaved_write_frame, which takes ownership of the packet).
 	maxSeen := 0.0
-	for _, p := range updates {
-		if p.PercentComplete > maxSeen {
-			maxSeen = p.PercentComplete
+	for _, update := range updates {
+		if update.PercentComplete > maxSeen {
+			maxSeen = update.PercentComplete
 		}
 
 		if maxSeen >= 50 {
-			assert.NotEqual(t, float64(0), p.PercentComplete,
+			assert.NotEqual(t, float64(0), update.PercentComplete,
 				"progress dropped back to 0%% after reaching %.2f%% (frames=%d) — likely reading pts from a consumed packet",
-				maxSeen, p.FramesProcessed)
+				maxSeen, update.FramesProcessed)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `copyStreamState.processPacket` called `sendProgress` after `remuxPacket`, which invokes `av_interleaved_write_frame`. That function takes ownership of the packet and zeroes its fields, so `sendProgress` read `packet.Pts()` from a consumed packet, the percent calculation produced a huge negative, and the `(< 0 -> 0)` clamp emitted `Progress{PercentComplete: 0}`. In the workflow's progress goroutine each received update overwrites `latest`, so a single bad event from a copy stream blanked the previously-good percentage and the next ticker tick logged `percent_complete=0` between two non-zero entries — exactly the symptom reported in the e2e logs.
- Bug introduced by #117 (added `sendProgress` to copy streams but placed it after `remuxPacket`). The encoder path was already correct.
- Fix: in `copyStreamState.processPacket`, do `RescaleTs` + `SetStreamIndex` first, send progress while `packet.Pts()` is still valid, then call `WriteInterleavedFrame`. Removed the now-single-use `remuxPacket` helper.
- Strengthened `TestTranscode_ProgressChannel` to assert no progress event reports 0% after progress has crossed 50%. Without the fix it fails (`progress dropped back to 0% after reaching 73.96% (frames=235)`); with the fix it passes.

## Test plan

- [x] `go test ./pkg/ffmpeg/...`
- [x] `go test ./workflows/media/...`
- [x] `make lint`
- [x] Confirmed regression test fails on master and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)