### PR TITLE
include downloadClientId in Sonarr DownloadedEpisodesScan to clear download queue

### DIFF
--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -90,15 +90,54 @@ func (c *Client) GetInfo(ctx context.Context, path string) (medialib.MediaInfo, 
 	return c.getEpisodeByFilePath(ctx, path)
 }
 
+// findTrackedDownloadID returns the download client's native ID for the pending
+// tracked download that corresponds to the episode at path, or "" if none is
+// found. API errors are treated as "no match" so callers always get a safe
+// fallback.
+func (c *Client) findTrackedDownloadID(ctx context.Context, path string) string {
+	episode, err := c.getEpisodeByFilePath(ctx, path)
+	if err != nil {
+		return ""
+	}
+
+	queue, err := c.sonarr.GetQueueContext(ctx, 0, 100)
+	if err != nil {
+		return ""
+	}
+
+	for _, record := range queue.Records {
+		if record.EpisodeID == 0 || record.EpisodeID != episode.GetID() {
+			continue
+		}
+		// Skip records already marked imported — Sonarr completed this on its own.
+		if strings.EqualFold(record.TrackedDownloadState, "imported") {
+			continue
+		}
+		if record.DownloadID == "" {
+			continue
+		}
+		return record.DownloadID
+	}
+
+	return ""
+}
+
 // ImportByFilePath implements medialib.ArrLibrary. It sends a DownloadedEpisodesScan command
 // for path, causing Sonarr to import the file at path into the library.
+// When a pending tracked download for the episode is found in the queue, its
+// download client ID is included so Sonarr calls VerifyImport and removes the
+// item from the downloads queue.
 func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
+	downloadClientID := c.findTrackedDownloadID(ctx, path)
+
 	requestPayload := struct {
-		Name string `json:"name"`
-		Path string `json:"path"`
+		Name             string `json:"name"`
+		Path             string `json:"path"`
+		DownloadClientId string `json:"downloadClientId,omitempty"`
 	}{
-		Name: "DownloadedEpisodesScan",
-		Path: path,
+		Name:             "DownloadedEpisodesScan",
+		Path:             path,
+		DownloadClientId: downloadClientID,
 	}
 
 	var body bytes.Buffer

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -100,23 +100,32 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, path string) string 
 		return ""
 	}
 
-	queue, err := c.sonarr.GetQueueContext(ctx, 0, 100)
-	if err != nil {
-		return ""
-	}
+	const pageSize = 100
 
