### PR TITLE
feat(helm): chart-side PodDisruptionBudget for scaledjob controllers

### DIFF
--- a/deploy/charts/media-processor/templates/_helpers.tpl
+++ b/deploy/charts/media-processor/templates/_helpers.tpl
@@ -194,6 +194,8 @@ metadata:
 spec:
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ include "bjw-s.common.lib.chart.names.name" $rootContext | quote }}
+      app.kubernetes.io/instance: {{ $rootContext.Release.Name | quote }}
       app.kubernetes.io/controller: {{ $controllerName | quote }}
   {{- /* hasKey + non-nil so explicit zero (the scaledjob chart default's
        maxUnavailable: 0 is exactly this case) survives, but a user-supplied

--- a/deploy/charts/media-processor/templates/_helpers.tpl
+++ b/deploy/charts/media-processor/templates/_helpers.tpl
@@ -202,10 +202,21 @@ spec:
        `null` (e.g. `maxUnavailable: null` to clear the chart default before
        supplying a different field) drops the key from the rendered spec
        rather than emitting `maxUnavailable:` with no value. */ -}}
-  {{- if and (hasKey $pdb "minAvailable") (not (kindIs "invalid" (index $pdb "minAvailable"))) }}
+  {{- $hasMin := and (hasKey $pdb "minAvailable") (not (kindIs "invalid" (index $pdb "minAvailable"))) -}}
+  {{- $hasMax := and (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" (index $pdb "maxUnavailable"))) -}}
+  {{- /* policy/v1 PodDisruptionBudget rejects spec with both fields set
+       (apiserver: "minAvailable and maxUnavailable cannot be both set").
+       The scaledjob chart default lands maxUnavailable: 0, so an operator
+       override that adds minAvailable without explicitly nulling the
+       default is a real footgun — fail at template time with a controller-
+       named message instead of letting kubectl apply surface it. */ -}}
+  {{- if and $hasMin $hasMax -}}
+    {{- fail (printf "podDisruptionBudget for controller %q: minAvailable and maxUnavailable are mutually exclusive; set the unused field to null" $controllerName) -}}
+  {{- end }}
+  {{- if $hasMin }}
   minAvailable: {{ get $pdb "minAvailable" }}
   {{- end }}
-  {{- if and (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" (index $pdb "maxUnavailable"))) }}
+  {{- if $hasMax }}
   maxUnavailable: {{ get $pdb "maxUnavailable" }}
   {{- end }}
 {{- end -}}

--- a/deploy/charts/media-processor/templates/_helpers.tpl
+++ b/deploy/charts/media-processor/templates/_helpers.tpl
@@ -138,6 +138,77 @@ spec:
 {{- end -}}
 
 {{/*
+podDisruptionBudget renders one policy/v1 PodDisruptionBudget for a single
+scaledjob controller. bjw-s renders PDBs through its own controller loop,
+which the chart cannot reach for type: scaledjob workers (they are stripped
+from the controllers map before bjw-s' generate pass runs), so the chart
+emits PDBs for those workers itself.
+
+Caller supplies a dict with keys "rootContext" (the chart root, post
+common.yaml merge so bjw-s helpers resolve fullname / labels), "controllerName"
+(the worker name, used both as the resource-name suffix and as the
+app.kubernetes.io/controller selector value — matches the label
+bjw-s.common.lib.pod.metadata.labels stamps onto the rendered Job pod
+template), and "pdb" (the merged podDisruptionBudget block carrying any
+combination of minAvailable / maxUnavailable from the chart default plus
+operator overrides).
+
+`hasKey` rather than `with` for minAvailable / maxUnavailable so an explicit
+zero (the scaledjob chart default's maxUnavailable: 0 is exactly this case)
+is preserved — Go template falsiness drops 0 with `with`, but PDB treats 0
+as a valid value with distinct meaning.
+
+Emitted only when the merged controller still carries a podDisruptionBudget
+block; the gating happens in the caller (templates/common.yaml) so a user-
+supplied podDisruptionBudget: null or .enabled: false produces no output.
+*/}}
+{{- define "media-processor.podDisruptionBudget" -}}
+{{- $rootContext := .rootContext -}}
+{{- $controllerName := .controllerName -}}
+{{- $pdb := .pdb -}}
+{{- $fullName := include "bjw-s.common.lib.chart.names.fullname" $rootContext -}}
+{{- $resolvedName := printf "%s-%s" $fullName $controllerName | lower | trunc 63 | trimSuffix "-" -}}
+{{- $topLabels := merge
+    (dict "app.kubernetes.io/controller" $controllerName)
+    (include "bjw-s.common.lib.metadata.allLabels" $rootContext | fromYaml)
+-}}
+{{- $topAnnotations := include "bjw-s.common.lib.metadata.globalAnnotations" $rootContext | fromYaml -}}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $resolvedName }}
+  namespace: {{ $rootContext.Release.Namespace }}
+  {{- with $topLabels }}
+  labels:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $rootContext | quote }}
+    {{- end }}
+  {{- end }}
+  {{- with $topAnnotations }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $rootContext | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: {{ $controllerName | quote }}
+  {{- /* hasKey + non-nil so explicit zero (the scaledjob chart default's
+       maxUnavailable: 0 is exactly this case) survives, but a user-supplied
+       `null` (e.g. `maxUnavailable: null` to clear the chart default before
+       supplying a different field) drops the key from the rendered spec
+       rather than emitting `maxUnavailable:` with no value. */ -}}
+  {{- if and (hasKey $pdb "minAvailable") (not (kindIs "invalid" (index $pdb "minAvailable"))) }}
+  minAvailable: {{ get $pdb "minAvailable" }}
+  {{- end }}
+  {{- if and (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" (index $pdb "maxUnavailable"))) }}
+  maxUnavailable: {{ get $pdb "maxUnavailable" }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 scaledjob renders one keda.sh/v1alpha1 ScaledJob per input controller. Caller
 supplies a dict with keys "rootContext" (the chart root, post common.yaml
 merge so .Values.global is populated) and "controllers" (a map of controller

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -612,14 +612,38 @@ config.worker.stopTimeout and config.worker.metrics.scrapeWaitTimeout).
 {{- $userControllers := index .Values.resources "controllers" | default dict -}}
 {{- $computedWorkerControllers := dict -}}
 {{- range $name := $workerNames -}}
-  {{/* PDB.enabled computed as a literal bool from the user-supplied replicas
-     value (or 1 when unset). Done at chart-build time rather than as a deferred
-     tpl string because resources.controllers.<workerName> may be absent in the
-     user values entirely (the default case), and chained index on missing keys
-     panics. */}}
   {{- $userCtrl := index $userControllers $name | default dict -}}
-  {{- $reps := index $userCtrl "replicas" | default 1 -}}
-  {{- $pdbEnabled := gt ($reps | int) 1 -}}
+  {{- $controllerType := index $userCtrl "type" | default "deployment" -}}
+
+  {{/* PDB default depends on controller type. Deployment-typed defaults gate
+     enabled on replicas > 1 and use minAvailable: 1 (the pre-multi-worker
+     chart's behaviour). Scaledjob-typed defaults are always enabled with
+     maxUnavailable: 0 — replicas is not meaningful for ScaledJob, and a node
+     hosting an in-flight transcode should be undrainable until the activity
+     completes (or its Temporal heartbeat times out). PDB.enabled is computed
+     here as a literal bool rather than a deferred tpl string because
+     resources.controllers.<workerName> may be absent in the user values
+     entirely (the default case) and chained index on missing keys panics. */}}
+  {{- $pdbDefault := dict -}}
+  {{- if eq $controllerType "scaledjob" -}}
+    {{- $pdbDefault = dict "enabled" true "maxUnavailable" 0 -}}
+  {{- else -}}
+    {{- $reps := index $userCtrl "replicas" | default 1 -}}
+    {{- $pdbDefault = dict "enabled" (gt ($reps | int) 1) "minAvailable" 1 -}}
+  {{- end -}}
+
+  {{/* Detect a user-explicit `podDisruptionBudget: null` opt-out before merge.
+     mustMergeOverwrite skips nil source values, so a chart default left in
+     $controller would silently override `null` and the PDB would still
+     emit. Setting podDisruptionBudget on $controller is gated on this flag
+     so the merged resource simply has no podDisruptionBudget key in the
+     null-opt-out case. */}}
+  {{- $userNulledPDB := false -}}
+  {{- if hasKey $userCtrl "podDisruptionBudget" -}}
+    {{- if kindIs "invalid" (index $userCtrl "podDisruptionBudget") -}}
+      {{- $userNulledPDB = true -}}
+    {{- end -}}
+  {{- end -}}
 
   {{/* For scaledjob-typed workers, inject the WORKER_IDLE_EXIT_AFTER chart default
      onto the per-worker env dict before merging user values. 5m for activity-only
@@ -629,7 +653,7 @@ config.worker.stopTimeout and config.worker.metrics.scrapeWaitTimeout).
      token (which includes workflow), "workflow" adds it, "!workflow" removes it.
      User-supplied resources.controllers.<name>.containers.main.env.WORKER_IDLE_EXIT_AFTER
      overrides this default via the resources mustMergeOverwrite below. */}}
-  {{- if eq (index $userCtrl "type" | default "deployment") "scaledjob" -}}
+  {{- if eq $controllerType "scaledjob" -}}
     {{- $entry := index $workers $name -}}
     {{- $activitiesList := index $entry "activities" -}}
     {{- $includesWorkflow := false -}}
@@ -688,14 +712,13 @@ config.worker.stopTimeout and config.worker.metrics.scrapeWaitTimeout).
       )
       "env" (index $workerEnvByName $name)
     ))
-    "podDisruptionBudget" (dict
-      "enabled" $pdbEnabled
-      "minAvailable" 1
-    )
     "pod" (dict
       "terminationGracePeriodSeconds" 120
     )
   -}}
+  {{- if not $userNulledPDB -}}
+    {{- $_ := set $controller "podDisruptionBudget" $pdbDefault -}}
+  {{- end -}}
   {{- $_ := set $computedWorkerControllers $name $controller -}}
 {{- end -}}
 
@@ -984,6 +1007,25 @@ metadata:
 type: Opaque
 stringData:
   {{ $kedaResolvedSecretKey }}: {{ $kedaAPIKeyValue | quote }}
+{{- end }}
+
+{{- /* Per-controller PodDisruptionBudget. The merged controller dict still
+     carries the merged podDisruptionBudget block at this point — the
+     post-merge enabled-template strip pass above either deleted the whole
+     key (enabled: false opt-out) or stripped just the enabled key
+     (enabled: true → live). A user-supplied podDisruptionBudget: null
+     was caught pre-merge in the per-worker controller-defaults block above,
+     so the merged dict simply has no podDisruptionBudget key in that case
+     and the helper invocation is skipped. */ -}}
+{{- range $name, $ctrl := $enabledScaledjobControllers }}
+{{- $pdb := index $ctrl "podDisruptionBudget" }}
+{{- if $pdb }}
+{{ include "media-processor.podDisruptionBudget" (dict
+    "rootContext" $
+    "controllerName" $name
+    "pdb" $pdb
+  ) }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -353,6 +353,15 @@ resources:
     # METRICS_SCRAPE_WAIT_TIMEOUT + buffer). Override per-worker by adding
     # resources.controllers.<name> here.
     #
+    # podDisruptionBudget defaults differ by controller type:
+    #   - type: deployment (default) — enabled when replicas > 1, minAvailable: 1.
+    #   - type: scaledjob          — always enabled, maxUnavailable: 0 (a node
+    #     hosting an in-flight transcode is undrainable until the activity
+    #     completes or its Temporal heartbeat times out).
+    # Opt out per-controller via either form:
+    #   resources.controllers.<name>.podDisruptionBudget: null
+    #   resources.controllers.<name>.podDisruptionBudget.enabled: false
+    #
     # DRA GPU example (requires config.worker.media.hardware.mountHostDevice: false):
     # transcode:
     #   pod:


### PR DESCRIPTION
Fixes #224

## Summary

Chart-side `PodDisruptionBudget` for every `type: scaledjob` worker. Default `maxUnavailable: 0` so a node hosting an in-flight transcode is undrainable until the activity completes (or its Temporal heartbeat times out). Selector `app.kubernetes.io/controller: <name>` matches the label `bjw-s.common.lib.pod.metadata.labels` stamps onto the rendered Job pod template (set by #225). Two opt-out paths: `podDisruptionBudget: null` (detected pre-merge, since `mustMergeOverwrite` skips nil source values) or `podDisruptionBudget.enabled: false` (handled by the existing post-merge enabled-template strip).

AC-4 (`make helm-smoke-test` target) and AC-5 (CI step) were dropped from this issue's scope per [comment](https://github.com/solidDoWant/media-processor/issues/224#issuecomment-IC_kwDORlxBLs8AAAABBe7etg). Manual validation results below stand in for the would-have-been smoke test.

## Changes

- `deploy/charts/media-processor/templates/common.yaml` — branch chart-default `podDisruptionBudget` on controller type (scaledjob → `{enabled: true, maxUnavailable: 0}`; deployment → existing `{enabled: gt replicas 1, minAvailable: 1}`); pre-merge null-opt-out detection; iterate `$enabledScaledjobControllers` after the existing helper invocations to call the new PDB helper.
- `deploy/charts/media-processor/templates/_helpers.tpl` — new `media-processor.podDisruptionBudget` helper rendering `policy/v1 PodDisruptionBudget` with selector + merged `minAvailable`/`maxUnavailable`. Uses `hasKey` + non-nil checks so an explicit `0` survives but a user-supplied nested `null` drops the field cleanly.
- `deploy/charts/media-processor/values.yaml` — operator-facing comment documenting the per-type PDB defaults and the two opt-out forms.

## Test plan / manual validation

All run against `helm 3.19.1` with `bjw-s common 4.6.2`:

- [x] **AC-3 — default render unchanged**: `helm template` against minimal values (one watcher, default workers map → single `main` worker, no scaledjob controllers) yields the same set of resources as `origin/master` with byte-identical content (any line-level reorder is pre-existing non-deterministic Go map iteration; reproduced on master at the same frequency).
- [x] **AC-1 — default scaledjob PDB**: fixture with `transcode.type: scaledjob` emits exactly one `policy/v1 PodDisruptionBudget` named `mp-media-processor-transcode`, `selector.matchLabels: app.kubernetes.io/controller: "transcode"`, `maxUnavailable: 0`, `minAvailable` absent.
- [x] **AC-2 — `podDisruptionBudget: null` opt-out**: same fixture with the override → 0 PDBs in the rendered output.
- [x] **AC-2 — `podDisruptionBudget.enabled: false` opt-out**: same fixture with the override → 0 PDBs in the rendered output.
- [x] **Multi-scaledjob fixture**: two scaledjob workers (one with default PDB, one with user override `minAvailable: 0` + `maxUnavailable: null`) renders cleanly: one PDB per worker, correct selector per worker, override flows through, nested `null` drops the field.
- [x] **`helm lint`**: passes against the default fixture, the scaledjob fixture, and both opt-out fixtures.
- [x] **KEDA v1alpha1 schema validation**: every emitted `ScaledJob` document validates clean against the upstream KEDA `keda.sh_scaledjobs.yaml` CRD `openAPIV3Schema` extracted as JSON Schema (Python `jsonschema` + `pyyaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
