### PR TITLE
feat(helm): scaledjob foundation with KEDA/Job lifting and idle-exit defaults

### DIFF
--- a/deploy/charts/media-processor/templates/_helpers.tpl
+++ b/deploy/charts/media-processor/templates/_helpers.tpl
@@ -47,6 +47,17 @@ TriggerAuthentication land in the follow-up sub-issue that depends on this one.
 {{- $controllers := .controllers -}}
 {{- $fullName := include "bjw-s.common.lib.chart.names.fullname" $rootContext -}}
 {{- range $name, $ctrl := $controllers }}
+  {{- /* Honor controller.enabled so a user-disabled scaledjob controller
+       produces no output, mirroring bjw-s.common.lib.controller.enabledControllers
+       for the deployment path. Tpl-evaluate the value to also handle the
+       chart's own '{{ … }}' string-template form (the deployment-typed
+       defaults already use that pattern via the post-merge enabled-template
+       eval in common.yaml). */ -}}
+  {{- $enabled := true -}}
+  {{- if hasKey $ctrl "enabled" -}}
+    {{- $enabled = eq (tpl (get $ctrl "enabled" | toString) $rootContext) "true" -}}
+  {{- end -}}
+  {{- if $enabled -}}
   {{- /* Build a synthetic controller object that bjw-s.common.lib.pod.spec /
        pod.metadata.labels / pod.metadata.annotations expect: a dict with the
        controller values plus identifier (and a Job-style restartPolicy default
@@ -96,37 +107,41 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- with $kedaCfg.pollingInterval }}
-  pollingInterval: {{ . }}
+  {{- /* hasKey rather than `with` so an explicit zero (e.g.
+       successfulJobsHistoryLimit: 0 or backoffLimit: 0) is preserved —
+       Go template falsiness drops 0 with `with`, but KEDA / Kubernetes
+       JobSpec accept 0 as a valid value with distinct meaning. */ -}}
+  {{- if hasKey $kedaCfg "pollingInterval" }}
+  pollingInterval: {{ get $kedaCfg "pollingInterval" }}
   {{- end }}
-  {{- with $kedaCfg.successfulJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ . }}
+  {{- if hasKey $kedaCfg "successfulJobsHistoryLimit" }}
+  successfulJobsHistoryLimit: {{ get $kedaCfg "successfulJobsHistoryLimit" }}
   {{- end }}
-  {{- with $kedaCfg.failedJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ . }}
+  {{- if hasKey $kedaCfg "failedJobsHistoryLimit" }}
+  failedJobsHistoryLimit: {{ get $kedaCfg "failedJobsHistoryLimit" }}
   {{- end }}
-  {{- with $kedaCfg.maxReplicaCount }}
-  maxReplicaCount: {{ . }}
+  {{- if hasKey $kedaCfg "maxReplicaCount" }}
+  maxReplicaCount: {{ get $kedaCfg "maxReplicaCount" }}
   {{- end }}
   {{- with $kedaCfg.scalingStrategy }}
   scalingStrategy: {{ . | toYaml | nindent 4 }}
   {{- end }}
   triggers: []
   jobTargetRef:
-    {{- with $jobCfg.parallelism }}
-    parallelism: {{ . }}
+    {{- if hasKey $jobCfg "parallelism" }}
+    parallelism: {{ get $jobCfg "parallelism" }}
     {{- end }}
-    {{- with $jobCfg.completions }}
-    completions: {{ . }}
+    {{- if hasKey $jobCfg "completions" }}
+    completions: {{ get $jobCfg "completions" }}
     {{- end }}
-    {{- with $jobCfg.activeDeadlineSeconds }}
-    activeDeadlineSeconds: {{ . }}
+    {{- if hasKey $jobCfg "activeDeadlineSeconds" }}
+    activeDeadlineSeconds: {{ get $jobCfg "activeDeadlineSeconds" }}
     {{- end }}
-    {{- with $jobCfg.backoffLimit }}
-    backoffLimit: {{ . }}
+    {{- if hasKey $jobCfg "backoffLimit" }}
+    backoffLimit: {{ get $jobCfg "backoffLimit" }}
     {{- end }}
-    {{- with $jobCfg.ttlSecondsAfterFinished }}
-    ttlSecondsAfterFinished: {{ . }}
+    {{- if hasKey $jobCfg "ttlSecondsAfterFinished" }}
+    ttlSecondsAfterFinished: {{ get $jobCfg "ttlSecondsAfterFinished" }}
     {{- end }}
     template:
       metadata:
@@ -137,5 +152,6 @@ spec:
         labels: {{ . | nindent 10 }}
         {{- end }}
       spec: {{ $podSpec | nindent 8 }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/charts/media-processor/templates/_helpers.tpl
+++ b/deploy/charts/media-processor/templates/_helpers.tpl
@@ -20,3 +20,122 @@ Limitation: every nested map's keys are rewritten. Subtrees whose keys are user-
 {{- end -}}
 {{- toYaml $out -}}
 {{- end -}}
+
+{{/*
+scaledjob renders one keda.sh/v1alpha1 ScaledJob per input controller. Caller
+supplies a dict with keys "rootContext" (the chart root, post common.yaml
+merge so .Values.global is populated) and "controllers" (a map of controller
+name -> merged controller values, the partition stashed by common.yaml).
+
+The Job pod template inside each ScaledJob is produced by the same bjw-s
+helpers the Job/Deployment classes use (bjw-s.common.lib.pod.spec,
+bjw-s.common.lib.pod.metadata.labels, bjw-s.common.lib.pod.metadata.annotations),
+so env, volume mounts, securityContext, image, and the
+app.kubernetes.io/controller pod-template label match what a Deployment for
+the same controller would have produced.
+
+KEDA-level fields (.spec.maxReplicaCount, .spec.pollingInterval, …) lift from
+controller.keda.* onto the ScaledJob's top-level spec. Job-level fields
+(backoffLimit, parallelism, …) lift from controller.job.* onto
+.spec.jobTargetRef.spec.
+
+.spec.triggers is intentionally an empty list — the Temporal triggers and the
+TriggerAuthentication land in the follow-up sub-issue that depends on this one.
+*/}}
+{{- define "media-processor.scaledjob" -}}
+{{- $rootContext := .rootContext -}}
+{{- $controllers := .controllers -}}
+{{- $fullName := include "bjw-s.common.lib.chart.names.fullname" $rootContext -}}
+{{- range $name, $ctrl := $controllers }}
+  {{- /* Build a synthetic controller object that bjw-s.common.lib.pod.spec /
+       pod.metadata.labels / pod.metadata.annotations expect: a dict with the
+       controller values plus identifier (and a Job-style restartPolicy default
+       so the rendered pod template would run in a Job context). */ -}}
+  {{- $controllerObject := mustDeepCopy $ctrl -}}
+  {{- $_ := set $controllerObject "identifier" $name -}}
+  {{- $pod := index $controllerObject "pod" | default dict -}}
+  {{- if not (hasKey $pod "restartPolicy") -}}
+    {{- $_ := set $pod "restartPolicy" "Never" -}}
+  {{- end -}}
+  {{- $_ := set $controllerObject "pod" $pod -}}
+
+  {{- $resolvedName := printf "%s-%s" $fullName $name | lower | trunc 63 | trimSuffix "-" -}}
+
+  {{- $topLabels := merge
+    (dict "app.kubernetes.io/controller" $name)
+    (index $controllerObject "labels" | default dict)
+    (include "bjw-s.common.lib.metadata.allLabels" $rootContext | fromYaml)
+  -}}
+  {{- $topAnnotations := merge
+    (index $controllerObject "annotations" | default dict)
+    (include "bjw-s.common.lib.metadata.globalAnnotations" $rootContext | fromYaml)
+  -}}
+
+  {{- $podLabels := include "bjw-s.common.lib.pod.metadata.labels" (dict "rootContext" $rootContext "controllerObject" $controllerObject) -}}
+  {{- $podAnnotations := include "bjw-s.common.lib.pod.metadata.annotations" (dict "rootContext" $rootContext "controllerObject" $controllerObject) -}}
+  {{- $podSpec := include "bjw-s.common.lib.pod.spec" (dict "rootContext" $rootContext "controllerObject" $controllerObject) -}}
+
+  {{- $kedaCfg := index $controllerObject "keda" | default dict -}}
+  {{- $jobCfg := index $controllerObject "job" | default dict }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: {{ $resolvedName }}
+  namespace: {{ $rootContext.Release.Namespace }}
+  {{- with $topLabels }}
+  labels:
+    {{- range $k, $v := . }}
+    {{ printf "%s: %s" $k (tpl $v $rootContext | toYaml) }}
+    {{- end }}
+  {{- end }}
+  {{- with $topAnnotations }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ printf "%s: %s" $k (tpl $v $rootContext | toYaml) }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with $kedaCfg.pollingInterval }}
+  pollingInterval: {{ . }}
+  {{- end }}
+  {{- with $kedaCfg.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with $kedaCfg.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with $kedaCfg.maxReplicaCount }}
+  maxReplicaCount: {{ . }}
+  {{- end }}
+  {{- with $kedaCfg.scalingStrategy }}
+  scalingStrategy: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  triggers: []
+  jobTargetRef:
+    {{- with $jobCfg.parallelism }}
+    parallelism: {{ . }}
+    {{- end }}
+    {{- with $jobCfg.completions }}
+    completions: {{ . }}
+    {{- end }}
+    {{- with $jobCfg.activeDeadlineSeconds }}
+    activeDeadlineSeconds: {{ . }}
+    {{- end }}
+    {{- with $jobCfg.backoffLimit }}
+    backoffLimit: {{ . }}
+    {{- end }}
+    {{- with $jobCfg.ttlSecondsAfterFinished }}
+    ttlSecondsAfterFinished: {{ . }}
+    {{- end }}
+    template:
+      metadata:
+        {{- with $podAnnotations }}
+        annotations: {{ . | nindent 10 }}
+        {{- end }}
+        {{- with $podLabels }}
+        labels: {{ . | nindent 10 }}
+        {{- end }}
+      spec: {{ $podSpec | nindent 8 }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -553,6 +553,30 @@ config.worker.stopTimeout and config.worker.metrics.scrapeWaitTimeout).
   {{- $userCtrl := index $userControllers $name | default dict -}}
   {{- $reps := index $userCtrl "replicas" | default 1 -}}
   {{- $pdbEnabled := gt ($reps | int) 1 -}}
