### PR TITLE
Block on arr command completion and prune empty output dirs

### DIFF
--- a/pkg/medialib/internal/arrcommand/arrcommand.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand.go
@@ -1,0 +1,93 @@
+// Package arrcommand provides shared polling logic for waiting on
+// Sonarr/Radarr long-running commands (e.g. DownloadedEpisodesScan,
+// DownloadedMoviesScan) to reach a terminal state.
+//
+// Both services queue a command and return immediately; the caller polls
+// /api/v3/command/{id} until the command resolves. The classification of
+// terminal states and the unsuccessful-result detection are identical
+// between the two, so the loop lives here and each client supplies a thin
+// fetch closure that knows how to talk to its starr instance.
+package arrcommand
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultPollInterval is used when the caller passes a non-positive interval.
+// Sonarr/Radarr command status updates are inexpensive (a single DB read on
+// the server side), but importing a season pack can serialize many commands
+// in their 3-thread executor — polling too aggressively just adds noise.
+const DefaultPollInterval = 2 * time.Second
+
+// Status is the subset of fields Wait inspects from a command response.
+// Only these three are needed: status drives the terminal-state classification,
+// message is included in error wrapping, and result distinguishes
+// command-completed-but-import-failed from command-completed-and-import-applied.
+type Status struct {
+	// Status is the command lifecycle state (queued, started, completed,
+	// failed, aborted, cancelled, orphaned).
+	Status string
+	// Message is the human-readable note attached to the latest state change.
+	Message string
+	// Result is the command outcome (unknown, successful, unsuccessful).
+	// Sonarr/Radarr set "unsuccessful" when the command itself completed but
+	// no useful work was performed (e.g. an import where every file was
+	// rejected). Empty/Unknown is treated the same as successful.
+	Result string
+}
+
+// Fetcher returns the latest status of the command identified by id.
+// Returning an error aborts the wait with that error wrapped.
+type Fetcher func(ctx context.Context, id int64) (Status, error)
+
+// Wait polls fetch every interval until the command reaches a terminal state.
+// Returns nil when the command completed with an empty or successful Result;
+// returns an error when:
+//   - the command status reports a terminal failure (failed, aborted, cancelled, orphaned),
+//   - the command completed with Result="unsuccessful",
+//   - fetch returns an error,
+//   - or ctx is cancelled.
+//
+// service ("sonarr"/"radarr") is interpolated into error messages so callers
+// can attribute failures without re-wrapping. id == 0 short-circuits to nil
+// (no command was issued); a non-positive interval falls back to
+// DefaultPollInterval.
+func Wait(ctx context.Context, fetch Fetcher, id int64, interval time.Duration, service string) error {
+	if id == 0 {
+		return nil
+	}
+
+	if interval <= 0 {
+		interval = DefaultPollInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		status, err := fetch(ctx, id)
+		if err != nil {
+			return fmt.Errorf("get %s command status (id=%d): %w", service, id, err)
+		}
+
+		switch strings.ToLower(status.Status) {
+		case "completed":
+			if strings.EqualFold(status.Result, "unsuccessful") {
+				return fmt.Errorf("%s command %d completed but reported no successful imports: %s", service, id, status.Message)
+			}
+
+			return nil
+		case "failed", "aborted", "cancelled", "orphaned":
+			return fmt.Errorf("%s command %d ended with status %q: %s", service, id, status.Status, status.Message)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/medialib/internal/arrcommand/arrcommand_test.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand_test.go
@@ -1,0 +1,176 @@
+package arrcommand_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/arrcommand"
+)
+
+const fastInterval = time.Millisecond
+
+func TestWait(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statuses     []arrcommand.Status
+		fetchErr     error
+		errFunc      require.ErrorAssertionFunc
+		errSubstring string
+		wantCalls    int
+	}{
+		{
+			name:      "zero id short-circuits without polling",
+			statuses:  nil,
+			errFunc:   require.NoError,
+			wantCalls: 0,
+		},
+		{
+			name: "completed on first poll returns nil",
+			statuses: []arrcommand.Status{
+				{Status: "completed"},
+			},
+			errFunc:   require.NoError,
+			wantCalls: 1,
+		},
+		{
+			name: "transitions queued then started then completed",
+			statuses: []arrcommand.Status{
+				{Status: "queued"},
+				{Status: "started"},
+				{Status: "completed"},
+			},
+			errFunc:   require.NoError,
+			wantCalls: 3,
+		},
+		{
+			name: "completed result successful is treated as success",
+			statuses: []arrcommand.Status{
+				{Status: "completed", Result: "successful"},
+			},
+			errFunc:   require.NoError,
+			wantCalls: 1,
+		},
+		{
+			name: "completed result unsuccessful surfaces as error",
+			statuses: []arrcommand.Status{
+				{Status: "completed", Result: "unsuccessful", Message: "no eligible files"},
+			},
+			errFunc:      require.Error,
+			errSubstring: "no successful imports",
+			wantCalls:    1,
+		},
+		{
+			name: "failed status surfaces as error",
+			statuses: []arrcommand.Status{
+				{Status: "failed", Message: "boom"},
+			},
+			errFunc:      require.Error,
+			errSubstring: "failed",
+			wantCalls:    1,
+		},
+		{
+			name: "aborted status surfaces as error",
+			statuses: []arrcommand.Status{
+				{Status: "started"},
+				{Status: "aborted"},
+			},
+			errFunc:      require.Error,
+			errSubstring: "aborted",
+			wantCalls:    2,
+		},
+		{
+			name:         "fetch error is wrapped",
+			fetchErr:     errors.New("network unreachable"),
+			errFunc:      require.Error,
+			errSubstring: "get arrtest command status",
+			wantCalls:    1,
+		},
+		{
+			name: "case-insensitive status matching",
+			statuses: []arrcommand.Status{
+				{Status: "COMPLETED"},
+			},
+			errFunc:   require.NoError,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			id := int64(1)
+			if tc.name == "zero id short-circuits without polling" {
+				id = 0
+			}
+
+			calls := 0
+			fetcher := func(_ context.Context, _ int64) (arrcommand.Status, error) {
+				calls++
+
+				if tc.fetchErr != nil {
+					return arrcommand.Status{}, tc.fetchErr
+				}
+
+				idx := calls - 1
+				if idx >= len(tc.statuses) {
+					idx = len(tc.statuses) - 1
+				}
+
+				return tc.statuses[idx], nil
+			}
+
+			err := arrcommand.Wait(t.Context(), fetcher, id, fastInterval, "arrtest")
+			tc.errFunc(t, err)
+
+			if tc.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), tc.errSubstring)
+			}
+
+			assert.Equal(t, tc.wantCalls, calls, "unexpected fetcher invocation count")
+		})
+	}
+}
+
+// TestWait_ContextCancellationStopsPolling verifies the wait loop honors
+// context cancellation while waiting between polls.
+func TestWait_ContextCancellationStopsPolling(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	fetcher := func(_ context.Context, _ int64) (arrcommand.Status, error) {
+		// Always return a non-terminal state so the loop keeps polling.
+		return arrcommand.Status{Status: "queued"}, nil
+	}
+
+	// Cancel after a short delay to interrupt the wait loop.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := arrcommand.Wait(ctx, fetcher, 1, fastInterval, "arrtest")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestWait_ZeroIntervalUsesDefault verifies that passing a non-positive
+// interval falls back to DefaultPollInterval rather than busy-looping.
+func TestWait_ZeroIntervalUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	// First call returns terminal so we don't actually wait DefaultPollInterval.
+	fetcher := func(_ context.Context, _ int64) (arrcommand.Status, error) {
+		return arrcommand.Status{Status: "completed"}, nil
+	}
+
+	require.NoError(t, arrcommand.Wait(t.Context(), fetcher, 1, 0, "arrtest"))
+	require.NoError(t, arrcommand.Wait(t.Context(), fetcher, 1, -1, "arrtest"))
+}