-	for _, record := range queue.Records {
-		if record.EpisodeID == 0 || record.EpisodeID != episode.GetID() {
-			continue
+	for page, fetched := 1, 0; ; page++ {
+		curr, err := c.sonarr.GetQueuePageContext(ctx, &starr.PageReq{PageSize: pageSize, Page: page})
+		if err != nil {
+			return ""
 		}
-		// Skip records already marked imported — Sonarr completed this on its own.
-		if strings.EqualFold(record.TrackedDownloadState, "imported") {
-			continue
+
+		for _, record := range curr.Records {
+			if record.EpisodeID == 0 || record.EpisodeID != episode.GetID() {
+				continue
+			}
+			// Skip records already marked imported — Sonarr completed this on its own.
+			if strings.EqualFold(record.TrackedDownloadState, "imported") {
+				continue
+			}
+			if record.DownloadID == "" {
+				continue
+			}
+			return record.DownloadID
 		}
-		if record.DownloadID == "" {
-			continue
+
+		fetched += len(curr.Records)
+		if fetched >= curr.TotalRecords || len(curr.Records) == 0 {
+			break
 		}
-		return record.DownloadID
 	}
 
 	return ""

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,9 +24,10 @@ const unreachableURL = "http://127.0.0.1:1"
 // sonarrTestServerConfig holds configuration for test HTTP servers.
 type sonarrTestServerConfig struct {
 	parseResp       *sonarrlib.ParseOutput
-	seriesByID      *sonarrlib.Series // response for /api/v3/series/{id}
-	queueResp       *sonarrlib.Queue  // response for /api/v3/queue; nil returns empty queue
-	queueHTTPStatus int               // override HTTP status for /api/v3/queue; 0 means 200
+	seriesByID      *sonarrlib.Series  // response for /api/v3/series/{id}
+	queueResp       *sonarrlib.Queue   // single-page queue response; nil returns empty queue
+	queuePages      []*sonarrlib.Queue // multi-page queue responses; index 0 = page 1; takes priority over queueResp
+	queueHTTPStatus int                // override HTTP status for /api/v3/queue; 0 means 200
 	imageBody       []byte
 	imageType       string
 	// onCommand is called with the raw command request when /api/v3/command is hit.
@@ -62,14 +64,31 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 
-		if status == http.StatusOK {
-			q := cfg.queueResp
+		if status != http.StatusOK {
+			return
+		}
+
+		var q *sonarrlib.Queue
+
+		if cfg.queuePages != nil {
+			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			if page < 1 {
+				page = 1
+			}
+
+			if page-1 < len(cfg.queuePages) {
+				q = cfg.queuePages[page-1]
+			} else {
+				q = &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{}}
+			}
+		} else {
+			q = cfg.queueResp
 			if q == nil {
 				q = &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{}}
 			}
-
-			require.NoError(t, json.NewEncoder(w).Encode(q))
 		}
+
+		require.NoError(t, json.NewEncoder(w).Encode(q))
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
@@ -124,6 +143,7 @@ func TestImportByFilePath(t *testing.T) {
 		path                 string
 		parseResp            *sonarrlib.ParseOutput
 		queueResp            *sonarrlib.Queue
+		queuePages           []*sonarrlib.Queue
 		queueHTTPStatus      int
 		wantCmdName          string
 		wantCmdPath          string
@@ -175,6 +195,27 @@ func TestImportByFilePath(t *testing.T) {
 			wantCmdName:     "DownloadedEpisodesScan",
 			wantCmdPath:     "/tv/Breaking.Bad.S01E01.mkv",
 		},
+		{
+			// Match found on second page: verifies pagination terminates early on hit.
+			name:      "match on second queue page: downloadClientId from second page included",
+			path:      "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp: episodeParseOutput,
+			queuePages: []*sonarrlib.Queue{
+				{
+					TotalRecords: 2,
+					Records: []*sonarrlib.QueueRecord{
+						{ID: 99, EpisodeID: 999, DownloadID: "nzb-other", TrackedDownloadState: "importPending"},
+					},
+				},
+				{
+					TotalRecords: 2,
+					Records:      []*sonarrlib.QueueRecord{pendingRecord},
+				},
+			},
+			wantCmdName:          "DownloadedEpisodesScan",
+			wantCmdPath:          "/tv/Breaking.Bad.S01E01.mkv",
+			wantDownloadClientID: "nzb-abc123",
+		},
 	}
 
 	for _, tc := range tests {
@@ -188,6 +229,7 @@ func TestImportByFilePath(t *testing.T) {
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
 				parseResp:       tc.parseResp,
 				queueResp:       tc.queueResp,
+				queuePages:      tc.queuePages,
 				queueHTTPStatus: tc.queueHTTPStatus,
 				onCommand: func(t *testing.T, r *http.Request) {
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&gotCmd))

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -22,10 +22,12 @@ const unreachableURL = "http://127.0.0.1:1"
 
 // sonarrTestServerConfig holds configuration for test HTTP servers.
 type sonarrTestServerConfig struct {
-	parseResp  *sonarrlib.ParseOutput
-	seriesByID *sonarrlib.Series // response for /api/v3/series/{id}
-	imageBody  []byte
-	imageType  string
+	parseResp       *sonarrlib.ParseOutput
+	seriesByID      *sonarrlib.Series // response for /api/v3/series/{id}
+	queueResp       *sonarrlib.Queue  // response for /api/v3/queue; nil returns empty queue
+	queueHTTPStatus int               // override HTTP status for /api/v3/queue; 0 means 200
+	imageBody       []byte
+	imageType       string
 	// onCommand is called with the raw command request when /api/v3/command is hit.
 	onCommand func(t *testing.T, r *http.Request)
 	// onParse is called with the raw parse request when /api/v3/parse is hit.
@@ -49,6 +51,25 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(cfg.parseResp))
+	})
+
+	mux.HandleFunc("/api/v3/queue", func(w http.ResponseWriter, r *http.Request) {
+		status := cfg.queueHTTPStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+
+		if status == http.StatusOK {
+			q := cfg.queueResp
+			if q == nil {
+				q = &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{}}
+			}
+
+			require.NoError(t, json.NewEncoder(w).Encode(q))
+		}
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
@@ -79,29 +100,95 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 }
 
 func TestImportByFilePath(t *testing.T) {
+	episodeParseOutput := &sonarrlib.ParseOutput{
+		Title: "Breaking Bad",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Breaking Bad",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
+		},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+		},
+	}
+
+	pendingRecord := &sonarrlib.QueueRecord{
+		ID:                   1,
+		EpisodeID:            200,
+		DownloadID:           "nzb-abc123",
+		TrackedDownloadState: "importPending",
+	}
+
 	tests := []struct {
-		name        string
-		path        string
-		wantCmdName string
-		wantCmdPath string
-		errFunc     require.ErrorAssertionFunc
+		name                 string
+		path                 string
+		parseResp            *sonarrlib.ParseOutput
+		queueResp            *sonarrlib.Queue
+		queueHTTPStatus      int
+		wantCmdName          string
+		wantCmdPath          string
+		wantDownloadClientID string
+		errFunc              require.ErrorAssertionFunc
 	}{
 		{
-			name:        "sends DownloadedEpisodesScan with the given path",
+			name:                 "pending queue record found: downloadClientId included in command",
+			path:                 "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp:            episodeParseOutput,
+			queueResp:            &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{pendingRecord}},
+			wantCmdName:          "DownloadedEpisodesScan",
+			wantCmdPath:          "/tv/Breaking.Bad.S01E01.mkv",
+			wantDownloadClientID: "nzb-abc123",
+		},
+		{
+			name:        "episode unrecognized: command sent without downloadClientId",
 			path:        "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp:   &sonarrlib.ParseOutput{},
+			queueResp:   &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{pendingRecord}},
 			wantCmdName: "DownloadedEpisodesScan",
 			wantCmdPath: "/tv/Breaking.Bad.S01E01.mkv",
+		},
+		{
+			name:        "no matching queue record: command sent without downloadClientId",
+			path:        "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp:   episodeParseOutput,
+			queueResp:   &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{}},
+			wantCmdName: "DownloadedEpisodesScan",
+			wantCmdPath: "/tv/Breaking.Bad.S01E01.mkv",
+		},
+		{
+			// Sonarr already imported the episode on its own before we scanned.
+			name:      "queue record already imported: command sent without downloadClientId",
+			path:      "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp: episodeParseOutput,
+			queueResp: &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{
+				{ID: 1, EpisodeID: 200, DownloadID: "nzb-abc123", TrackedDownloadState: "imported"},
+			}},
+			wantCmdName: "DownloadedEpisodesScan",
+			wantCmdPath: "/tv/Breaking.Bad.S01E01.mkv",
+		},
+		{
+			// Queue API unreachable: fall back gracefully rather than blocking the import.
+			name:            "queue API error: command sent without downloadClientId",
+			path:            "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp:       episodeParseOutput,
+			queueHTTPStatus: http.StatusInternalServerError,
+			wantCmdName:     "DownloadedEpisodesScan",
+			wantCmdPath:     "/tv/Breaking.Bad.S01E01.mkv",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotCmd struct {
-				Name string `json:"name"`
-				Path string `json:"path"`
+				Name             string `json:"name"`
+				Path             string `json:"path"`
+				DownloadClientId string `json:"downloadClientId"`
 			}
 
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+				parseResp:       tc.parseResp,
+				queueResp:       tc.queueResp,
+				queueHTTPStatus: tc.queueHTTPStatus,
 				onCommand: func(t *testing.T, r *http.Request) {
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&gotCmd))
 				},
