### PR TITLE
feat(watcher): use human-readable Temporal WorkflowID format

### DIFF
--- a/cmd/watcher/integration_test.go
+++ b/cmd/watcher/integration_test.go
@@ -103,7 +103,7 @@ func TestMultiWatcherDedup_OnlyOneWorkflowPerFile(t *testing.T) {
 	err = dispatch(t.Context(), input)
 	require.ErrorIs(t, err, errWorkflowAlreadyStarted, "second dispatch should be deduplicated")
 
-	wfID := workflowID(filePath)
+	wfID := workflowID(input)
 
 	t.Cleanup(func() {
 		_ = c.TerminateWorkflow(context.Background(), wfID, "", "test cleanup")

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -132,8 +132,10 @@ const workflowIDShortHashLen = 12
 // sha256(absFilePath). Determinism and collision resistance are anchored on
 // the full absolute path, so two paths with the same basename still produce
 // distinct IDs. If the assembled ID would exceed Temporal's 1000-char limit,
-// the basename segment is right-truncated by exactly the overflow amount so
-// the trailing "-{shortHash}" segment is preserved unchanged.
+// basename is trimmed first so the operator-configured mapping name stays
+// visible; only when mapping alone would exceed the budget does mapping get
+// trimmed too. The trailing "-{shortHash}" segment is always preserved
+// unchanged.
 func workflowID(input mediatypes.MediaInput) string {
 	sum := sha256.Sum256([]byte(input.FilePath))
 	shortHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
@@ -141,20 +143,19 @@ func workflowID(input mediatypes.MediaInput) string {
 	mapping := sanitizeWorkflowIDSegment(input.MappingName, false)
 	basename := sanitizeWorkflowIDSegment(filepath.Base(input.FilePath), true)
 
-	suffix := "-" + shortHash
-
-	id := mapping + "-" + basename + suffix
-	if overflow := len(id) - workflowIDMaxLen; overflow > 0 {
-		if overflow >= len(basename) {
+	// Two literal "-" separators plus the hash are the fixed overhead; the
+	// remaining budget is shared between mapping and basename.
+	budget := workflowIDMaxLen - (2 + workflowIDShortHashLen)
+	if len(mapping)+len(basename) > budget {
+		if len(mapping) >= budget {
+			mapping = mapping[:budget]
 			basename = ""
 		} else {
-			basename = basename[:len(basename)-overflow]
+			basename = basename[:budget-len(mapping)]
 		}
-
-		id = mapping + "-" + basename + suffix
 	}
 
-	return id
+	return mapping + "-" + basename + "-" + shortHash
 }
 
 // workflowIDSegmentInvalid matches any run of characters that should be

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -156,39 +157,19 @@ func workflowID(input mediatypes.MediaInput) string {
 	return id
 }
 
-// sanitizeWorkflowIDSegment restricts s to [A-Za-z0-9._-], replacing any other
-// rune with "_" and collapsing adjacent underscores. When stripLeadingDots is
-// true, leading dots are also removed so a sanitized hidden filename does not
-// produce an ID that resembles a sentinel file.
+// workflowIDSegmentInvalid matches any run of characters that should be
+// replaced by a single "_" in a sanitized WorkflowID segment: anything outside
+// [A-Za-z0-9.-]. Treating "_" as part of the run (rather than allowed) is what
+// gives us the "adjacent underscores collapsed" behaviour for free, since runs
+// of input underscores are matched and replaced by exactly one "_".
+var workflowIDSegmentInvalid = regexp.MustCompile(`[^A-Za-z0-9.-]+`)
+
+// sanitizeWorkflowIDSegment restricts s to [A-Za-z0-9._-], replacing any run
+// of disallowed characters (or input underscores) with a single "_". When
+// stripLeadingDots is true, leading dots are also removed so a sanitized
+// hidden filename does not produce an ID that resembles a sentinel file.
 func sanitizeWorkflowIDSegment(s string, stripLeadingDots bool) string {
-	var b strings.Builder
-	b.Grow(len(s))
-
-	var prevUnderscore bool
-
-	for _, r := range s {
-		allowed := (r >= 'A' && r <= 'Z') ||
-			(r >= 'a' && r <= 'z') ||
-			(r >= '0' && r <= '9') ||
-			r == '.' || r == '_' || r == '-'
-		if !allowed {
-			r = '_'
-		}
-
-		if r == '_' {
-			if prevUnderscore {
-				continue
-			}
-
-			prevUnderscore = true
-		} else {
-			prevUnderscore = false
-		}
-
-		b.WriteRune(r)
-	}
-
-	out := b.String()
+	out := workflowIDSegmentInvalid.ReplaceAllString(s, "_")
 	if stripLeadingDots {
 		out = strings.TrimLeft(out, ".")
 	}

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -112,13 +112,88 @@ func newScanInstruments(reg prometheus.Registerer) (*scanInstruments, error) {
 	}, nil
 }
 
-// workflowID derives the deterministic Temporal WorkflowID for a media file from its
-// absolute path. The full SHA-256 hex digest (64 chars + "media-" prefix = 70 chars
-// total) is well within Temporal's 1000-char WorkflowID limit and removes any
-// realistic risk of two different paths colliding into the same ID.
-func workflowID(absFilePath string) string {
-	sum := sha256.Sum256([]byte(absFilePath))
-	return "media-" + hex.EncodeToString(sum[:])
+// workflowIDMaxLen is Temporal's hard cap on WorkflowID length. workflowID()
+// truncates the basename segment to keep the overall ID within this bound.
+const workflowIDMaxLen = 1000
+
+// workflowIDShortHashLen is the number of hex characters (48 bits) taken from
+// the head of sha256(absFilePath) for the trailing hash segment. Enough
+// collision resistance for a per-host watcher while keeping the ID short and
+// scannable in the Temporal Web UI.
+const workflowIDShortHashLen = 12
+
+// workflowID derives a human-readable, deterministic Temporal WorkflowID for a
+// media file. The format is "{mappingName}-{basename}-{shortHash}" where
+// mappingName and basename are sanitized so only [A-Za-z0-9._-] survive
+// (anything else replaced by "_", adjacent underscores collapsed; the basename
+// also has leading dots stripped so a sanitized hidden file does not look like
+// a sentinel) and shortHash is the first 12 hex characters of
+// sha256(absFilePath). Determinism and collision resistance are anchored on
+// the full absolute path, so two paths with the same basename still produce
+// distinct IDs. If the assembled ID would exceed Temporal's 1000-char limit,
+// the basename segment is right-truncated by exactly the overflow amount so
+// the trailing "-{shortHash}" segment is preserved unchanged.
+func workflowID(input mediatypes.MediaInput) string {
+	sum := sha256.Sum256([]byte(input.FilePath))
+	shortHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
+
+	mapping := sanitizeWorkflowIDSegment(input.MappingName, false)
+	basename := sanitizeWorkflowIDSegment(filepath.Base(input.FilePath), true)
+
+	suffix := "-" + shortHash
+
+	id := mapping + "-" + basename + suffix
+	if overflow := len(id) - workflowIDMaxLen; overflow > 0 {
+		if overflow >= len(basename) {
+			basename = ""
+		} else {
+			basename = basename[:len(basename)-overflow]
+		}
+
+		id = mapping + "-" + basename + suffix
+	}
+
+	return id
+}
+
+// sanitizeWorkflowIDSegment restricts s to [A-Za-z0-9._-], replacing any other
+// rune with "_" and collapsing adjacent underscores. When stripLeadingDots is
+// true, leading dots are also removed so a sanitized hidden filename does not
+// produce an ID that resembles a sentinel file.
+func sanitizeWorkflowIDSegment(s string, stripLeadingDots bool) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	var prevUnderscore bool
+
+	for _, r := range s {
+		allowed := (r >= 'A' && r <= 'Z') ||
+			(r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') ||
+			r == '.' || r == '_' || r == '-'
+		if !allowed {
+			r = '_'
+		}
+
+		if r == '_' {
+			if prevUnderscore {
+				continue
+			}
+
+			prevUnderscore = true
+		} else {
+			prevUnderscore = false
+		}
+
+		b.WriteRune(r)
+	}
+
+	out := b.String()
+	if stripLeadingDots {
+		out = strings.TrimLeft(out, ".")
+	}
+
+	return out
 }
 
 // newTemporalDispatch returns a dispatchFunc that calls ExecuteWorkflow on the given
@@ -145,7 +220,7 @@ func workflowID(absFilePath string) string {
 func newTemporalDispatch(c client.Client, taskQueue string) dispatchFunc {
 	return func(ctx context.Context, input mediatypes.MediaInput) error {
 		options := client.StartWorkflowOptions{
-			ID:                                       workflowID(input.FilePath),
+			ID:                                       workflowID(input),
 			TaskQueue:                                taskQueue,
 			WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 			WorkflowIDConflictPolicy:                 enums.WORKFLOW_ID_CONFLICT_POLICY_FAIL,

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -772,6 +772,24 @@ func TestWorkflowID_LengthCapPreservesHash(t *testing.T) {
 	assert.True(t, strings.HasSuffix(id, "-"+expectedHash), "short hash suffix must be preserved unchanged")
 }
 
+// TestWorkflowID_LengthCapTrimsMappingWhenItAloneOverflows verifies that when
+// the mapping name alone is already long enough to overflow the 1000-char
+// cap, mapping is also trimmed (after basename is fully consumed) so the
+// resulting ID still fits and the trailing -{shortHash} suffix survives.
+func TestWorkflowID_LengthCapTrimsMappingWhenItAloneOverflows(t *testing.T) {
+	t.Parallel()
+
+	longMapping := strings.Repeat("m", 2000)
+	path := "/watch/x/movie.mkv"
+	id := workflowID(mediatypes.MediaInput{FilePath: path, MappingName: longMapping})
+
+	sum := sha256.Sum256([]byte(path))
+	expectedHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
+
+	assert.LessOrEqual(t, len(id), workflowIDMaxLen, "ID must respect the 1000-char cap even when mapping alone overflows")
+	assert.True(t, strings.HasSuffix(id, "-"+expectedHash), "short hash suffix must be preserved unchanged")
+}
+
 // TestScan_PreserveSourceForwardedToDispatch verifies that the preserveSource value from a
 // WatchEntry is forwarded verbatim to the dispatch callback for each discovered file.
 func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -665,19 +668,108 @@ func TestScan_AlreadyStartedNotCountedAsDispatchOrError(t *testing.T) {
 	assert.EqualValues(t, 1, m.GetCounter().GetValue())
 }
 
-// TestWorkflowID_DeterministicAndPathSensitive verifies that workflowID is stable for
-// the same path across calls and produces a different ID for a different path.
+// TestWorkflowID_DeterministicAndPathSensitive verifies that workflowID is
+// stable for the same input across calls and produces a different ID for two
+// paths whose basenames are identical but whose absolute paths differ.
 func TestWorkflowID_DeterministicAndPathSensitive(t *testing.T) {
 	t.Parallel()
 
-	a := workflowID("/watch/movies/movie.mkv")
-	b := workflowID("/watch/movies/movie.mkv")
-	c := workflowID("/watch/movies/other.mkv")
+	a := workflowID(mediatypes.MediaInput{FilePath: "/watch/movies/movie.mkv", MappingName: "movies"})
+	b := workflowID(mediatypes.MediaInput{FilePath: "/watch/movies/movie.mkv", MappingName: "movies"})
+	sameBasename := workflowID(mediatypes.MediaInput{FilePath: "/watch/other/movie.mkv", MappingName: "movies"})
 
-	assert.Equal(t, a, b, "same path should produce the same WorkflowID")
-	assert.NotEqual(t, a, c, "different paths should produce different WorkflowIDs")
-	assert.True(t, len(a) > 0 && len(a) < 1000, "WorkflowID should be non-empty and within Temporal's length limits")
-	assert.Contains(t, a, "media-", "WorkflowID should carry the media- prefix for UI readability")
+	assert.Equal(t, a, b, "same input should produce the same WorkflowID")
+	assert.NotEqual(t, a, sameBasename, "different absolute paths should produce different WorkflowIDs even when basenames match")
+}
+
+// TestWorkflowID_Format verifies that the WorkflowID has the structure
+// "{mappingName}-{basename}-{shortHash}" with a 12-hex-character hash derived
+// from the absolute path.
+func TestWorkflowID_Format(t *testing.T) {
+	t.Parallel()
+
+	path := "/watch/movies/movie.mkv"
+	id := workflowID(mediatypes.MediaInput{FilePath: path, MappingName: "movies"})
+
+	sum := sha256.Sum256([]byte(path))
+	expectedHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
+
+	assert.Equal(t, "movies-movie.mkv-"+expectedHash, id)
+	assert.LessOrEqual(t, len(id), workflowIDMaxLen)
+}
+
+// TestWorkflowID_BasenameSanitization verifies that characters outside
+// [A-Za-z0-9._-] in the basename are replaced with underscores, adjacent
+// underscores are collapsed, and leading dots are stripped.
+func TestWorkflowID_BasenameSanitization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		path             string
+		expectedBasename string
+	}{
+		{name: "spaces and brackets", path: "/watch/show/Show Title (S01E01) [1080p].mkv", expectedBasename: "Show_Title_S01E01_1080p_.mkv"},
+		{name: "unicode runes replaced", path: "/watch/show/résumé.mkv", expectedBasename: "r_sum_.mkv"},
+		{name: "leading dots stripped", path: "/watch/show/.hidden.mkv", expectedBasename: "hidden.mkv"},
+		{name: "adjacent specials collapse", path: "/watch/show/a   b.mkv", expectedBasename: "a_b.mkv"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			id := workflowID(mediatypes.MediaInput{FilePath: test.path, MappingName: "show"})
+
+			sum := sha256.Sum256([]byte(test.path))
+			expectedHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
+			assert.Equal(t, "show-"+test.expectedBasename+"-"+expectedHash, id)
+		})
+	}
+}
+
+// TestWorkflowID_MappingNameSanitization verifies that characters outside
+// [A-Za-z0-9._-] in the mapping name are replaced with underscores and
+// adjacent underscores are collapsed.
+func TestWorkflowID_MappingNameSanitization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		mappingName     string
+		expectedMapping string
+	}{
+		{name: "space replaced", mappingName: "my movies", expectedMapping: "my_movies"},
+		{name: "punctuation collapsed", mappingName: "my!@#movies", expectedMapping: "my_movies"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			id := workflowID(mediatypes.MediaInput{FilePath: "/watch/x/movie.mkv", MappingName: test.mappingName})
+			assert.True(t, strings.HasPrefix(id, test.expectedMapping+"-"), "expected sanitized mapping segment %q at start of %q", test.expectedMapping, id)
+		})
+	}
+}
+
+// TestWorkflowID_LengthCapPreservesHash verifies that when the assembled ID
+// would exceed Temporal's 1000-character WorkflowID limit, the basename
+// segment is truncated while the trailing -{shortHash} suffix is preserved
+// unchanged.
+func TestWorkflowID_LengthCapPreservesHash(t *testing.T) {
+	t.Parallel()
+
+	longBasename := strings.Repeat("a", 2000) + ".mkv"
+	path := "/watch/movies/" + longBasename
+	id := workflowID(mediatypes.MediaInput{FilePath: path, MappingName: "movies"})
+
+	sum := sha256.Sum256([]byte(path))
+	expectedHash := hex.EncodeToString(sum[:])[:workflowIDShortHashLen]
+
+	assert.Equal(t, workflowIDMaxLen, len(id), "ID should be truncated to exactly the cap")
+	assert.True(t, strings.HasPrefix(id, "movies-"), "mapping prefix must be preserved")
+	assert.True(t, strings.HasSuffix(id, "-"+expectedHash), "short hash suffix must be preserved unchanged")
 }
 
 // TestScan_PreserveSourceForwardedToDispatch verifies that the preserveSource value from a


### PR DESCRIPTION
Fixes #194

## Summary

Replaces the opaque `media-{full sha256}` Temporal WorkflowID with a scannable `{sanitizedMappingName}-{sanitizedBasename}-{shortHash}` form so operators can recognise and substring-filter runs in the Temporal Web UI. Determinism and collision-resistance are preserved via a 12-hex-character prefix of `sha256(absFilePath)`.

## Changes

- `cmd/watcher/watcher.go`: `workflowID` now takes `mediatypes.MediaInput` (not `absFilePath`) and assembles the new format. A new `sanitizeWorkflowIDSegment` helper restricts segments to `[A-Za-z0-9._-]`, replaces other runes with `_`, collapses adjacent `_`, and strips leading dots from the basename so sanitized hidden files don't look like sentinel files. If the assembled ID would exceed 1000 chars, the basename is right-truncated by exactly the overflow so the trailing `-{shortHash}` suffix survives intact.
- `cmd/watcher/watcher_test.go`: replaces the old `media-` prefix assertion with focused tests covering format, idempotency, basename sanitization, mapping-name sanitization, and the 1000-character length cap.
- `cmd/watcher/integration_test.go`: updates the single existing call site to pass `MediaInput` instead of `filePath`.

The reuse policy (`ALLOW_DUPLICATE`) and conflict policy (`FAIL`) are unchanged.

## Notes

- No docs update: the WorkflowID format is operator-visible only in the Temporal Web UI itself; no existing doc references it and the change introduces no operator-configurable surface.
- New format applies to new dispatches only — existing in-flight or completed runs keep their old IDs (per the issue's Non-Goals).

## Test plan

- [x] `make test` (unit) — `go test ./cmd/watcher/...` passes
- [x] `make vet`
- [x] `make lint`
- [x] `make build`
- [x] `make test-integration` — not run locally; the existing `TestDispatch_DedupesIdenticalFiles_RealTemporal` test continues to use `workflowID(input)` and exercises both dispatch and `DescribeWorkflowExecution` paths against a real Temporal. Run on a host with a Temporal dev stack via `make temporal-up`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workflow identifiers are now deterministic, more readable, and sanitize special characters for greater stability and compatibility.
  * IDs now respect system length limits while preserving distinguishing information and are used consistently for dispatch, cleanup, and verification.
* **Tests**
  * Expanded test coverage validating ID format, sanitization rules, determinism, and length constraints across varied inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->