--- a/pkg/medialib/internal/arrcommand/arrcommand_test.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand_test.go
@@ -27,8 +27,6 @@ func TestWait(t *testing.T) {
 	}{
 		{
 			name:      "zero id short-circuits without polling",
-			statuses:  nil,
-			errFunc:   require.NoError,
 			wantCalls: 0,
 		},
 		{
@@ -36,7 +34,6 @@ func TestWait(t *testing.T) {
 			statuses: []arrcommand.Status{
 				{Status: "completed"},
 			},
-			errFunc:   require.NoError,
 			wantCalls: 1,
 		},
 		{
@@ -46,7 +43,6 @@ func TestWait(t *testing.T) {
 				{Status: "started"},
 				{Status: "completed"},
 			},
-			errFunc:   require.NoError,
 			wantCalls: 3,
 		},
 		{
@@ -54,7 +50,6 @@ func TestWait(t *testing.T) {
 			statuses: []arrcommand.Status{
 				{Status: "completed", Result: "successful"},
 			},
-			errFunc:   require.NoError,
 			wantCalls: 1,
 		},
 		{
@@ -97,7 +92,6 @@ func TestWait(t *testing.T) {
 			statuses: []arrcommand.Status{
 				{Status: "COMPLETED"},
 			},
-			errFunc:   require.NoError,
 			wantCalls: 1,
 		},
 	}
@@ -105,6 +99,10 @@ func TestWait(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+
+			if test.errFunc == nil {
+				test.errFunc = require.NoError
+			}
 
 			id := int64(1)
 			if test.name == "zero id short-circuits without polling" {

--- a/pkg/medialib/internal/arrcommand/arrcommand_test.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand_test.go
@@ -102,12 +102,12 @@ func TestWait(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
 			id := int64(1)
-			if tc.name == "zero id short-circuits without polling" {
+			if test.name == "zero id short-circuits without polling" {
 				id = 0
 			}
 
@@ -115,26 +115,26 @@ func TestWait(t *testing.T) {
 			fetcher := func(_ context.Context, _ int64) (arrcommand.Status, error) {
 				calls++
 
-				if tc.fetchErr != nil {
-					return arrcommand.Status{}, tc.fetchErr
+				if test.fetchErr != nil {
+					return arrcommand.Status{}, test.fetchErr
 				}
 
 				idx := calls - 1
-				if idx >= len(tc.statuses) {
-					idx = len(tc.statuses) - 1
+				if idx >= len(test.statuses) {
+					idx = len(test.statuses) - 1
 				}
 
-				return tc.statuses[idx], nil
+				return test.statuses[idx], nil
 			}
 
 			err := arrcommand.Wait(t.Context(), fetcher, id, fastInterval, "arrtest")
-			tc.errFunc(t, err)
+			test.errFunc(t, err)
 
-			if tc.errSubstring != "" && err != nil {
-				assert.Contains(t, err.Error(), tc.errSubstring)
+			if test.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), test.errSubstring)
 			}
 
-			assert.Equal(t, tc.wantCalls, calls, "unexpected fetcher invocation count")
+			assert.Equal(t, test.wantCalls, calls, "unexpected fetcher invocation count")
 		})
 	}
 }

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -7,13 +7,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"golift.io/starr"
 	radarrlib "golift.io/starr/radarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/arrcommand"
 	"github.com/solidDoWant/media-processor/pkg/medialib/internal/artwork"
 )
 
@@ -24,6 +28,9 @@ var _ medialib.ArrLibrary = (*Client)(nil)
 type Config struct {
 	URL    string
 	APIKey string
+	// CommandPollInterval overrides the default poll interval for waiting on
+	// command completion. Zero uses arrcommand.DefaultPollInterval.
+	CommandPollInterval time.Duration
 }
 
 // Client is a Radarr client implementing medialib.ArrLibrary.
@@ -41,8 +48,8 @@ func New(cfg Config) *Client {
 // getMovieByFilePath returns the movie identified by parsing the file path.
 // Uses Radarr's parse endpoint, so it works for pre-import files.
 // Returns medialib.ErrNotFound if no movie is identified.
-func (c *Client) getMovieByFilePath(ctx context.Context, path string) (*medialib.Movie, error) {
-	movie, err := c.parseFilePath(ctx, path)
+func (c *Client) getMovieByFilePath(ctx context.Context, filePath string) (*medialib.Movie, error) {
+	movie, err := c.parseFilePath(ctx, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("parse file path: %w", err)
 	}
@@ -61,12 +68,12 @@ func (c *Client) getMovieByFilePath(ctx context.Context, path string) (*medialib
 // path parameter because Radarr's parse endpoint matches path against library
 // paths only, returning 204 No Content for download paths that haven't been
 // imported yet.
-func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Movie, error) {
+func (c *Client) parseFilePath(ctx context.Context, filePath string) (*radarrlib.Movie, error) {
 	var output struct {
 		Movie *radarrlib.Movie `json:"movie"`
 	}
 
-	base := filepath.Base(path)
+	base := filepath.Base(filePath)
 	q := make(url.Values)
 	q.Set("title", strings.TrimSuffix(base, filepath.Ext(base)))
 
@@ -83,8 +90,8 @@ func (c *Client) parseFilePath(ctx context.Context, path string) (*radarrlib.Mov
 // when no JPEG or PNG poster is available. Returns medialib.ErrNotFound if the
 // path cannot be matched to a movie. Returns other errors if the library is
 // unreachable or a Radarr API call fails.
-func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
-	movie, err := c.getMovieByFilePath(ctx, path)
+func (c *Client) GetPosterImage(ctx context.Context, filePath string) ([]byte, string, error) {
+	movie, err := c.getMovieByFilePath(ctx, filePath)
 	if err != nil {
 		return nil, "", fmt.Errorf("get movie for poster: %w", err)
 	}
@@ -99,19 +106,22 @@ func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, strin
 
 // GetInfo implements medialib.ArrLibrary. It returns structured metadata for
 // the movie at path.
-func (c *Client) GetInfo(ctx context.Context, path string) (medialib.MediaInfo, error) {
-	return c.getMovieByFilePath(ctx, path)
+func (c *Client) GetInfo(ctx context.Context, filePath string) (medialib.MediaInfo, error) {
+	return c.getMovieByFilePath(ctx, filePath)
 }
 
 // ImportByFilePath implements medialib.ArrLibrary. It sends a DownloadedMoviesScan command
-// for path, causing Radarr to import the file at path into the library.
-func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
+// for filePath, causing Radarr to import the file at filePath into the library, and blocks
+// until Radarr reports the command has reached a terminal status.
+// Blocking is required so the caller can safely operate on filePath (e.g. prune the
+// containing directory) once Radarr has finished moving the file into its library.
+func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
 	requestPayload := struct {
 		Name string `json:"name"`
 		Path string `json:"path"`
 	}{
 		Name: "DownloadedMoviesScan",
-		Path: path,
+		Path: filePath,
 	}
 
 	var body bytes.Buffer
@@ -121,8 +131,30 @@ func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
 
 	var resp radarrlib.CommandResponse
 	if err := c.radarr.PostInto(ctx, starr.Request{URI: radarrlib.APIver + "/command", Body: &body}, &resp); err != nil {
-		return fmt.Errorf("scan downloaded movies at %q: %w", path, err)
+		return fmt.Errorf("scan downloaded movies at %q: %w", filePath, err)
+	}
+
+	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "radarr"); err != nil {
+		return fmt.Errorf("wait for command for %q: %w", filePath, err)
 	}
 
 	return nil
+}
+
+// fetchCommandStatus implements arrcommand.Fetcher. It hits Radarr's
+// /command/{id} endpoint with a custom struct so the Result field
+// (not exposed by starr's typed response) is decoded too.
+func (c *Client) fetchCommandStatus(ctx context.Context, id int64) (arrcommand.Status, error) {
+	var resp struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+		Result  string `json:"result"`
+	}
+
+	uri := path.Join(radarrlib.APIver, "command", strconv.FormatInt(id, 10))
+	if err := c.radarr.GetInto(ctx, starr.Request{URI: uri}, &resp); err != nil {
+		return arrcommand.Status{}, err
+	}
+
+	return arrcommand.Status{Status: resp.Status, Message: resp.Message, Result: resp.Result}, nil
 }

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,9 @@ import (
 // privileged port with no listener in any normal environment).
 const unreachableURL = "http://127.0.0.1:1"
 
+// fastPollInterval keeps tests that exercise the command polling loop snappy.
+const fastPollInterval = time.Millisecond
+
 // parseResponse mirrors the shape of Radarr's /api/v3/parse response.
 type parseResponse struct {
 	Movie *radarrlib.Movie `json:"movie"`
@@ -32,6 +37,20 @@ type testServerConfig struct {
 	movieByID *radarrlib.Movie // response for /api/v3/movie/{id}
 	imageBody []byte           // raw bytes served at image paths
 	imageType string           // Content-Type for image responses
+	// commandStatuses is the sequence of status values returned by GET
+	// /api/v3/command/{id} on successive polls. The last entry is reused for
+	// further polls. Empty defaults to a single "completed" entry.
+	commandStatuses []string
+	// commandResult is the value of the response's "result" field. Radarr
+	// returns "unsuccessful" when a command finishes but reports no useful
+	// work (e.g. import that found nothing eligible). Empty leaves the field
+	// out of the response.
+	commandResult string
+	// commandStatusMessage is the message attached to status responses.
+	commandStatusMessage string
+	// commandStatusHTTPStatus, when non-zero, is returned by GET
+	// /api/v3/command/{id} instead of the JSON body.
+	commandStatusHTTPStatus int
 	// onCommand is called with the raw command request when /api/v3/command is hit.
 	onCommand func(t *testing.T, r *http.Request)
 	// onParse is called with the raw parse request when /api/v3/parse is hit.
@@ -64,6 +83,43 @@ func newTestServerWithConfig(t *testing.T, cfg testServerConfig) *httptest.Serve
 
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(&radarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	// /api/v3/command/{id} drives the post-submit polling loop. Default
+	// behavior is to immediately return a terminal "completed" so existing
+	// tests don't have to opt in.
+	var commandStatusCalls atomic.Int32
+
+	mux.HandleFunc("/api/v3/command/", func(w http.ResponseWriter, r *http.Request) {
+		if cfg.commandStatusHTTPStatus != 0 {
+			w.WriteHeader(cfg.commandStatusHTTPStatus)
+			return
+		}
+
+		statuses := cfg.commandStatuses
+		if len(statuses) == 0 {
+			statuses = []string{"completed"}
+		}
+
+		idx := int(commandStatusCalls.Add(1) - 1)
+		if idx >= len(statuses) {
+			idx = len(statuses) - 1
+		}
+
+		// starr's typed CommandResponse doesn't carry the Result field, so
+		// build the body manually to include it.
+		body := map[string]any{
+			"id":      1,
+			"status":  statuses[idx],
+			"message": cfg.commandStatusMessage,
+		}
+
+		if cfg.commandResult != "" {
+			body["result"] = cfg.commandResult
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(body))
 	})
 
 	mux.HandleFunc("/api/v3/movie/", func(w http.ResponseWriter, r *http.Request) {
@@ -114,7 +170,7 @@ func TestImportByFilePath(t *testing.T) {
 			})
 			t.Cleanup(srv.Close)
 
-			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
+			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			err := client.ImportByFilePath(t.Context(), tc.path)
 
@@ -128,6 +184,78 @@ func TestImportByFilePath(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, tc.wantCmdName, gotCmd.Name)
 				assert.Equal(t, tc.wantCmdPath, gotCmd.Path)
+			}
+		})
+	}
+}
+
+func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		commandStatuses  []string
+		commandResult    string
+		commandHTTPError int
+		commandMessage   string
+		errFunc          require.ErrorAssertionFunc
+		errSubstring     string
+	}{
+		{
+			name:            "transitions queued then started then completed",
+			commandStatuses: []string{"queued", "started", "completed"},
+			errFunc:         require.NoError,
+		},
+		{
+			name:            "completed with successful result is treated as success",
+			commandStatuses: []string{"completed"},
+			commandResult:   "successful",
+			errFunc:         require.NoError,
+		},
+		{
+			name:            "completed with unsuccessful result surfaces as error",
+			commandStatuses: []string{"completed"},
+			commandResult:   "unsuccessful",
+			commandMessage:  "no eligible files",
+			errFunc:         require.Error,
+			errSubstring:    "no successful imports",
+		},
+		{
+			name:            "terminal failed surfaces as error",
+			commandStatuses: []string{"failed"},
+			commandMessage:  "import rejected",
+			errFunc:         require.Error,
+			errSubstring:    "failed",
+		},
+		{
+			name:            "terminal aborted surfaces as error",
+			commandStatuses: []string{"started", "aborted"},
+			errFunc:         require.Error,
+			errSubstring:    "aborted",
+		},
+		{
+			name:             "polling endpoint failure surfaces as error",
+			commandHTTPError: http.StatusInternalServerError,
+			errFunc:          require.Error,
+			errSubstring:     "get radarr command status",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServerWithConfig(t, testServerConfig{
+				commandStatuses:         tc.commandStatuses,
+				commandResult:           tc.commandResult,
+				commandStatusMessage:    tc.commandMessage,
+				commandStatusHTTPStatus: tc.commandHTTPError,
+			})
+			t.Cleanup(srv.Close)
+
+			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv")
+			tc.errFunc(t, err)
+
+			if tc.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), tc.errSubstring)
 			}
 		})
 	}

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -202,13 +202,11 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 		{
 			name:            "transitions queued then started then completed",
 			commandStatuses: []string{"queued", "started", "completed"},
-			errFunc:         require.NoError,
 		},
 		{
 			name:            "completed with successful result is treated as success",
 			commandStatuses: []string{"completed"},
 			commandResult:   "successful",
-			errFunc:         require.NoError,
 		},
 		{
 			name:            "completed with unsuccessful result surfaces as error",
@@ -241,6 +239,10 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.errFunc == nil {
+				test.errFunc = require.NoError
+			}
+
 			srv := newTestServerWithConfig(t, testServerConfig{
 				commandStatuses:         test.commandStatuses,
 				commandResult:           test.commandResult,

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -156,8 +156,8 @@ func TestImportByFilePath(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var gotCmd struct {
 				Name string `json:"name"`
 				Path string `json:"path"`
@@ -172,9 +172,9 @@ func TestImportByFilePath(t *testing.T) {
 
 			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), tc.path)
+			err := client.ImportByFilePath(t.Context(), test.path)
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
@@ -182,8 +182,8 @@ func TestImportByFilePath(t *testing.T) {
 			errFunc(t, err)
 
 			if err == nil {
-				assert.Equal(t, tc.wantCmdName, gotCmd.Name)
-				assert.Equal(t, tc.wantCmdPath, gotCmd.Path)
+				assert.Equal(t, test.wantCmdName, gotCmd.Name)
+				assert.Equal(t, test.wantCmdPath, gotCmd.Path)
 			}
 		})
 	}
@@ -239,23 +239,23 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			srv := newTestServerWithConfig(t, testServerConfig{
-				commandStatuses:         tc.commandStatuses,
-				commandResult:           tc.commandResult,
-				commandStatusMessage:    tc.commandMessage,
-				commandStatusHTTPStatus: tc.commandHTTPError,
+				commandStatuses:         test.commandStatuses,
+				commandResult:           test.commandResult,
+				commandStatusMessage:    test.commandMessage,
+				commandStatusHTTPStatus: test.commandHTTPError,
 			})
 			t.Cleanup(srv.Close)
 
 			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv")
-			tc.errFunc(t, err)
+			test.errFunc(t, err)
 
-			if tc.errSubstring != "" && err != nil {
-				assert.Contains(t, err.Error(), tc.errSubstring)
+			if test.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), test.errSubstring)
 			}
 		})
 	}