+
+  {{/* For scaledjob-typed workers, inject the WORKER_IDLE_EXIT_AFTER chart default
+     onto the per-worker env dict before merging user values. 5m for activity-only
+     workers; 15m for workers whose activities resolve to include the workflow
+     token. Resolution mirrors cmd/worker/activities_resolver.go: tokens are
+     evaluated left-to-right against an empty set, "all" expands to every known
+     token (which includes workflow), "workflow" adds it, "!workflow" removes it.
+     User-supplied resources.controllers.<name>.containers.main.env.WORKER_IDLE_EXIT_AFTER
+     overrides this default via the resources mustMergeOverwrite below. */}}
+  {{- if eq (index $userCtrl "type" | default "deployment") "scaledjob" -}}
+    {{- $entry := index $workers $name -}}
+    {{- $activitiesList := index $entry "activities" -}}
+    {{- $includesWorkflow := false -}}
+    {{- range $tok := $activitiesList -}}
+      {{- $t := toString $tok -}}
+      {{- if or (eq $t "all") (eq $t "workflow") -}}
+        {{- $includesWorkflow = true -}}
+      {{- else if eq $t "!workflow" -}}
+        {{- $includesWorkflow = false -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $defaultIdle := ternary "15m" "5m" $includesWorkflow -}}
+    {{- $_ := set (index $workerEnvByName $name) "WORKER_IDLE_EXIT_AFTER" $defaultIdle -}}
+  {{- end -}}
   {{- $controller := dict
     "strategy" "RollingUpdate"
     "containers" (dict $workerContainerName (dict
@@ -693,6 +717,38 @@ a ServiceMonitor would lose the pod from Endpoints and miss the final scrape.
 {{- $mergedResources := mustMergeOverwrite $computedAdditions (mustDeepCopy .Values.resources) -}}
 
 {{/* ============================================================ */}}
+{{/* Controller-type validation + scaledjob partition             */}}
+{{/* ============================================================ */}}
+{{/*
+Allowed controller types are bjw-s 4.6.2's set plus "scaledjob" (rendered by
+this chart as a keda.sh/v1alpha1 ScaledJob). Unknown types fail here with a
+controller-named message rather than reaching bjw-s, which would emit a less
+specific "Not a valid controller.type" without naming the controller.
+
+Scaledjob entries are partitioned aside into $scaledjobControllers (keyed by
+controller name, sharing the same dict references that live in
+$mergedResources.controllers so subsequent post-merge mutations — image-tag
+tpl resolution, enabled-template eval — apply to them too) and stripped from
+$mergedResources.controllers below so the bjw-s loader never sees a type it
+does not support. The new templates/scaledjob.yaml renders them as ScaledJobs.
+*/}}
+{{- $allowedControllerTypes := list "deployment" "daemonset" "statefulset" "cronjob" "job" "scaledjob" -}}
+{{- $scaledjobControllers := dict -}}
+{{- $mergedControllers := index $mergedResources "controllers" -}}
+{{- range $name, $ctrl := $mergedControllers -}}
+  {{- $type := index $ctrl "type" | default "deployment" -}}
+  {{- if not (has $type $allowedControllerTypes) -}}
+    {{- fail (printf "resources.controllers.%s.type %q is not a valid controller type (allowed: %s)" $name $type (join ", " $allowedControllerTypes)) -}}
+  {{- end -}}
+  {{- if eq $type "scaledjob" -}}
+    {{- if not (has $name $workerNames) -}}
+      {{- fail (printf "resources.controllers.%s has type scaledjob but is not declared in workers" $name) -}}
+    {{- end -}}
+    {{- $_ := set $scaledjobControllers $name $ctrl -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* ============================================================ */}}
 {{/* Worker image tags: evaluate tpl strings post-merge so user   */}}
 {{/* overrides of containers.main.image.tag are honoured.        */}}
 {{/* ============================================================ */}}
@@ -741,5 +797,47 @@ a ServiceMonitor would lose the pod from Endpoints and miss the final scrape.
 {{- $mergedValues = mustMergeOverwrite $mergedValues $mergedResources -}}
 {{- $_ := set . "Values" $mergedValues -}}
 
-{{/* Hand off to the bjw-s common library */}}
-{{- include "bjw-s.common.loader.all" . }}
+{{/* Run the bjw-s init pass (merges .Values.common over .Values, populating
+   .Values.global etc.) before our helper invokes bjw-s.common.lib.chart.names.fullname
+   and friends. We split init from generate so the scaledjob render below can
+   reuse the post-init bjw-s helpers without bjw-s' generate pass having seen
+   the scaledjob entries (those would fail bjw-s' controller-type validation). */}}
+{{- include "bjw-s.common.loader.init" . }}
+
+{{/* Render scaledjob controllers (partitioned aside above) as
+   keda.sh/v1alpha1 ScaledJob resources. Done before stripping their
+   advancedMounts entries so bjw-s.common.lib.pod.field.volumes (called
+   from pod.spec inside the helper) still finds the persistence mounts
+   for scaledjob workers and produces matching volume / volumeMount
+   YAML in the rendered Job pod template.
+
+   Inlined in this template (rather than a separate templates/scaledjob.yaml
+   file) because Helm does not reliably propagate intra-template Values
+   mutations across template files. */}}
+{{- if $scaledjobControllers -}}
+{{- include "media-processor.scaledjob" (dict "rootContext" . "controllers" $scaledjobControllers) }}
+{{- end -}}
+
+{{/* ============================================================ */}}
+{{/* Strip scaledjob controllers + their advancedMounts entries   */}}
+{{/* from .Values before handing off to bjw-s' generate pass.     */}}
+{{/* Stripping the controllers keeps bjw-s from rendering them as */}}
+{{/* Jobs/etc. and from failing controller-type validation;       */}}
+{{/* stripping their advancedMounts entries on each persistence   */}}
+{{/* item keeps bjw-s.common.lib.chart.validate from failing on   */}}
+{{/* "No enabled controller found" for the now-removed names.    */}}
+{{/* ============================================================ */}}
+{{- $valuesControllers := index .Values "controllers" -}}
+{{- $valuesPersistence := index .Values "persistence" | default dict -}}
+{{- range $name := keys $scaledjobControllers -}}
+  {{- $_ := unset $valuesControllers $name -}}
+  {{- range $persistenceValues := values $valuesPersistence -}}
+    {{- $advancedMounts := index $persistenceValues "advancedMounts" -}}
+    {{- if $advancedMounts -}}
+      {{- $_ := unset $advancedMounts $name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Hand off the rest of bjw-s rendering. */}}
+{{- include "bjw-s.common.loader.generate" . }}

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -225,6 +225,18 @@ workers: {}
 # resources.controllers in this file. Override individual worker controllers by
 # adding resources.controllers.<workerName> with the standard bjw-s controller
 # schema (replicas, pod, containers.main, etc.).
+#
+# Controller `type` selects the rendered Kubernetes kind. The chart accepts
+# bjw-s' supported types (`deployment` (default), `daemonset`, `statefulset`,
+# `cronjob`, `job`) plus `scaledjob`, which renders a `keda.sh/v1alpha1`
+# ScaledJob in place of the Deployment for that worker (KEDA must be installed
+# separately). `type: scaledjob` is only valid for entries that match a
+# `workers.<name>` key. Lift KEDA-level config under `resources.controllers.<name>.keda.*`
+# (e.g. `pollingInterval`, `maxReplicaCount`) and Job-template config under
+# `resources.controllers.<name>.job.*` (e.g. `parallelism`, `backoffLimit`).
+# Scaledjob workers default `WORKER_IDLE_EXIT_AFTER` to `5m`, or `15m` if
+# the worker's activities resolve to include the `workflow` token; override
+# via `containers.main.env.WORKER_IDLE_EXIT_AFTER`.
 resources:
   controllers:
     watcher:


### PR DESCRIPTION
Fixes #222.

## Summary

Adds the chart skeleton that renders a `keda.sh/v1alpha1` `ScaledJob` for any worker controller whose `resources.controllers.<name>.type` is `scaledjob`, while leaving every other controller type rendering through bjw-s as today. Foundation sub-issue of the parent KEDA rollout (#218) — Temporal triggers / `TriggerAuthentication` (#223) and `PodDisruptionBudget` + helm-template smoke test (#224) layer on top.

A `ScaledJob` rendered by this PR has an empty `triggers` list and so does not actually scale yet — that is intentional and will be wired up in #223.

### How it works

1. After `templates/common.yaml` deep-merges user resources over the chart-computed controller defaults, it validates every controller's `type` (allowed: `deployment`, `daemonset`, `statefulset`, `cronjob`, `job`, `scaledjob`) and partitions the `type: scaledjob` entries aside.
2. The bjw-s init pass runs (so `.Values.global` etc. are populated) and the new `media-processor.scaledjob` helper renders one ScaledJob per partitioned entry, producing the Job pod template via the same bjw-s helpers Deployments use (`bjw-s.common.lib.pod.spec`, `pod.metadata.labels`, `pod.metadata.annotations`). The `app.kubernetes.io/controller: <name>` label comes through `pod.metadata.labels` automatically.
3. KEDA-level fields lift from `controller.keda.*` (`pollingInterval`, `successfulJobsHistoryLimit`, `failedJobsHistoryLimit`, `maxReplicaCount`, `scalingStrategy`); Job-level fields lift from `controller.job.*` (`parallelism`, `completions`, `activeDeadlineSeconds`, `backoffLimit`, `ttlSecondsAfterFinished`).
4. The scaledjob entries (and the corresponding `advancedMounts` keys on every persistence item) are stripped from `.Values` and the bjw-s generate pass runs, so bjw-s never sees a controller type it does not support and `bjw-s.common.lib.chart.validate` does not fail on now-removed names.

Inlined in `common.yaml` (rather than a separate `templates/scaledjob.yaml`) because Helm does not reliably propagate intra-template `.Values` mutations across template files.

### Idle-exit defaults

Scaledjob workers default `WORKER_IDLE_EXIT_AFTER` to `5m`, or `15m` when the worker's `activities` resolve to include the `workflow` token. Resolution mirrors `cmd/worker/activities_resolver.go` (left-to-right grammar: `all` expands to every known token incl. `workflow`, `workflow` adds it, `!workflow` removes it). User-supplied `containers.main.env.WORKER_IDLE_EXIT_AFTER` overrides the chart default.

## Test plan

- [x] `helm template` against default values produces byte-identical output to master (verified locally — `diff` empty).
- [x] `helm template` against a values file mixing `type: deployment` and `type: scaledjob` workers renders one Deployment and one ScaledJob with matching pod templates.
- [x] Rendered ScaledJob carries `app.kubernetes.io/controller: <name>` on its Job pod template.
- [x] Unknown `type:` values fail with a controller-named error message.
- [x] `type: scaledjob` for a name that does not appear in `workers` fails with a controller-named error message.
- [x] Activity-only scaledjob workers default to `WORKER_IDLE_EXIT_AFTER=5m`; workers with `["all"]` or `["workflow"]` default to `15m`; `["all", "!workflow"]` defaults to `5m`.
- [x] User-supplied `containers.main.env.WORKER_IDLE_EXIT_AFTER` overrides the chart default.
- [x] `helm lint` clean for both default and mixed values.
- [x] `enabled: false` on a scaledjob controller produces no output (added in review fixup f064810).
- [x] Explicit `0` values for KEDA/Job lifted fields are preserved in the rendered manifest (added in review fixup f064810).

## Out of scope

- Temporal triggers, `TriggerAuthentication` → #223.
- `PodDisruptionBudget` for `type: scaledjob`, helm-template smoke test in CI → #224.
- Operator-facing docs in `docs/configuration.md` → parent docs sub-issue #219. Limited the doc surface here to the new `type` field comment in `values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)