@@ -122,6 +209,7 @@ func TestImportByFilePath(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, tc.wantCmdName, gotCmd.Name)
 				assert.Equal(t, tc.wantCmdPath, gotCmd.Path)
+				assert.Equal(t, tc.wantDownloadClientID, gotCmd.DownloadClientId)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Sonarr downloads were permanently stuck in the queue with `importPending` state after the media processor imported them. Root cause: without `downloadClientId` in the `DownloadedEpisodesScan` command, Sonarr treats the scan as a plain manual import and never calls `VerifyImport`, so the tracked download is never marked `Imported`.
- Added `findTrackedDownloadID` to look up the pending tracked download from Sonarr's queue by matching the parsed episode ID, then include its `downloadClientId` in the command so Sonarr calls `VerifyImport` and clears the queue entry.
- Handles the race where Sonarr auto-imports the file on its own: if the queue record is gone, already `imported`, or the queue API fails, the code falls back to the existing behavior (no `downloadClientId`) rather than erroring.

## How it works

Before sending `DownloadedEpisodesScan`, the client now:
1. Calls Sonarr's `/api/v3/parse` endpoint to identify the episode from the output filename
2. Fetches `/api/v3/queue` and finds the record matching that episode ID whose state is not `imported`
3. Includes that record's `downloadId` as `downloadClientId` in the scan command

When `downloadClientId` is present, Sonarr's `DownloadedEpisodesCommandService` calls `CompletedDownloadService.VerifyImport`, which marks the download `Imported` and fires the `DownloadCompletedEvent` that removes it from the queue.

## Race condition handling

- **Queue record already gone** (Sonarr imported on its own between transcode finish and our scan): `findTrackedDownloadID` returns `""`, scan proceeds without `downloadClientId` — harmless, episode is already in the library.
- **Sonarr imports between our queue lookup and our scan**: we still have `downloadClientId`; Sonarr calls `VerifyImport` which finds the import in history and returns `Imported` — correct.
- **Queue API error**: treated as no-match, falls back to the old behavior rather than blocking the import.

## Test plan

- `TestImportByFilePath` expanded with five table cases covering: pending record found (downloadClientId sent), episode unrecognized (omitted), no matching record (omitted), record already imported (omitted), queue API error (omitted).
- `make test` passes with `-race`.