@@ -323,16 +323,16 @@ func TestGetInfo(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			srv := newTestServer(t, tc.parseResp)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newTestServer(t, test.parseResp)
 			t.Cleanup(srv.Close)
 
 			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key"})
 
 			info, err := client.GetInfo(t.Context(), "/movies/some.file.mkv")
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
@@ -340,9 +340,9 @@ func TestGetInfo(t *testing.T) {
 			errFunc(t, err)
 
 			if err == nil {
-				assert.Equal(t, tc.wantID, info.GetID())
-				assert.Equal(t, tc.wantTitle, info.GetTitle())
-				assert.Equal(t, tc.wantYear, info.GetYear())
+				assert.Equal(t, test.wantID, info.GetID())
+				assert.Equal(t, test.wantTitle, info.GetTitle())
+				assert.Equal(t, test.wantYear, info.GetYear())
 				assert.Equal(t, "", info.GetSeriesTitle())
 				assert.Equal(t, 0, info.GetSeasonNumber())
 				assert.Equal(t, 0, info.GetEpisodeNumber())
@@ -420,13 +420,13 @@ func TestGetPosterImage(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			srv := newTestServerWithConfig(t, testServerConfig{
 				parseResp: &parseResponse{Movie: knownMovie},
-				movieByID: tc.movieByID,
-				imageBody: tc.imageBody,
-				imageType: tc.imageType,
+				movieByID: test.movieByID,
+				imageBody: test.imageBody,
+				imageType: test.imageType,
 			})
 			t.Cleanup(srv.Close)
 
@@ -434,14 +434,14 @@ func TestGetPosterImage(t *testing.T) {
 
 			gotBytes, gotMime, err := client.GetPosterImage(t.Context(), "/movies/The.Matrix.1999.mkv")
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
 
 			errFunc(t, err)
-			assert.Equal(t, tc.wantBytes, gotBytes)
-			assert.Equal(t, tc.wantMime, gotMime)
+			assert.Equal(t, test.wantBytes, gotBytes)
+			assert.Equal(t, test.wantMime, gotMime)
 		})
 	}
 }

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -6,13 +6,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"golift.io/starr"
 	sonarrlib "golift.io/starr/sonarr"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
+	"github.com/solidDoWant/media-processor/pkg/medialib/internal/arrcommand"
 	"github.com/solidDoWant/media-processor/pkg/medialib/internal/artwork"
 )
 
@@ -23,6 +27,9 @@ var _ medialib.ArrLibrary = (*Client)(nil)
 type Config struct {
 	URL    string
 	APIKey string
+	// CommandPollInterval overrides the default poll interval for waiting on
+	// command completion. Zero uses arrcommand.DefaultPollInterval.
+	CommandPollInterval time.Duration
 }
 
 // Client is a Sonarr client implementing medialib.ArrLibrary.
@@ -40,11 +47,11 @@ func New(cfg Config) *Client {
 // getEpisodeByFilePath returns the episode identified by parsing the file path.
 // Uses Sonarr's parse endpoint, so it works for pre-import files.
 // Returns medialib.ErrNotFound if no episode is identified.
-func (c *Client) getEpisodeByFilePath(ctx context.Context, path string) (*medialib.Episode, error) {
+func (c *Client) getEpisodeByFilePath(ctx context.Context, filePath string) (*medialib.Episode, error) {
 	// Use the title parameter (filename stem) rather than path because Sonarr's
 	// parse endpoint matches path against library paths only, returning 204 No
 	// Content for download paths that haven't been imported yet.
-	base := filepath.Base(path)
+	base := filepath.Base(filePath)
 
 	parsed, err := c.sonarr.ParseContext(ctx, &sonarrlib.ParseInput{Title: strings.TrimSuffix(base, filepath.Ext(base))})
 	if err != nil {
@@ -70,8 +77,8 @@ func (c *Client) getEpisodeByFilePath(ctx context.Context, path string) (*medial
 // Returns nil bytes (no error) when no JPEG or PNG poster is available.
 // Returns medialib.ErrNotFound if the path cannot be matched to an episode.
 // Returns other errors if the library is unreachable or a Sonarr API call fails.
-func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, string, error) {
-	episode, err := c.getEpisodeByFilePath(ctx, path)
+func (c *Client) GetPosterImage(ctx context.Context, filePath string) ([]byte, string, error) {
+	episode, err := c.getEpisodeByFilePath(ctx, filePath)
 	if err != nil {
 		return nil, "", fmt.Errorf("get episode for poster: %w", err)
 	}
@@ -86,16 +93,16 @@ func (c *Client) GetPosterImage(ctx context.Context, path string) ([]byte, strin
 
 // GetInfo implements medialib.ArrLibrary. It returns structured metadata for
 // the episode at path.
-func (c *Client) GetInfo(ctx context.Context, path string) (medialib.MediaInfo, error) {
-	return c.getEpisodeByFilePath(ctx, path)
+func (c *Client) GetInfo(ctx context.Context, filePath string) (medialib.MediaInfo, error) {
+	return c.getEpisodeByFilePath(ctx, filePath)
 }
 
 // findTrackedDownloadID returns the download client's native ID for the pending
 // tracked download that corresponds to the episode at path, or "" if none is
 // found. API errors are treated as "no match" so callers always get a safe
 // fallback.
-func (c *Client) findTrackedDownloadID(ctx context.Context, path string) string {
-	episode, err := c.getEpisodeByFilePath(ctx, path)
+func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) string {
+	episode, err := c.getEpisodeByFilePath(ctx, filePath)
 	if err != nil {
 		return ""
 	}
@@ -135,12 +142,15 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, path string) string 
 }
 
 // ImportByFilePath implements medialib.ArrLibrary. It sends a DownloadedEpisodesScan command
-// for path, causing Sonarr to import the file at path into the library.
+// for filePath, causing Sonarr to import the file at filePath into the library, and blocks
+// until Sonarr reports the command has reached a terminal status.
+// Blocking is required so the caller can safely operate on filePath (e.g. prune the
+// containing directory) once Sonarr has finished moving the file into its library.
 // When a pending tracked download for the episode is found in the queue, its
 // download client ID is included so Sonarr calls VerifyImport and removes the
 // item from the downloads queue.
-func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
-	downloadClientID := c.findTrackedDownloadID(ctx, path)
+func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
+	downloadClientID := c.findTrackedDownloadID(ctx, filePath)
 
 	requestPayload := struct {
 		Name             string `json:"name"`
@@ -148,7 +158,7 @@ func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
 		DownloadClientId string `json:"downloadClientId,omitempty"`
 	}{
 		Name:             "DownloadedEpisodesScan",
-		Path:             path,
+		Path:             filePath,
 		DownloadClientId: downloadClientID,
 	}
 
@@ -160,8 +170,30 @@ func (c *Client) ImportByFilePath(ctx context.Context, path string) error {
 	var resp sonarrlib.CommandResponse
 
 	if err := c.sonarr.PostInto(ctx, starr.Request{URI: sonarrlib.APIver + "/command", Body: &body}, &resp); err != nil {
-		return fmt.Errorf("scan downloaded episodes at %q: %w", path, err)
+		return fmt.Errorf("scan downloaded episodes at %q: %w", filePath, err)
+	}
+
+	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "sonarr"); err != nil {
+		return fmt.Errorf("wait for command for %q: %w", filePath, err)
 	}
 
 	return nil
+}
+
+// fetchCommandStatus implements arrcommand.Fetcher. It hits Sonarr's
+// /command/{id} endpoint with a custom struct so the Result field
+// (not exposed by starr's typed response) is decoded too.
+func (c *Client) fetchCommandStatus(ctx context.Context, id int64) (arrcommand.Status, error) {
+	var resp struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+		Result  string `json:"result"`
+	}
+
+	uri := path.Join(sonarrlib.APIver, "command", strconv.FormatInt(id, 10))
+	if err := c.sonarr.GetInto(ctx, starr.Request{URI: uri}, &resp); err != nil {
+		return arrcommand.Status{}, err
+	}
+
+	return arrcommand.Status{Status: resp.Status, Message: resp.Message, Result: resp.Result}, nil
 }

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,9 @@ import (
 // privileged port with no listener in any normal environment).
 const unreachableURL = "http://127.0.0.1:1"
 
+// fastPollInterval keeps tests that exercise the command polling loop snappy.
+const fastPollInterval = time.Millisecond
+
 // sonarrTestServerConfig holds configuration for test HTTP servers.
 type sonarrTestServerConfig struct {
 	parseResp       *sonarrlib.ParseOutput
@@ -30,6 +35,21 @@ type sonarrTestServerConfig struct {
 	queueHTTPStatus int                // override HTTP status for /api/v3/queue; 0 means 200
 	imageBody       []byte
 	imageType       string
+	// commandStatuses is the sequence of status values returned by GET
+	// /api/v3/command/{id} on successive polls. The last entry is reused for
+	// any further polls. Empty defaults to a single "completed" entry.
+	commandStatuses []string
+	// commandResult is the value of the response's "result" field. Sonarr
+	// returns "unsuccessful" when a command finishes but reports no useful
+	// work (e.g. import that found nothing eligible). Empty leaves the field
+	// out of the response.
+	commandResult string
+	// commandStatusMessage is the message attached to non-terminal/terminal
+	// status responses. Useful to assert the wrapped error mentions it.
+	commandStatusMessage string
+	// commandStatusHTTPStatus, when non-zero, is returned by GET
+	// /api/v3/command/{id} instead of the JSON body.
+	commandStatusHTTPStatus int
 	// onCommand is called with the raw command request when /api/v3/command is hit.
 	onCommand func(t *testing.T, r *http.Request)
 	// onParse is called with the raw parse request when /api/v3/parse is hit.
@@ -98,6 +118,44 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(&sonarrlib.CommandResponse{ID: 1, Status: "queued"}))
+	})
+
+	// /api/v3/command/{id} drives the post-submit polling loop. Default
+	// behavior is to immediately return a terminal "completed" so existing
+	// tests don't have to opt in. Tests that want to exercise the polling
+	// loop set commandStatuses to a sequence of returns.
+	var commandStatusCalls atomic.Int32
+
+	mux.HandleFunc("/api/v3/command/", func(w http.ResponseWriter, r *http.Request) {
+		if cfg.commandStatusHTTPStatus != 0 {
+			w.WriteHeader(cfg.commandStatusHTTPStatus)
+			return
+		}
+
+		statuses := cfg.commandStatuses
+		if len(statuses) == 0 {
+			statuses = []string{"completed"}
+		}
+
+		idx := int(commandStatusCalls.Add(1) - 1)
+		if idx >= len(statuses) {
+			idx = len(statuses) - 1
+		}
+
+		// starr's typed CommandResponse doesn't carry the Result field, so
+		// build the body manually to include it.
+		body := map[string]any{
+			"id":      1,
+			"status":  statuses[idx],
+			"message": cfg.commandStatusMessage,
+		}
+
+		if cfg.commandResult != "" {
+			body["result"] = cfg.commandResult
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(body))
 	})
 
 	mux.HandleFunc("/api/v3/series/", func(w http.ResponseWriter, r *http.Request) {
@@ -237,7 +295,7 @@ func TestImportByFilePath(t *testing.T) {
 			})
 			t.Cleanup(srv.Close)
 
-			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			err := client.ImportByFilePath(t.Context(), tc.path)
 
@@ -304,6 +362,79 @@ func TestImportByFilePath_UnreachableURL(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		commandStatuses  []string
+		commandResult    string
+		commandHTTPError int
+		commandMessage   string
+		errFunc          require.ErrorAssertionFunc
+		errSubstring     string
+	}{
+		{
+			name:            "transitions queued then started then completed",
+			commandStatuses: []string{"queued", "started", "completed"},
+			errFunc:         require.NoError,
+		},
+		{
+			name:            "completed with successful result is treated as success",
+			commandStatuses: []string{"completed"},
+			commandResult:   "successful",
+			errFunc:         require.NoError,
+		},
+		{
+			name:            "completed with unsuccessful result surfaces as error",
+			commandStatuses: []string{"completed"},
+			commandResult:   "unsuccessful",
+			commandMessage:  "no eligible files",
+			errFunc:         require.Error,
+			errSubstring:    "no successful imports",
+		},
+		{
+			name:            "terminal failed surfaces as error",
+			commandStatuses: []string{"failed"},
+			commandMessage:  "import rejected",
+			errFunc:         require.Error,
+			errSubstring:    "failed",
+		},
+		{
+			name:            "terminal aborted surfaces as error",
+			commandStatuses: []string{"started", "aborted"},
+			errFunc:         require.Error,
+			errSubstring:    "aborted",
+		},
+		{
+			name:             "polling endpoint failure surfaces as error",
+			commandHTTPError: http.StatusInternalServerError,
+			errFunc:          require.Error,
+			errSubstring:     "get sonarr command status",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+				parseResp:               &sonarrlib.ParseOutput{},
+				commandStatuses:         tc.commandStatuses,
+				commandResult:           tc.commandResult,
+				commandStatusMessage:    tc.commandMessage,
+				commandStatusHTTPStatus: tc.commandHTTPError,
+			})
+			t.Cleanup(srv.Close)
+
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
+			tc.errFunc(t, err)
+
+			if tc.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), tc.errSubstring)
+			}
+		})
+	}
+}
+
 func TestGetInfo(t *testing.T) {
 	knownParseOutput := &sonarrlib.ParseOutput{
 		Title: "Breaking Bad",
@@ -355,7 +486,7 @@ func TestGetInfo(t *testing.T) {
 			srv := newSonarrTestServer(t, tc.parseResp)
 			t.Cleanup(srv.Close)
 
-			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			info, err := client.GetInfo(t.Context(), "/tv/some.file.mkv")
 
@@ -467,7 +598,7 @@ func TestGetPosterImage(t *testing.T) {
 			})
 			t.Cleanup(srv.Close)
 
-			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key"})
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			gotBytes, gotMime, err := client.GetPosterImage(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
 

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -276,8 +276,8 @@ func TestImportByFilePath(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var gotCmd struct {
 				Name             string `json:"name"`
 				Path             string `json:"path"`
@@ -285,10 +285,10 @@ func TestImportByFilePath(t *testing.T) {
 			}
 
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
-				parseResp:       tc.parseResp,
-				queueResp:       tc.queueResp,
-				queuePages:      tc.queuePages,
-				queueHTTPStatus: tc.queueHTTPStatus,
+				parseResp:       test.parseResp,
+				queueResp:       test.queueResp,
+				queuePages:      test.queuePages,
+				queueHTTPStatus: test.queueHTTPStatus,
 				onCommand: func(t *testing.T, r *http.Request) {
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&gotCmd))
 				},
@@ -297,9 +297,9 @@ func TestImportByFilePath(t *testing.T) {
 
 			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), tc.path)
+			err := client.ImportByFilePath(t.Context(), test.path)
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
@@ -307,9 +307,9 @@ func TestImportByFilePath(t *testing.T) {
 			errFunc(t, err)
 
 			if err == nil {
-				assert.Equal(t, tc.wantCmdName, gotCmd.Name)
-				assert.Equal(t, tc.wantCmdPath, gotCmd.Path)
-				assert.Equal(t, tc.wantDownloadClientID, gotCmd.DownloadClientId)
+				assert.Equal(t, test.wantCmdName, gotCmd.Name)
+				assert.Equal(t, test.wantCmdPath, gotCmd.Path)
+				assert.Equal(t, test.wantDownloadClientID, gotCmd.DownloadClientId)
 			}
 		})
 	}
@@ -412,24 +412,24 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
 				parseResp:               &sonarrlib.ParseOutput{},
-				commandStatuses:         tc.commandStatuses,
-				commandResult:           tc.commandResult,
-				commandStatusMessage:    tc.commandMessage,
-				commandStatusHTTPStatus: tc.commandHTTPError,
+				commandStatuses:         test.commandStatuses,
+				commandResult:           test.commandResult,
+				commandStatusMessage:    test.commandMessage,
+				commandStatusHTTPStatus: test.commandHTTPError,
 			})
 			t.Cleanup(srv.Close)
 
 			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
-			tc.errFunc(t, err)
+			test.errFunc(t, err)
 
-			if tc.errSubstring != "" && err != nil {
-				assert.Contains(t, err.Error(), tc.errSubstring)
+			if test.errSubstring != "" && err != nil {
+				assert.Contains(t, err.Error(), test.errSubstring)
 			}
 		})
 	}
@@ -481,16 +481,16 @@ func TestGetInfo(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			srv := newSonarrTestServer(t, tc.parseResp)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newSonarrTestServer(t, test.parseResp)
 			t.Cleanup(srv.Close)
 
 			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
 			info, err := client.GetInfo(t.Context(), "/tv/some.file.mkv")
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
@@ -498,12 +498,12 @@ func TestGetInfo(t *testing.T) {
 			errFunc(t, err)
 
 			if err == nil {
-				assert.Equal(t, tc.wantID, info.GetID())
-				assert.Equal(t, tc.wantTitle, info.GetTitle())
-				assert.Equal(t, tc.wantYear, info.GetYear())
-				assert.Equal(t, tc.wantSeries, info.GetSeriesTitle())
-				assert.Equal(t, tc.wantSeason, info.GetSeasonNumber())
-				assert.Equal(t, tc.wantEp, info.GetEpisodeNumber())
+				assert.Equal(t, test.wantID, info.GetID())
+				assert.Equal(t, test.wantTitle, info.GetTitle())
+				assert.Equal(t, test.wantYear, info.GetYear())
+				assert.Equal(t, test.wantSeries, info.GetSeriesTitle())
+				assert.Equal(t, test.wantSeason, info.GetSeasonNumber())
+				assert.Equal(t, test.wantEp, info.GetEpisodeNumber())
 			}
 		})
 	}
@@ -588,13 +588,13 @@ func TestGetPosterImage(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
 				parseResp:  knownParseOutput,
-				seriesByID: tc.seriesByID,
-				imageBody:  tc.imageBody,
-				imageType:  tc.imageType,
+				seriesByID: test.seriesByID,
+				imageBody:  test.imageBody,
+				imageType:  test.imageType,
 			})
 			t.Cleanup(srv.Close)
 
@@ -602,14 +602,14 @@ func TestGetPosterImage(t *testing.T) {
 
 			gotBytes, gotMime, err := client.GetPosterImage(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
 
-			errFunc := tc.errFunc
+			errFunc := test.errFunc
 			if errFunc == nil {
 				errFunc = require.NoError
 			}
 
 			errFunc(t, err)
-			assert.Equal(t, tc.wantBytes, gotBytes)
-			assert.Equal(t, tc.wantMime, gotMime)
+			assert.Equal(t, test.wantBytes, gotBytes)
+			assert.Equal(t, test.wantMime, gotMime)
 		})
 	}
 }

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -375,13 +375,11 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 		{
 			name:            "transitions queued then started then completed",
 			commandStatuses: []string{"queued", "started", "completed"},
-			errFunc:         require.NoError,
 		},
 		{
 			name:            "completed with successful result is treated as success",
 			commandStatuses: []string{"completed"},
 			commandResult:   "successful",
-			errFunc:         require.NoError,
 		},
 		{
 			name:            "completed with unsuccessful result surfaces as error",
@@ -414,6 +412,10 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.errFunc == nil {
+				test.errFunc = require.NoError
+			}
+
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
 				parseResp:               &sonarrlib.ParseOutput{},
 				commandStatuses:         test.commandStatuses,

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -330,13 +330,16 @@ func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode Tra
 	return nil
 }
 
-// Cleanup deletes the source file or writes the .done sentinel. RunCleanup
-// tolerates ErrNotExist so retrying after a partial cleanup is safe;
-// WriteSentinel re-writes the same zero-byte file. Shared between the valid
-// and invalid paths — in the invalid path the source has already been removed
-// by Probe and Cleanup is a near-no-op for the file, but the sentinel branch
-// is still exercised when PreserveSource is set.
-func (a *Activities) Cleanup(ctx context.Context, input MediaInput) error {
+// Cleanup deletes the source file or writes the .done sentinel, then prunes
+// the mirrored subdirectory under OutputPath if Notify has drained the
+// transcoded file. RunCleanup tolerates ErrNotExist so retrying after a
+// partial cleanup is safe; WriteSentinel re-writes the same zero-byte file.
+// Output-side pruning is best-effort: it only removes truly-empty
+// directories, so a copied-but-not-moved transcode is left in place.
+// Shared between the valid and invalid paths — in the invalid path the
+// source has already been removed by Probe (RunCleanup is a near-no-op),
+// transcode.DestFilePath is empty, and output pruning is skipped.
+func (a *Activities) Cleanup(ctx context.Context, input MediaInput, transcode TranscodeOutput) error {
 	start := time.Now()
 
 	var err error
@@ -344,6 +347,10 @@ func (a *Activities) Cleanup(ctx context.Context, input MediaInput) error {
 		err = WriteSentinel(input.FilePath)
 	} else {
 		err = RunCleanup(input.FilePath, input.WatchRoot, input.RetainEmptyDirectories)
+	}
+
+	if err == nil && !input.RetainEmptyDirectories {
+		PruneOutputDirs(transcode.DestFilePath, input.OutputPath)
 	}
 
 	logStepResult(ctx, "cleanup", input.FilePath, start, err)

--- a/workflows/media/activities_test.go
+++ b/workflows/media/activities_test.go
@@ -272,9 +272,9 @@ func TestResolveHighCardinalityLabels_StableKeySetAcrossOutcomes(t *testing.T) {
 
 	wantKeys := []string{"episode_number", "id", "season_number", "series_title", "title", "year"}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			a, err := NewActivities(MediaWorkflowConfig{HighCardinalityLabels: true}, tc.stub, &stubLibraryClient{}, &webhook.Client{})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a, err := NewActivities(MediaWorkflowConfig{HighCardinalityLabels: true}, test.stub, &stubLibraryClient{}, &webhook.Client{})
 			require.NoError(t, err)
 
 			// resolveHighCardinalityLabels is a method, not a registered
@@ -282,14 +282,14 @@ func TestResolveHighCardinalityLabels_StableKeySetAcrossOutcomes(t *testing.T) {
 			// activity.GetMetricsHandler / GetLogger calls find a real
 			// activity context.
 			wrap := func(ctx context.Context, in MediaInput) (map[string]string, error) {
-				return a.resolveHighCardinalityLabels(ctx, in, tc.stub), nil
+				return a.resolveHighCardinalityLabels(ctx, in, test.stub), nil
 			}
 
 			suite := &testsuite.WorkflowTestSuite{}
 			env := suite.NewTestActivityEnvironment()
 			env.RegisterActivity(wrap)
 
-			val, err := env.ExecuteActivity(wrap, tc.input)
+			val, err := env.ExecuteActivity(wrap, test.input)
 			require.NoError(t, err)
 
 			var got map[string]string
@@ -297,7 +297,7 @@ func TestResolveHighCardinalityLabels_StableKeySetAcrossOutcomes(t *testing.T) {
 
 			assert.Equal(t, wantKeys, slices.Sorted(maps.Keys(got)),
 				"key set must be identical across all GetInfo outcomes")
-			tc.assert(t, got)
+			test.assert(t, got)
 		})
 	}
 }
@@ -335,8 +335,8 @@ func TestEmitTranscodeMetrics_FullTagSetAndArtworkCounter(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			scope := tally.NewTestScope("", nil)
 			suite := &testsuite.WorkflowTestSuite{}
 			suite.SetMetricsHandler(contribtally.NewMetricsHandler(scope))
@@ -351,11 +351,11 @@ func TestEmitTranscodeMetrics_FullTagSetAndArtworkCounter(t *testing.T) {
 				DestFileSizeBytes:        2_000_000_000,
 				TranscodeDurationSeconds: 1800,
 				HardwareAccelerated:      true,
-				ArtworkFetchSkipped:      tc.artworkSkipped,
+				ArtworkFetchSkipped:      test.artworkSkipped,
 			}
 
 			wrap := func(ctx context.Context) error {
-				emitTranscodeMetrics(ctx, input, probe, out, tc.hcTags)
+				emitTranscodeMetrics(ctx, input, probe, out, test.hcTags)
 				return nil
 			}
 			env.RegisterActivity(wrap)
@@ -383,13 +383,13 @@ func TestEmitTranscodeMetrics_FullTagSetAndArtworkCounter(t *testing.T) {
 				h := findHistogram(t, snap, name, expectedBaseTags)
 				assertHistogramSampleCount(t, h, 1)
 
-				if tc.extraTagAssertion != nil {
-					tc.extraTagAssertion(t, h.Tags())
+				if test.extraTagAssertion != nil {
+					test.extraTagAssertion(t, h.Tags())
 				}
 			}
 
 			counters := findCounters(snap, "media_workflow_artwork_fetch_skipped")
-			if tc.artworkSkipped {
+			if test.artworkSkipped {
 				require.Len(t, counters, 1, "artwork-fetch-skipped counter should fire when flag is set")
 				assert.EqualValues(t, 1, counters[0].Value())
 			} else {

--- a/workflows/media/activities_test.go
+++ b/workflows/media/activities_test.go
@@ -97,7 +97,7 @@ func TestCleanup_DeletesSource(t *testing.T) {
 
 	a, env := newActivityEnv(t, MediaWorkflowConfig{}, &stubLibraryClient{}, &stubLibraryClient{}, &webhook.Client{}, nil)
 
-	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{FilePath: srcPath, MediaType: medialib.MovieType})
+	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{FilePath: srcPath, MediaType: medialib.MovieType}, TranscodeOutput{})
 	require.NoError(t, err)
 
 	_, statErr := os.Stat(srcPath)
@@ -113,7 +113,7 @@ func TestCleanup_PreserveSourceWritesSentinel(t *testing.T) {
 
 	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{
 		FilePath: srcPath, MediaType: medialib.MovieType, PreserveSource: true,
-	})
+	}, TranscodeOutput{})
 	require.NoError(t, err)
 
 	_, statErr := os.Stat(srcPath)
@@ -132,8 +132,70 @@ func TestCleanup_AlreadyDeletedSourceIsNotAnError(t *testing.T) {
 
 	a, env := newActivityEnv(t, MediaWorkflowConfig{}, &stubLibraryClient{}, &stubLibraryClient{}, &webhook.Client{}, nil)
 
-	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{FilePath: srcPath, MediaType: medialib.MovieType})
+	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{FilePath: srcPath, MediaType: medialib.MovieType}, TranscodeOutput{})
 	require.NoError(t, err, "cleanup must be idempotent so retries do not fail when the file is already gone")
+}
+
+// TestCleanup_PrunesOutputDirAfterImport verifies that the mirrored output
+// subdirectory is removed once Notify has drained the transcoded file (so by
+// the time Cleanup runs, the file is gone and the directory is empty).
+func TestCleanup_PrunesOutputDirAfterImport(t *testing.T) {
+	srcRoot := t.TempDir()
+	srcSub := filepath.Join(srcRoot, "Show.S01E01")
+	require.NoError(t, os.MkdirAll(srcSub, 0o755))
+
+	srcPath := filepath.Join(srcSub, "video.mkv")
+	require.NoError(t, os.WriteFile(srcPath, []byte("source"), 0o600))
+
+	outputRoot := t.TempDir()
+	outSub := filepath.Join(outputRoot, "Show.S01E01")
+	require.NoError(t, os.MkdirAll(outSub, 0o755))
+	// destFilePath points at the (now-moved) transcoded file. The directory
+	// is empty, mirroring the post-import state.
+	destFilePath := filepath.Join(outSub, "video.mkv")
+
+	a, env := newActivityEnv(t, MediaWorkflowConfig{}, &stubLibraryClient{}, &stubLibraryClient{}, &webhook.Client{}, nil)
+
+	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{
+		FilePath:   srcPath,
+		MediaType:  medialib.MovieType,
+		WatchRoot:  srcRoot,
+		OutputPath: outputRoot,
+	}, TranscodeOutput{DestFilePath: destFilePath})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(outSub)
+	assert.True(t, os.IsNotExist(statErr), "empty output subdir should be pruned after Notify drains the file")
+
+	_, statErr = os.Stat(outputRoot)
+	assert.NoError(t, statErr, "output root must not be removed")
+}
+
+// TestCleanup_RetainEmptyDirsSkipsOutputPruning verifies that when the user
+// has opted to retain empty directories, the output side is also skipped.
+func TestCleanup_RetainEmptyDirsSkipsOutputPruning(t *testing.T) {
+	srcRoot := t.TempDir()
+	srcPath := filepath.Join(srcRoot, "video.mkv")
+	require.NoError(t, os.WriteFile(srcPath, []byte("source"), 0o600))
+
+	outputRoot := t.TempDir()
+	outSub := filepath.Join(outputRoot, "release")
+	require.NoError(t, os.MkdirAll(outSub, 0o755))
+	destFilePath := filepath.Join(outSub, "video.mkv")
+
+	a, env := newActivityEnv(t, MediaWorkflowConfig{}, &stubLibraryClient{}, &stubLibraryClient{}, &webhook.Client{}, nil)
+
+	_, err := env.ExecuteActivity(a.Cleanup, MediaInput{
+		FilePath:               srcPath,
+		MediaType:              medialib.MovieType,
+		WatchRoot:              srcRoot,
+		OutputPath:             outputRoot,
+		RetainEmptyDirectories: true,
+	}, TranscodeOutput{DestFilePath: destFilePath})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(outSub)
+	assert.NoError(t, statErr, "output subdir must be kept when RetainEmptyDirectories is true")
 }
 
 func TestNotifyFailure_SendsWebhookPayload(t *testing.T) {

--- a/workflows/media/cleanup.go
+++ b/workflows/media/cleanup.go
@@ -37,6 +37,23 @@ func RunCleanup(filePath, watchRoot string, retainEmptyDirs bool) error {
 	return nil
 }
 
+// PruneOutputDirs removes the parent directories of destFilePath bottom-up
+// while each directory is empty, stopping at outputRoot. Intended for use
+// after Sonarr/Radarr has moved the transcoded file into its library, leaving
+// the mirrored subdirectory tree under outputRoot empty. When the file is
+// still present (e.g. Sonarr copied rather than moved, or the import was
+// rejected), pruning halts at the first non-empty directory and is a no-op.
+// Removal errors are logged and do not propagate; pruning is best-effort.
+// outputRoot itself is never removed. If outputRoot is empty or destFilePath
+// is empty, no pruning is performed.
+func PruneOutputDirs(destFilePath, outputRoot string) {
+	if destFilePath == "" {
+		return
+	}
+
+	pruneEmptyParents(destFilePath, outputRoot)
+}
+
 // pruneEmptyParents removes parent directories of filePath bottom-up as long as each
 // directory is empty, stopping when it reaches watchRoot or a non-empty directory.
 // The watch root itself is never removed. If watchRoot is empty, no pruning is performed.

--- a/workflows/media/cleanup_test.go
+++ b/workflows/media/cleanup_test.go
@@ -188,6 +188,68 @@ func TestRunCleanup_WatchRootNotRemoved(t *testing.T) {
 	assert.NoError(t, statErr, "watch root must not be removed even when empty")
 }
 
+// TestPruneOutputDirs_RemovesEmptyMirroredSubdirs verifies that the mirrored
+// subdirectory holding the transcoded file is removed once Sonarr/Radarr has
+// drained the file, leaving the directory empty.
+func TestPruneOutputDirs_RemovesEmptyMirroredSubdirs(t *testing.T) {
+	t.Parallel()
+
+	outputRoot := t.TempDir()
+	subdir := filepath.Join(outputRoot, "Show.S01.Complete")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	// destFilePath points at where the transcode wrote the file. Sonarr has
+	// already moved it out, so the file path no longer exists on disk.
+	destFilePath := filepath.Join(subdir, "Show.S01E01.mkv")
+
+	PruneOutputDirs(destFilePath, outputRoot)
+
+	_, statErr := os.Stat(subdir)
+	assert.True(t, os.IsNotExist(statErr), "empty mirrored subdir should be removed")
+
+	_, statErr = os.Stat(outputRoot)
+	assert.NoError(t, statErr, "output root must not be removed")
+}
+
+// TestPruneOutputDirs_LeavesNonEmptyDirAlone verifies that pruning halts when
+// the directory is not empty (e.g. Sonarr copied rather than moved, or a
+// sibling release file is still present).
+func TestPruneOutputDirs_LeavesNonEmptyDirAlone(t *testing.T) {
+	t.Parallel()
+
+	outputRoot := t.TempDir()
+	subdir := filepath.Join(outputRoot, "release")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	// File still present (e.g. Sonarr copied instead of moved). Pruning
+	// should not remove the parent directory.
+	stillThere := filepath.Join(subdir, "Show.S01E01.mkv")
+	require.NoError(t, os.WriteFile(stillThere, []byte("data"), 0o600))
+
+	PruneOutputDirs(stillThere, outputRoot)
+
+	_, statErr := os.Stat(subdir)
+	assert.NoError(t, statErr, "directory still containing the transcoded file must be kept")
+
+	_, statErr = os.Stat(stillThere)
+	assert.NoError(t, statErr, "file itself must not be touched")
+}
+
+// TestPruneOutputDirs_EmptyDestPathIsNoOp verifies that the invalid-media
+// path (no transcode → empty DestFilePath) does not attempt any pruning.
+func TestPruneOutputDirs_EmptyDestPathIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	outputRoot := t.TempDir()
+	keep := filepath.Join(outputRoot, "keep")
+	require.NoError(t, os.MkdirAll(keep, 0o755))
+
+	PruneOutputDirs("", outputRoot)
+
+	_, statErr := os.Stat(keep)
+	assert.NoError(t, statErr, "empty destFilePath must skip pruning entirely")
+}
+
 // TestRunCleanup_PrunesMultiLevelEmptyChain verifies that multiple levels of empty
 // ancestor directories are removed bottom-up until a non-empty ancestor or the watch root.
 func TestRunCleanup_PrunesMultiLevelEmptyChain(t *testing.T) {

--- a/workflows/media/config.go
+++ b/workflows/media/config.go
@@ -39,9 +39,15 @@ const (
 
 	// defaultProbeTimeout is the StartToCloseTimeout applied to the probe activity.
 	defaultProbeTimeout = 5 * time.Minute
-	// defaultFinalizeTimeout is the StartToCloseTimeout applied to the
-	// post-transcode activities (notify, cleanup, failure-webhook).
+	// defaultFinalizeTimeout is the StartToCloseTimeout applied to cleanup and
+	// the failure-webhook activity.
 	defaultFinalizeTimeout = 10 * time.Minute
+	// defaultNotifyTimeout is the StartToCloseTimeout applied to the notify
+	// activity. Notify blocks on Sonarr/Radarr command completion, and those
+	// services run import-disk commands strictly serially across a 3-thread
+	// pool, so a queued scan can wait behind many siblings before executing.
+	// One hour covers ~120 serialized scans at a generous 30s each.
+	defaultNotifyTimeout = 1 * time.Hour
 
 	// defaultMaxAttempts is the RetryPolicy MaximumAttempts applied to probe,
 	// detectcrop, transcode, and the failure-webhook. Single attempt: retry

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -44,7 +44,7 @@ func TestMediaWorkflow_ValidPath_RunsAllActivitiesInOrder(t *testing.T) {
 	env.OnActivity(DetectCropActivityName, mock.Anything, mock.Anything, mock.Anything).Return(cropOut, nil).Once()
 	env.OnActivity(TranscodeActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(transOut, nil).Once()
 	env.OnActivity(NotifyActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	env.ExecuteWorkflow(MediaWorkflowName, MediaInput{FilePath: "/in/file.mp4", MediaType: medialib.MovieType, OutputPath: "/out"})
 
@@ -60,7 +60,7 @@ func TestMediaWorkflow_InvalidPath_SkipsTranscodeAndCallsCleanup(t *testing.T) {
 
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 		Return(ProbeOutput{IsValidMedia: false}, nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	// DetectCrop, Transcode, and Notify must NOT be invoked. The mock fails
 	// the test if any unexpected call arrives because no .Return was
@@ -151,8 +151,8 @@ func TestMediaWorkflow_NotifyAndCleanupRetry(t *testing.T) {
 			return nil
 		})
 
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything).
-		Return(func(_ context.Context, _ MediaInput) error {
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, _ MediaInput, _ TranscodeOutput) error {
 			cleanupAttempts++
 			if cleanupAttempts < 3 {
 				return errors.New("transient cleanup failure")
@@ -349,7 +349,7 @@ func TestMediaWorkflow_TranscodeHeartbeatTimeoutMatchesConfig(t *testing.T) {
 		}).Once()
 
 	env.OnActivity(NotifyActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	env.ExecuteWorkflow(MediaWorkflowName, MediaInput{FilePath: "/in/file.mp4", MediaType: medialib.MovieType, OutputPath: "/out"})
 

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -44,7 +44,7 @@ func TestMediaWorkflow_ValidPath_RunsAllActivitiesInOrder(t *testing.T) {
 	env.OnActivity(DetectCropActivityName, mock.Anything, mock.Anything, mock.Anything).Return(cropOut, nil).Once()
 	env.OnActivity(TranscodeActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(transOut, nil).Once()
 	env.OnActivity(NotifyActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, expectTranscode(transOut)).Return(nil).Once()
 
 	env.ExecuteWorkflow(MediaWorkflowName, MediaInput{FilePath: "/in/file.mp4", MediaType: medialib.MovieType, OutputPath: "/out"})
 
@@ -60,7 +60,9 @@ func TestMediaWorkflow_InvalidPath_SkipsTranscodeAndCallsCleanup(t *testing.T) {
 
 	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).
 		Return(ProbeOutput{IsValidMedia: false}, nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	// Invalid-media path skips Transcode; Cleanup must receive a zero-value
+	// TranscodeOutput so output-side pruning is suppressed.
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, expectTranscode(TranscodeOutput{})).Return(nil).Once()
 
 	// DetectCrop, Transcode, and Notify must NOT be invoked. The mock fails
 	// the test if any unexpected call arrives because no .Return was
@@ -151,7 +153,7 @@ func TestMediaWorkflow_NotifyAndCleanupRetry(t *testing.T) {
 			return nil
 		})
 
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, expectTranscode(TranscodeOutput{DestFilePath: "/out/file.mkv"})).
 		Return(func(_ context.Context, _ MediaInput, _ TranscodeOutput) error {
 			cleanupAttempts++
 			if cleanupAttempts < 3 {
@@ -349,7 +351,7 @@ func TestMediaWorkflow_TranscodeHeartbeatTimeoutMatchesConfig(t *testing.T) {
 		}).Once()
 
 	env.OnActivity(NotifyActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, expectTranscode(TranscodeOutput{DestFilePath: "/out/file.mkv"})).Return(nil).Once()
 
 	env.ExecuteWorkflow(MediaWorkflowName, MediaInput{FilePath: "/in/file.mp4", MediaType: medialib.MovieType, OutputPath: "/out"})
 
@@ -362,3 +364,13 @@ func TestMediaWorkflow_TranscodeHeartbeatTimeoutMatchesConfig(t *testing.T) {
 // stubLibraryClient lives in testhelpers_test.go and satisfies medialib.ArrLibrary
 // for tests that do not exercise the live library calls.
 var _ medialib.ArrLibrary = (*stubLibraryClient)(nil)
+
+// expectTranscode builds a mock matcher that asserts the Cleanup activity
+// received the exact TranscodeOutput the workflow should have passed at this
+// call site. Equality matters here: the valid path must forward the real
+// transcode result (so output-side pruning targets the right file), and the
+// invalid path must pass a zero TranscodeOutput (so pruning is suppressed).
+// Using mock.Anything would let either regression slip through.
+func expectTranscode(want TranscodeOutput) any {
+	return mock.MatchedBy(func(got TranscodeOutput) bool { return got == want })
+}

--- a/workflows/media/workflow.go
+++ b/workflows/media/workflow.go
@@ -76,10 +76,11 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		// Invalid path. Probe has already removed the source file and emitted
 		// the invalid-files counter; Cleanup here is a near-no-op for the file
 		// (RunCleanup tolerates ErrNotExist) but still writes the .done
-		// sentinel when PreserveSource is set.
+		// sentinel when PreserveSource is set. No transcode happened, so an
+		// empty TranscodeOutput suppresses output-side pruning.
 		invalidCleanupCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
 
-		if err := workflow.ExecuteActivity(invalidCleanupCtx, CleanupActivityName, input).Get(invalidCleanupCtx, nil); err != nil {
+		if err := workflow.ExecuteActivity(invalidCleanupCtx, CleanupActivityName, input, TranscodeOutput{}).Get(invalidCleanupCtx, nil); err != nil {
 			return err
 		}
 
@@ -102,7 +103,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		return err
 	}
 
-	notifyCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
+	notifyCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultNotifyTimeout, retryableMaxAttempts))
 
 	if err := workflow.ExecuteActivity(notifyCtx, NotifyActivityName, input, transcode).Get(notifyCtx, nil); err != nil {
 		return err
@@ -110,7 +111,7 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 
 	cleanupCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions(defaultFinalizeTimeout, retryableMaxAttempts))
 
-	if err := workflow.ExecuteActivity(cleanupCtx, CleanupActivityName, input).Get(cleanupCtx, nil); err != nil {
+	if err := workflow.ExecuteActivity(cleanupCtx, CleanupActivityName, input, transcode).Get(cleanupCtx, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- **Block Notify on arr command completion.** `ImportByFilePath` now polls Sonarr/Radarr's `/api/v3/command/{id}` until the command reaches a terminal state. The shared poll loop and terminal-state classification live in a new internal package, `pkg/medialib/internal/arrcommand`; each client supplies a small fetch closure. Completion with `result=unsuccessful` (the case where the scan finishes but no files imported — every file rejected, no eligible files, etc.) is surfaced as an error so the workflow's failure-webhook fires.
- **Prune empty output-side directories.** `PruneOutputDirs` walks up from the transcoded file's path toward the configured `OutputPath`, removing directories that became empty once Sonarr/Radarr drained the file. Best-effort: a still-present file (Sonarr copied rather than moved, or import was rejected) halts pruning. Plumbed through the `Cleanup` activity's signature so the invalid-media branch (no transcode happened) can pass an empty `TranscodeOutput{}` and skip output-side work.
- **Bumped Notify timeout to 1h.** Sonarr serializes `DownloadedEpisodesScan` across its 3-thread executor (`RequiresDiskAccess` blocks other disk commands), so a queued scan can wait many siblings before executing. The previous 10-minute `defaultFinalizeTimeout` was set under the old fire-and-forget assumption; the new `defaultNotifyTimeout` covers ~120 serialized scans at 30 s each. Cleanup keeps the 10-minute timeout.

### Why this matters
Previously, the mirrored output subdirectories created by transcode (to avoid confusing arr services with the download client's path) were never removed. Sonarr only cleans up folders via `ProcessFolder`, but media-processor calls scan with a single file path so `ProcessFile` runs and the parent is left alone. media-processor's existing `RunCleanup` only prunes the source side. The new flow ensures the output tree is collected once Sonarr has actually drained the file — and waiting for completion is the prerequisite that makes that safe.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full unit-test suite passes; new `arrcommand` package, polling table tests, output-pruning cases all green)
- [x] `make lint` (zero issues)
- [ ] Verify on a real Sonarr/Radarr deployment that mirrored output subdirs are removed after a successful scan, and that the workflow's failure-webhook fires when an arr service reports `result=unsuccessful`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imports for Sonarr/Radarr now wait for remote command completion before finishing.
  * Output-side empty directories are pruned automatically after successful imports.

* **Configuration**
  * New poll-interval setting for Sonarr and Radarr import command polling.
  * Added a dedicated notification timeout for workflow notify steps.

* **Improvements**
  * Unified file-path parameter naming across media client methods.
  * Improved error handling around command poll results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->