### PR TITLE
feat: per-watch input volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sonarr/Radarr's `/downloads` is bind-mounted from `/processed-output` on the hos
 2. Sonarr/Radarr sends the release to the download client.
 3. The download client saves the completed file to `/downloads` and reports the path back to Sonarr/Radarr.
 4. The watcher detects the new file and starts a Temporal workflow execution.
-5. The worker picks up the job: it probes the file, detects black-bar crop, and writes an MKV output to the directory specified by `output.path` in the watcher config (mirroring the input's subdirectory under that path when `watchedPath` is a parent of the input file). Non-H.264/H.265 video is re-encoded to H.265; H.264 or H.265 sources already in MKV are remuxed without re-encode unless a crop is being applied.
+5. The worker picks up the job: it probes the file, detects black-bar crop, and writes an MKV output to the directory specified by `output.path` in the watcher config (mirroring the input's subdirectory under that path when `input.path` is a parent of the input file). Non-H.264/H.265 video is re-encoded to H.265; H.264 or H.265 sources already in MKV are remuxed without re-encode unless a crop is being applied.
 6. The worker calls the Radarr or Sonarr API to trigger a library rescan using the transcoded output file path. When `output.remotePath` is configured, the `output.path` prefix in that path is replaced by `output.remotePath` to produce the path as Sonarr/Radarr sees it (e.g., local `/processed-output/movies/film.mkv` becomes `/downloads/movies/film.mkv` when `output.remotePath` is `/downloads`).
 7. Sonarr/Radarr scans the notified path, finds the processed file, and imports it into the library.
 
@@ -62,12 +62,14 @@ Minimal watcher config:
 ```yaml
 watches:
   - name: movies
-    watchedPath: /downloads/movies
+    input:
+      path: /downloads/movies
     mediaType: movie
     output:
       path: /processed/movies
   - name: shows
-    watchedPath: /downloads/tv
+    input:
+      path: /downloads/tv
     mediaType: show
     output:
       path: /processed/tv

--- a/cmd/watcher/config_test.go
+++ b/cmd/watcher/config_test.go
@@ -30,12 +30,14 @@ func TestLoadConfig(t *testing.T) {
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
   - name: shows
-    watchedPath: /watch/shows
+    input:
+      path: /watch/shows
     mediaType: show
     output:
       path: /out/shows
@@ -43,8 +45,8 @@ watches:
 			expected: Config{
 				ScanInterval: watcherconfig.DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/watch/movies", MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies"}},
-					{Name: "shows", WatchedPath: "/watch/shows", MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: "/out/shows"}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: "/watch/movies"}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies"}},
+					{Name: "shows", Input: watcherconfig.WatchEntryInput{Path: "/watch/shows"}, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: "/out/shows"}},
 				},
 			},
 		},
@@ -76,7 +78,8 @@ watches: []
 			name: "omitted name in watch entry returns error",
 			content: `
 watches:
-  - watchedPath: /watch/movies
+  - input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -88,7 +91,8 @@ watches:
 			content: `
 watches:
   - name: ""
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -96,7 +100,7 @@ watches:
 			errFunc: require.Error,
 		},
 		{
-			name: "omitted watchedPath in watch entry returns error",
+			name: "omitted input.path in watch entry returns error",
 			content: `
 watches:
   - name: movies
@@ -107,11 +111,12 @@ watches:
 			errFunc: require.Error,
 		},
 		{
-			name: "empty watchedPath in watch entry returns error",
+			name: "empty input.path in watch entry returns error",
 			content: `
 watches:
   - name: movies
-    watchedPath: ""
+    input:
+      path: ""
     mediaType: movie
     output:
       path: /out/movies
@@ -123,7 +128,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
 `,
 			errFunc: require.Error,
@@ -133,7 +139,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: ""
@@ -145,7 +152,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -154,7 +162,7 @@ watches:
 			expected: Config{
 				ScanInterval: watcherconfig.DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/watch/movies", MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies", RemotePath: "/remote/movies"}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: "/watch/movies"}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies", RemotePath: "/remote/movies"}},
 				},
 			},
 		},
@@ -163,7 +171,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: ""
     output:
       path: /out/movies
@@ -175,7 +184,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: UnknownType
     output:
       path: /out/movies
@@ -217,7 +227,8 @@ watches: []
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     preserveSource: true
     output:
@@ -226,7 +237,7 @@ watches:
 			expected: Config{
 				ScanInterval: watcherconfig.DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/watch/movies", MediaType: medialib.MovieType, PreserveSource: true, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies"}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: "/watch/movies"}, MediaType: medialib.MovieType, PreserveSource: true, Output: watcherconfig.WatchEntryOutput{Path: "/out/movies"}},
 				},
 			},
 		},
@@ -235,7 +246,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -249,7 +261,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -263,7 +276,8 @@ watches:
 			content: `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -309,7 +323,8 @@ func TestLoadConfig_NullIgnorePatternEntryDropped(t *testing.T) {
 	content := `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies
@@ -331,7 +346,8 @@ func TestLoadConfig_IgnorePatternsParsedAndCompiled(t *testing.T) {
 	content := `
 watches:
   - name: movies
-    watchedPath: /watch/movies
+    input:
+      path: /watch/movies
     mediaType: movie
     output:
       path: /out/movies

--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -369,14 +369,14 @@ func validateWatchDirs(cfg *Config) error {
 	errs := make([]error, 0, len(cfg.Watches))
 
 	for _, w := range cfg.Watches {
-		info, err := os.Stat(w.WatchedPath)
+		info, err := os.Stat(w.Input.Path)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("watch directory %q: %w", w.WatchedPath, err))
+			errs = append(errs, fmt.Errorf("watch directory %q: %w", w.Input.Path, err))
 			continue
 		}
 
 		if !info.IsDir() {
-			errs = append(errs, fmt.Errorf("watch path %q is not a directory", w.WatchedPath))
+			errs = append(errs, fmt.Errorf("watch path %q is not a directory", w.Input.Path))
 		}
 	}
 
@@ -404,9 +404,9 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 		// Normalise the watch path to an absolute path once per entry so that watchRoot
 		// is always comparable to the absolute file paths produced inside the walk callback.
-		absWatchRoot, err := filepath.Abs(w.WatchedPath)
+		absWatchRoot, err := filepath.Abs(w.Input.Path)
 		if err != nil {
-			mappingErrs = append(mappingErrs, fmt.Errorf("resolve absolute path for watch directory %q: %w", w.WatchedPath, err))
+			mappingErrs = append(mappingErrs, fmt.Errorf("resolve absolute path for watch directory %q: %w", w.Input.Path, err))
 			errs = append(errs, mappingErrs...)
 
 			continue
@@ -414,7 +414,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 
 		trimmedOutputPath := strings.TrimSpace(w.Output.Path)
 		if trimmedOutputPath == "" {
-			mappingErrs = append(mappingErrs, fmt.Errorf("output.path is blank or whitespace-only for watch %q (watched path %q)", w.Name, w.WatchedPath))
+			mappingErrs = append(mappingErrs, fmt.Errorf("output.path is blank or whitespace-only for watch %q (watched path %q)", w.Name, w.Input.Path))
 			errs = append(errs, mappingErrs...)
 
 			continue
@@ -509,7 +509,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				return err
 			}
 
-			mappingErrs = append(mappingErrs, fmt.Errorf("walk directory %q: %w", w.WatchedPath, err))
+			mappingErrs = append(mappingErrs, fmt.Errorf("walk directory %q: %w", w.Input.Path, err))
 		}
 
 		slog.InfoContext(ctx, "scan complete",

--- a/cmd/watcher/watcher_test.go
+++ b/cmd/watcher/watcher_test.go
@@ -114,7 +114,7 @@ func TestValidateWatchDirs(t *testing.T) {
 			name: "existing directory passes",
 			cfg: &Config{
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: t.TempDir(), MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: t.TempDir()}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 				},
 			},
 			errFunc: require.NoError,
@@ -123,7 +123,7 @@ func TestValidateWatchDirs(t *testing.T) {
 			name: "missing directory returns error",
 			cfg: &Config{
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/nonexistent/path/abc123", MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: "/nonexistent/path/abc123"}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 				},
 			},
 			errFunc: require.Error,
@@ -132,8 +132,8 @@ func TestValidateWatchDirs(t *testing.T) {
 			name: "all errors reported when multiple dirs are missing",
 			cfg: &Config{
 				Watches: []WatchEntry{
-					{Name: "alpha", WatchedPath: "/nonexistent/alpha", MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
-					{Name: "beta", WatchedPath: "/nonexistent/beta", MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "alpha", Input: watcherconfig.WatchEntryInput{Path: "/nonexistent/alpha"}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "beta", Input: watcherconfig.WatchEntryInput{Path: "/nonexistent/beta"}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 				},
 			},
 			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
@@ -154,7 +154,7 @@ func TestValidateWatchDirs(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 
-				return &Config{Watches: []WatchEntry{{Name: "movies", WatchedPath: f.Name(), MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}}}}
+				return &Config{Watches: []WatchEntry{{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: f.Name()}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}}}}
 			}(),
 			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
 				require.Error(t, err, msgAndArgs...)
@@ -182,7 +182,7 @@ func TestScan_FileInWatchedDir(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestScan_SubdirectoryFilesUseParentMapping(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "shows", WatchedPath: dir, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "shows", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -246,7 +246,7 @@ func TestScan_DispatchErrorsAreAggregated(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -272,7 +272,7 @@ func TestScan_ContextCancellationStopsWalk(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -297,8 +297,8 @@ func TestScan_MultipleWatchEntries(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: movieDir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
-			{Name: "shows", WatchedPath: showDir, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: movieDir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "shows", Input: watcherconfig.WatchEntryInput{Path: showDir}, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -325,7 +325,7 @@ func TestScan_MetricsPresenceAfterScan(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -353,7 +353,7 @@ func TestScan_SuccessCounterIncrements(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -380,7 +380,7 @@ func TestScan_ErrorCounterIncrements(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -407,8 +407,8 @@ func TestScan_DurationObservedPerMapping(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: movieDir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
-			{Name: "shows", WatchedPath: showDir, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: movieDir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "shows", Input: watcherconfig.WatchEntryInput{Path: showDir}, MediaType: medialib.ShowType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -446,7 +446,7 @@ func TestScan_LastSuccessfulScanSetOnSuccess(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -473,7 +473,7 @@ func TestScan_FilesDiscoveredCounter(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -503,7 +503,7 @@ func TestScan_DispatchesTotalCounter(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -534,7 +534,7 @@ func TestScan_IgnorePatternSkipsMatchingFile(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`\.!qB$`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`\.!qB$`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -563,7 +563,7 @@ func TestScan_IgnorePatternPrunesMatchingDirectory(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`(^|/)_unpack(/|$)`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`(^|/)_unpack(/|$)`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -590,7 +590,7 @@ func TestScan_NonMatchingFileDispatchedWithIgnorePatterns(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`\.!qB$`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, IgnorePatterns: []CompiledRegexp{{Regexp: regexp.MustCompile(`\.!qB$`)}}, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -616,7 +616,7 @@ func TestScan_DispatchErrorsCounter(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -648,7 +648,7 @@ func TestScan_AlreadyStartedNotCountedAsDispatchOrError(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -815,7 +815,7 @@ func TestScan_PreserveSourceForwardedToDispatch(t *testing.T) {
 
 			cfg := &Config{
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, PreserveSource: tt.preserveSource, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, PreserveSource: tt.preserveSource, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 				},
 			}
 
@@ -847,7 +847,7 @@ func TestScan_WatchRootForwardedToDispatch(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -889,7 +889,7 @@ func TestScan_RetainEmptyDirsForwardedToDispatch(t *testing.T) {
 
 			cfg := &Config{
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, RetainEmptyDirectories: tt.retainEmptyDirectories, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+					{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, RetainEmptyDirectories: tt.retainEmptyDirectories, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 				},
 			}
 
@@ -922,7 +922,7 @@ func TestScan_SkipsSentinelledFile(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -947,7 +947,7 @@ func TestScan_SkipsSentinelFileItself(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: t.TempDir()}},
 		},
 	}
 
@@ -973,7 +973,7 @@ func TestScan_OutputPathForwardedToDispatch(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: outputDir}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: outputDir}},
 		},
 	}
 
@@ -1006,7 +1006,7 @@ func TestScan_OutputRemotePathForwardedToDispatch(t *testing.T) {
 
 	cfg := &Config{
 		Watches: []WatchEntry{
-			{Name: "movies", WatchedPath: dir, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: dir, RemotePath: "/remote/movies"}},
+			{Name: "movies", Input: watcherconfig.WatchEntryInput{Path: dir}, MediaType: medialib.MovieType, Output: watcherconfig.WatchEntryOutput{Path: dir, RemotePath: "/remote/movies"}},
 		},
 	}
 

--- a/deploy/charts/media-processor/templates/common.yaml
+++ b/deploy/charts/media-processor/templates/common.yaml
@@ -2,7 +2,6 @@
 {{/* ============================================================ */}}
 {{/* Hard-coded chart internals (not exposed in values)           */}}
 {{/* ============================================================ */}}
-{{- $inputMountPath     := "/media/input" -}}
 {{- $configMountPath    := "/etc/media-processor" -}}
 {{- $temporalConfigDir  := "/etc/temporal" -}}
 {{- $temporalTLSRoot    := "/etc/temporal-tls" -}}
@@ -380,31 +379,65 @@ free-form secretKeyRef because CA bundles use varying Secret layouts.
 {{/* ============================================================ */}}
 {{- $computedPersistence := dict -}}
 
-{{/* Input volume (RO in watcher, RW in every worker) */}}
-{{- $inputVolBase := omit .Values.config.inputVolume "subPath" -}}
-{{- if $inputVolBase -}}
-  {{- $watcherMount := dict "path" $inputMountPath "readOnly" true -}}
-  {{- $workerMount  := dict "path" $inputMountPath -}}
-  {{- if .Values.config.inputVolume.subPath -}}
-    {{- $watcherMount = dict "path" $inputMountPath "readOnly" true "subPath" .Values.config.inputVolume.subPath -}}
-    {{- $workerMount  = dict "path" $inputMountPath "subPath"  .Values.config.inputVolume.subPath -}}
-  {{- end -}}
-  {{- $workerSide := include "media-processor.workersAdvancedMounts" (dict "names" $workerNames "mounts" (list $workerMount) "container" $workerContainerName) | fromYaml -}}
-  {{- $advanced := mustMergeOverwrite (dict "watcher" (dict "watcher" (list $watcherMount))) $workerSide -}}
-  {{- $_ := set $inputVolBase "advancedMounts" $advanced -}}
-  {{- $_ := set $computedPersistence "input" $inputVolBase -}}
-{{- end -}}
-
-{{/* Per-watch-entry output volumes (every worker) */}}
-{{/* Build mount map: volumeName -> (mountPath -> mountSpec), deduped by mountPath per volume */}}
+{{/* ============================================================ */}}
+{{/* Per-watch-entry input + output volumes                       */}}
+{{/* ============================================================ */}}
+{{/*
+Each watch entry declares its own `input` and `output` block, both following
+the same {volumeName, mountPath, subPath} shape. References resolve against
+config.watcher.volumes (a single map of volume definitions). For each
+referenced volume the chart computes:
+  - watcher-side advancedMounts: read-only mounts of the input refs only
+    (the watcher only reads from input volumes; it never touches output
+    volumes).
+  - worker-side advancedMounts: read-write mounts of input + output refs
+    on every worker controller's main container (workers read sources
+    from inputs and write results to outputs, plus delete sources when
+    preserveSource: false).
+Volumes referenced only by outputs end up with no watcher mount entry —
+the strip-empty-advancedMounts pass at the end of this template drops them
+from .Values when every worker is type: scaledjob, so bjw-s' generate pass
+doesn't fall back to mounting them at /<identifier> on the watcher pod.
+*/}}
+{{- $inputVolMounts := dict -}}
 {{- $outputVolMounts := dict -}}
 {{- range .Values.config.watcher.watches -}}
+  {{- $watchName := index . "name" | default "(unnamed)" -}}
+  {{- $input := index . "input" -}}
+  {{- if $input -}}
+    {{- $volName := index $input "volumeName" | default "" -}}
+    {{- $mountPath := index $input "mountPath" | default "" -}}
+    {{- $subPath := index $input "subPath" | default "" -}}
+    {{- if and (or $mountPath $subPath) (not $volName) -}}
+      {{- fail (printf "config.watcher.watches[%q]: input.mountPath/subPath require input.volumeName to be set" $watchName) -}}
+    {{- end -}}
+    {{- if and $volName (not $mountPath) -}}
+      {{- fail (printf "config.watcher.watches[%q]: input.volumeName requires input.mountPath to be set" $watchName) -}}
+    {{- end -}}
+    {{- if and $mountPath (not (hasPrefix "/" $mountPath)) -}}
+      {{- fail (printf "config.watcher.watches[%q]: input.mountPath must be an absolute path, got %q" $watchName $mountPath) -}}
+    {{- end -}}
+    {{- if $volName -}}
+      {{- $mount := dict "path" $mountPath -}}
+      {{- if $subPath -}}
+        {{- $mount = dict "path" $mountPath "subPath" $subPath -}}
+      {{- end -}}
+      {{- $volMounts := index $inputVolMounts $volName | default dict -}}
+      {{- if hasKey $volMounts $mountPath -}}
+        {{- $existingSubPath := index (index $volMounts $mountPath) "subPath" | default "" -}}
+        {{- if ne $existingSubPath $subPath -}}
+          {{- fail (printf "config.watcher.watches[%q]: conflicting input mount for volumeName %q and mountPath %q: subPath %q conflicts with %q" $watchName $volName $mountPath $existingSubPath $subPath) -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $_ := set $volMounts $mountPath $mount -}}
+      {{- $_ := set $inputVolMounts $volName $volMounts -}}
+    {{- end -}}
+  {{- end -}}
   {{- $output := index . "output" -}}
   {{- if $output -}}
     {{- $volName := index $output "volumeName" | default "" -}}
     {{- $mountPath := index $output "mountPath" | default "" -}}
     {{- $subPath := index $output "subPath" | default "" -}}
-    {{- $watchName := index . "name" | default "(unnamed)" -}}
     {{- if and (or $mountPath $subPath) (not $volName) -}}
       {{- fail (printf "config.watcher.watches[%q]: output.mountPath/subPath require output.volumeName to be set" $watchName) -}}
     {{- end -}}
@@ -431,10 +464,20 @@ free-form secretKeyRef because CA bundles use varying Secret layouts.
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/* Build the per-volume persistence entries by walking the union of input
+   and output volume names. Volumes referenced only by inputs get a watcher
+   RO mount entry; volumes referenced only by outputs get worker RW only;
+   volumes referenced by both get both. The worker side mounts inputs and
+   outputs together (deduped by mountPath, with conflicting subPath
+   detection across the input/output split). */}}
 {{- $watcherVolumes := .Values.config.watcher.volumes | default dict -}}
-{{- $reservedPersistenceKeys := list "input" "watcher-config" "hardware-device" "temporal-config" -}}
+{{- $reservedPersistenceKeys := list "watcher-config" "hardware-device" "temporal-config" -}}
 {{- $reservedPersistenceKeyPrefixes := list "temporal-tls-" -}}
-{{- range $volName, $volMounts := $outputVolMounts -}}
+{{- $allVolNames := dict -}}
+{{- range $k, $_ := $inputVolMounts -}}{{- $_ := set $allVolNames $k true -}}{{- end -}}
+{{- range $k, $_ := $outputVolMounts -}}{{- $_ := set $allVolNames $k true -}}{{- end -}}
+{{- range $volName, $_ := $allVolNames -}}
   {{- if has $volName $reservedPersistenceKeys -}}
     {{- fail (printf "config.watcher.volumes: volume name %q conflicts with a chart-reserved persistence key (reserved: %s)" $volName (join ", " $reservedPersistenceKeys)) -}}
   {{- end -}}
@@ -444,14 +487,51 @@ free-form secretKeyRef because CA bundles use varying Secret layouts.
     {{- end -}}
   {{- end -}}
   {{- if not (hasKey $watcherVolumes $volName) -}}
-    {{- fail (printf "config.watcher.watches: output.volumeName %q not found in config.watcher.volumes" $volName) -}}
+    {{- fail (printf "config.watcher.watches: input/output volumeName %q not found in config.watcher.volumes" $volName) -}}
   {{- end -}}
   {{- $volBase := mustDeepCopy (index $watcherVolumes $volName) -}}
-  {{- $sortedMounts := list -}}
-  {{- range $mp := keys $volMounts | sortAlpha -}}
-    {{- $sortedMounts = append $sortedMounts (index $volMounts $mp) -}}
+
+  {{- /* Watcher RO mounts: input refs only, sorted by mount path for
+       deterministic render. Output refs are intentionally absent — the
+       watcher does not write to outputs, so granting it visibility would
+       only enlarge the attack surface. */ -}}
+  {{- $inputForVol := index $inputVolMounts $volName | default dict -}}
+  {{- $watcherMounts := list -}}
+  {{- range $mp := keys $inputForVol | sortAlpha -}}
+    {{- $m := index $inputForVol $mp -}}
+    {{- $roMount := merge (dict "readOnly" true) $m -}}
+    {{- $watcherMounts = append $watcherMounts $roMount -}}
   {{- end -}}
-  {{- $advanced := include "media-processor.workersAdvancedMounts" (dict "names" $workerNames "mounts" $sortedMounts "container" $workerContainerName) | fromYaml -}}
+
+  {{- /* Worker RW mounts: union of input + output refs, deduped by mount
+       path. A subPath conflict between the input and output entries for
+       the same mount path is a configuration error — fail render-time
+       rather than letting one silently shadow the other. */ -}}
+  {{- $workerMountsByPath := dict -}}
+  {{- range $mp, $m := $inputForVol -}}
+    {{- $_ := set $workerMountsByPath $mp $m -}}
+  {{- end -}}
+  {{- $outputForVol := index $outputVolMounts $volName | default dict -}}
+  {{- range $mp, $m := $outputForVol -}}
+    {{- if hasKey $workerMountsByPath $mp -}}
+      {{- $existingSub := index (index $workerMountsByPath $mp) "subPath" | default "" -}}
+      {{- $newSub := index $m "subPath" | default "" -}}
+      {{- if ne $existingSub $newSub -}}
+        {{- fail (printf "config.watcher.volumes: volumeName %q has conflicting input/output mounts at %q (input subPath %q vs output subPath %q)" $volName $mp $existingSub $newSub) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $_ := set $workerMountsByPath $mp $m -}}
+  {{- end -}}
+  {{- $workerMounts := list -}}
+  {{- range $mp := keys $workerMountsByPath | sortAlpha -}}
+    {{- $workerMounts = append $workerMounts (index $workerMountsByPath $mp) -}}
+  {{- end -}}
+
+  {{- $workerSide := include "media-processor.workersAdvancedMounts" (dict "names" $workerNames "mounts" $workerMounts "container" $workerContainerName) | fromYaml -}}
+  {{- $advanced := $workerSide -}}
+  {{- if $watcherMounts -}}
+    {{- $advanced = mustMergeOverwrite (dict "watcher" (dict "watcher" $watcherMounts)) $workerSide -}}
+  {{- end -}}
   {{- $_ := set $volBase "advancedMounts" $advanced -}}
   {{- $_ := set $computedPersistence $volName $volBase -}}
 {{- end -}}
@@ -468,24 +548,29 @@ free-form secretKeyRef because CA bundles use varying Secret layouts.
 {{- end -}}
 
 {{/* Watcher config ConfigMap / Secret + persistence */}}
-{{/* Build cleaned watches: strip Helm-only output fields, inject output.path from mountPath */}}
+{{/* Build cleaned watches: strip Helm-only input/output fields, inject path
+   from mountPath on each side so the binary's YAML config sees only
+   {input.path, output.path, output.remotePath} and no chart-internal
+   volumeName / mountPath / subPath leakage. */}}
 {{- $cleanWatches := list -}}
 {{- range .Values.config.watcher.watches -}}
   {{- $entry := mustDeepCopy . -}}
-  {{- $output := index $entry "output" -}}
-  {{- if $output -}}
-    {{- $volName := index $output "volumeName" | default "" -}}
-    {{- if $volName -}}
-      {{- $mountPath := index $output "mountPath" | default "" -}}
-      {{- $existingPath := index $output "path" | default "" -}}
-      {{- if and $existingPath (ne $existingPath $mountPath) -}}
-        {{- $watchName := index $entry "name" | default "(unnamed)" -}}
-        {{- fail (printf "config.watcher.watches[%q]: output.path %q conflicts with output.mountPath %q; remove output.path — it is set automatically from mountPath" $watchName $existingPath $mountPath) -}}
+  {{- $watchName := index $entry "name" | default "(unnamed)" -}}
+  {{- range $direction := list "input" "output" -}}
+    {{- $block := index $entry $direction -}}
+    {{- if $block -}}
+      {{- $volName := index $block "volumeName" | default "" -}}
+      {{- if $volName -}}
+        {{- $mountPath := index $block "mountPath" | default "" -}}
+        {{- $existingPath := index $block "path" | default "" -}}
+        {{- if and $existingPath (ne $existingPath $mountPath) -}}
+          {{- fail (printf "config.watcher.watches[%q]: %s.path %q conflicts with %s.mountPath %q; remove %s.path — it is set automatically from mountPath" $watchName $direction $existingPath $direction $mountPath $direction) -}}
+        {{- end -}}
+        {{- $_ := set $block "path" $mountPath -}}
+        {{- $_ := unset $block "volumeName" -}}
+        {{- $_ := unset $block "mountPath" -}}
+        {{- $_ := unset $block "subPath" -}}
       {{- end -}}
-      {{- $_ := set $output "path" $mountPath -}}
-      {{- $_ := unset $output "volumeName" -}}
-      {{- $_ := unset $output "mountPath" -}}
-      {{- $_ := unset $output "subPath" -}}
     {{- end -}}
   {{- end -}}
   {{- $cleanWatches = append $cleanWatches $entry -}}

--- a/deploy/charts/media-processor/values.yaml
+++ b/deploy/charts/media-processor/values.yaml
@@ -117,16 +117,6 @@ config:
             name: ""
             key: ""
 
-  # inputVolume is a bjw-s persistence item (type, existingClaim, etc.) without globalMounts or
-  # advancedMounts; the chart manages mounts at /media/input. An optional chart-specific subPath
-  # field controls the volume mount subPath. When empty, no input volume is created.
-  inputVolume: {}
-  # inputVolume:
-  #   type: nfs
-  #   server: nas.example.com
-  #   path: /volume1/media
-  #   subPath: input
-
   watcher:
     # configType controls whether the watcher YAML config file is stored as a ConfigMap or Secret.
     configType: ConfigMap
@@ -134,14 +124,40 @@ config:
     # "1m30s"). Defaults to "5s" when empty (the watcher binary applies the default). Written to
     # scanInterval in the rendered watcher YAML config.
     scanInterval: ""
+    # watches is the list of directories the watcher scans. Each entry has its own input
+    # (where the watcher reads from) and output (where the worker writes to) blocks. Both
+    # blocks reference a volume defined under config.watcher.volumes by name and pin the
+    # in-container mount path (mountPath) and an optional subPath into that volume:
+    #
+    #   - name: bittorrent-movies
+    #     mediaType: movie
+    #     input:
+    #       volumeName: bittorrent
+    #       mountPath: /media/input/bittorrent/Movies
+    #       subPath: Movies
+    #     output:
+    #       volumeName: media
+    #       mountPath: /media/output/movies
+    #       subPath: converted/Movies
+    #       remotePath: /mnt/complete
+    #
+    # The chart wires input volumes onto the watcher (read-only) and every worker (read-write),
+    # and output volumes onto every worker (read-write). The watcher container only ever sees
+    # input volumes — outputs never get a read-only watcher mount, since the watcher does not
+    # touch them. Multiple watches may reference the same volume at different mount paths.
     watches: []
-    # volumes is a map of volume names to bjw-s persistence items (type, existingClaim, server/path,
-    # etc.) without globalMounts or advancedMounts; the chart manages mounts. Keys become bjw-s
-    # persistence keys. Referenced by watch entry output.volumeName fields. Volumes not referenced
-    # by any watch entry are not mounted. When empty, no output volumes are created.
+    # volumes is a map of volume names to bjw-s persistence items (type, existingClaim,
+    # server/path, etc.) without globalMounts or advancedMounts; the chart manages mounts.
+    # Keys become bjw-s persistence keys. Referenced by watch entry input.volumeName /
+    # output.volumeName fields. Volumes not referenced by any watch entry are not mounted.
+    # When empty, no input or output volumes are created.
     volumes: {}
     # volumes:
-    #   media-output:
+    #   bittorrent:
+    #     type: nfs
+    #     server: nas.example.com
+    #     path: /volume1/downloads
+    #   media:
     #     type: nfs
     #     server: nas.example.com
     #     path: /volume1/media

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,25 +22,28 @@ scanInterval: 5s
 
 watches:
   - name: movies
-    watchedPath: /downloads/movies
-    mediaType: movie          # "movie" or "show"
+    input:
+      path: /downloads/movies   # directory the watcher scans
+    mediaType: movie            # "movie" or "show"
     output:
       path: /processed/movies
-      remotePath: /media/movies   # path as seen by Radarr (omit if same as output.path)
+      remotePath: /media/movies # path as seen by Radarr (omit if same as output.path)
     ignorePatterns:
-      - \.!qB$               # incomplete qBittorrent downloads
-      - (^|/)_unpack(/|$)    # unpack-in-progress directories
-    preserveSource: false     # delete source after processing (default)
+      - \.!qB$                  # incomplete qBittorrent downloads
+      - (^|/)_unpack(/|$)       # unpack-in-progress directories
+    preserveSource: false       # delete source after processing (default)
     retainEmptyDirectories: false  # prune empty dirs after deletion (default)
 
   - name: shows
-    watchedPath: /downloads/tv
+    input:
+      path: /downloads/tv
     mediaType: show
     output:
       path: /processed/tv
 
   - name: archive
-    watchedPath: /downloads/archive
+    input:
+      path: /downloads/archive
     mediaType: movie
     output:
       path: /processed/archive
@@ -54,7 +57,7 @@ watches:
 | ---------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scanInterval`                     | string   | `5s`    | Go duration string (e.g. `5s`, `1m30s`) controlling how often each watch directory is scanned. Defaults to `5s` when omitted.                                                                                           |
 | `watches[].name`                   | string   | —       | **Required.** Logical name for this watch entry; used as a label in metrics.                                                                                                                                            |
-| `watches[].watchedPath`            | string   | —       | **Required.** Path to the directory to watch. Relative paths are resolved against the watcher's working directory.                                                                                                      |
+| `watches[].input.path`             | string   | —       | **Required.** Path to the directory to watch. Relative paths are resolved against the watcher's working directory.                                                                                                      |
 | `watches[].mediaType`              | string   | —       | **Required.** `movie` or `show`. Determines which library service (Radarr or Sonarr) is notified.                                                                                                                       |
 | `watches[].output.path`            | string   | —       | **Required.** Directory where processed files for this watch entry are written.                                                                                                                                         |
 | `watches[].output.remotePath`      | string   | `""`    | Path by which the output directory is known to the arr service (Radarr or Sonarr). Set this when the worker and the arr service mount the output volume at different paths. When empty, no path translation is applied. |
@@ -229,7 +232,8 @@ Example: the worker writes to `/processed/radarr` but Radarr sees the same volum
 ```yaml
 watches:
   - name: movies
-    watchedPath: /downloads/movies
+    input:
+      path: /downloads/movies
     mediaType: movie
     output:
       path: /processed/radarr

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -15,11 +15,10 @@ helm install my-release oci://ghcr.io/soliddowant/charts/media-processor --versi
 `config.temporal.address` is required at `helm template` time — the chart fails with a clear error when it (or any of `config.temporal.namespace` / `config.temporal.taskQueue`) is empty. `namespace` and `taskQueue` have built-in defaults, so only `address` typically needs to be supplied. In addition, the pods will fail at runtime without the following values. You will need at a minimum:
 
 - `config.temporal.address` — Temporal frontend host:port (e.g. `temporal-frontend.temporal.svc.cluster.local:7233`)
-- `config.watcher.watches` — at least one watch entry
+- `config.watcher.watches` — at least one watch entry, each with `input` and `output` blocks
 - `config.worker.radarr.url` + `config.worker.radarr.apiKey`
 - `config.worker.sonarr.url` + `config.worker.sonarr.apiKey`
-- `config.inputVolume` — volume definition for the media input directory
-- `config.watcher.volumes` — one volume definition per distinct `output.volumeName` referenced by watch entries
+- `config.watcher.volumes` — one volume definition per distinct `input.volumeName` / `output.volumeName` referenced by watch entries
 
 ## Values reference
 
@@ -72,33 +71,13 @@ config:
       X-Trace-Origin: helm
 ```
 
-### `config.inputVolume`
-
-A bjw-s persistence item describing the volume that holds the input media files. The chart mounts it at `/media/input` in both the watcher (read-only) and the worker (read-write). When empty (`{}`), no input volume is created.
-
-Any bjw-s persistence item type is supported (`persistentVolumeClaim`, `hostPath`, `nfs`, `custom`, etc.). Do not set `globalMounts` or `advancedMounts` — the chart manages those.
-
-| Field                        | Type   | Default | Description                                |
-| ---------------------------- | ------ | ------- | ------------------------------------------ |
-| `config.inputVolume.subPath` | string | `""`    | Optional subPath for the volume mount      |
-| (all other fields)           | —      | —       | Passed through as a bjw-s persistence item |
-
-Example:
-
-```yaml
-config:
-  inputVolume:
-    type: persistentVolumeClaim
-    existingClaim: my-input-pvc
-```
-
 ### `config.watcher`
 
 | Field                                      | Type   | Default     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ------------------------------------------ | ------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `config.watcher.configType`                | string | `ConfigMap` | Storage type for the watcher YAML config file. `ConfigMap` or `Secret`                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `config.watcher.scanInterval`              | string | `""`        | Duration between directory scans, as a Go duration string (e.g. `5s`, `1m30s`). When empty, the watcher uses the built-in default of `5s`. Written to `scanInterval` in the rendered watcher YAML config                                                                                                                                                                                                                                                                                   |
-| `config.watcher.volumes`                   | map    | `{}`        | Map of volume names to bjw-s persistence items (see below). When empty, no output volumes are created                                                                                                                                                                                                                                                                                                                                                                                      |
+| `config.watcher.volumes`                   | map    | `{}`        | Map of volume names to bjw-s persistence items (see below). Each volume is referenced by `input.volumeName` and/or `output.volumeName` on watch entries. Volumes never referenced are not mounted                                                                                                                                                                                                                                                                                          |
 | `config.watcher.watches`                   | list   | `[]`        | List of watch entries. Written to `watches` in the config file (see below)                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `config.watcher.logLevel`                  | string | `info`      | Sets `LOG_LEVEL` on the watcher container                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `config.watcher.metrics.enabled`           | bool   | `false`     | When true, the chart emits the watcher-metrics `Service` and its `ServiceMonitor`. The watcher binary always exposes `/metrics` on port 9091 regardless; this toggle only controls cluster-side scraping infrastructure (see [Metrics scraping](#metrics-scraping))                                                                                                                                                                                                                        |
@@ -109,51 +88,62 @@ The watcher YAML config file is stored as a `ConfigMap` (or `Secret` when `confi
 
 ### `config.watcher.volumes`
 
-A map of volume names to bjw-s persistence items. Keys become the bjw-s persistence key (and the Kubernetes volume name). Values are standard bjw-s persistence items (`type`, `existingClaim`, `server`/`path` for NFS, etc.) — do not set `globalMounts` or `advancedMounts`, the chart manages those. Volumes are mounted in the worker only. A volume is only mounted if at least one watch entry references it by `volumeName`; volumes with no references are ignored.
+A map of volume names to bjw-s persistence items. Keys become the bjw-s persistence key (and the Kubernetes volume name). Values are standard bjw-s persistence items (`type`, `existingClaim`, `server`/`path` for NFS, etc.) — do not set `globalMounts` or `advancedMounts`, the chart manages those. Each volume is referenced by `input.volumeName` and/or `output.volumeName` on watch entries; volumes referenced by neither are ignored.
 
 | Field                         | Type   | Default | Description                              |
 | ----------------------------- | ------ | ------- | ---------------------------------------- |
 | `config.watcher.volumes.NAME` | object | —       | bjw-s persistence item for volume `NAME` |
 
-### `config.watcher.watches` — output fields
+### `config.watcher.watches` — input and output fields
 
-Each watch entry in `config.watcher.watches` may include the following fields in its `output` block. `output.volumeName`, `output.mountPath`, and `output.subPath` are Helm-only fields used to configure Kubernetes volume mounts; they are not written to the watcher YAML config. The chart injects `output.path` from `mountPath` so the worker receives the correct path at runtime. `output.remotePath` is not Helm-only and is preserved as `remotePath` in the watcher YAML config.
+Each watch entry in `config.watcher.watches` declares an `input` block (where the watcher reads from) and an `output` block (where the worker writes to). Both blocks share the same `{volumeName, mountPath, subPath}` shape; `volumeName`, `mountPath`, and `subPath` are Helm-only fields used to configure Kubernetes volume mounts and are stripped before the watcher YAML config is written. The chart injects `input.path` and `output.path` from each block's `mountPath` so the binary receives the correct in-container paths at runtime. `output.remotePath` is not Helm-only and is preserved as `output.remotePath` in the watcher YAML.
 
-| Field               | Type   | Required | Description                                                                                    |
-| ------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------- |
-| `output.volumeName` | string | yes      | Name of the volume from `config.watcher.volumes` to mount for this watch entry's output        |
-| `output.mountPath`  | string | yes      | Container path where the volume is mounted; becomes `output.path` in the watcher YAML config   |
-| `output.subPath`    | string | no       | Optional volume mount subPath; not written to the watcher YAML config                          |
-| `output.remotePath` | string | no       | How the arr service (Radarr/Sonarr) sees this output path. Written to `remotePath` in the YAML |
+The chart wires referenced volumes onto the watcher (read-only mounts of `input` refs only) and every worker (read-write mounts of both `input` and `output` refs) — the watcher never sees output volumes, since it does not touch them.
 
-Multiple watch entries may reference the same `volumeName` with different `mountPath`/`subPath` values; the chart creates one Kubernetes volume with multiple mounts rather than duplicating the underlying PVC or NFS share.
+| Field               | Type   | Required | Description                                                                                                                |
+| ------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `input.volumeName`  | string | yes      | Name of the volume from `config.watcher.volumes` to mount as the watch's input directory                                   |
+| `input.mountPath`   | string | yes      | In-container path where the volume is mounted; becomes `input.path` in the watcher YAML config                             |
+| `input.subPath`     | string | no       | Optional volume mount subPath; not written to the watcher YAML config                                                      |
+| `output.volumeName` | string | yes      | Name of the volume from `config.watcher.volumes` to mount for this watch entry's output                                    |
+| `output.mountPath`  | string | yes      | In-container path where the volume is mounted; becomes `output.path` in the watcher YAML config                            |
+| `output.subPath`    | string | no       | Optional volume mount subPath; not written to the watcher YAML config                                                      |
+| `output.remotePath` | string | no       | How the arr service (Radarr/Sonarr) sees this output path. Written to `output.remotePath` in the YAML                      |
 
-Example — one NFS share serving two watch entries at different sub-paths:
+Multiple watch entries may reference the same `volumeName` (in either block) with different `mountPath`/`subPath` values; the chart creates one Kubernetes volume with multiple mounts rather than duplicating the underlying PVC or NFS share.
+
+Example — one NFS share serving downloads (input) and processed files (output) under different sub-paths:
 
 ```yaml
 config:
   watcher:
     volumes:
-      media-output:
+      media:
         type: nfs
         server: nas.example.com
         path: /volume1/media
     watches:
       - name: movies
-        watchedPath: /media/input/movies
         mediaType: movie
+        input:
+          volumeName: media
+          mountPath: /media/input/movies
+          subPath: downloads/movies
         output:
-          volumeName: media-output
+          volumeName: media
           mountPath: /media/output/movies
-          subPath: movies
+          subPath: converted/movies
           remotePath: /downloads/movies
       - name: shows
-        watchedPath: /media/input/shows
         mediaType: show
+        input:
+          volumeName: media
+          mountPath: /media/input/shows
+          subPath: downloads/shows
         output:
-          volumeName: media-output
+          volumeName: media
           mountPath: /media/output/shows
-          subPath: shows
+          subPath: converted/shows
           remotePath: /downloads/shows
 ```
 
@@ -408,7 +398,6 @@ These values are intentionally not configurable in `values.yaml`:
 
 | Setting               | Value                       |
 | --------------------- | --------------------------- |
-| Input mount path      | `/media/input`              |
 | Watcher config mount  | `/etc/media-processor/`     |
 | Temporal config mount | `/etc/temporal/`            |
 | Temporal TLS root     | `/etc/temporal-tls/<name>/` |
@@ -459,21 +448,23 @@ config:
     namespace: "default"
     taskQueue: "media-processor"
 
-  inputVolume:
-    type: persistentVolumeClaim
-    existingClaim: downloads-pvc
-
   watcher:
     scanInterval: "30s"
     volumes:
+      downloads:
+        type: persistentVolumeClaim
+        existingClaim: downloads-pvc
       processed-output:
         type: nfs
         server: nas.example.com
         path: /volume1/processed
     watches:
       - name: movies
-        watchedPath: /media/input/movies
         mediaType: movie
+        input:
+          volumeName: downloads
+          mountPath: /media/input/movies
+          subPath: movies
         output:
           volumeName: processed-output
           mountPath: /media/output/movies
@@ -482,8 +473,11 @@ config:
           # so Radarr sees /downloads/movies where the worker writes /media/output/movies.
           remotePath: /downloads/movies
       - name: shows
-        watchedPath: /media/input/shows
         mediaType: show
+        input:
+          volumeName: downloads
+          mountPath: /media/input/shows
+          subPath: shows
         output:
           volumeName: processed-output
           mountPath: /media/output/shows

--- a/e2e/fixtures/watcher.yaml
+++ b/e2e/fixtures/watcher.yaml
@@ -1,6 +1,7 @@
 watches:
   - name: radarr
-    watchedPath: /tmp/e2e-media-processor/downloads/radarr
+    input:
+      path: /tmp/e2e-media-processor/downloads/radarr
     mediaType: movie
     output:
       path: /tmp/e2e-media-processor/processed-output/radarr
@@ -8,7 +9,8 @@ watches:
     ignorePatterns:
       - \.tmp$
   - name: sonarr
-    watchedPath: /tmp/e2e-media-processor/downloads/sonarr
+    input:
+      path: /tmp/e2e-media-processor/downloads/sonarr
     mediaType: show
     output:
       path: /tmp/e2e-media-processor/processed-output/sonarr
@@ -16,7 +18,8 @@ watches:
     ignorePatterns:
       - \.tmp$
   - name: preserve-source
-    watchedPath: /tmp/e2e-media-processor/downloads/preserve-source
+    input:
+      path: /tmp/e2e-media-processor/downloads/preserve-source
     mediaType: movie
     output:
       path: /tmp/e2e-media-processor/processed-output/preserve-source

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -98,6 +98,13 @@ func (c *CompiledRegexp) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// WatchEntryInput describes the input source for a watch entry.
+type WatchEntryInput struct {
+	// Path is the filesystem path to the directory the watcher scans. Relative paths are
+	// resolved against the watcher's working directory.
+	Path string `yaml:"path" jsonschema:"minLength=1"`
+}
+
 // WatchEntryOutput describes the output destination for a watch entry.
 type WatchEntryOutput struct {
 	// Path is the filesystem path to the directory where processed files are written.
@@ -113,9 +120,8 @@ type WatchEntryOutput struct {
 type WatchEntry struct {
 	// Name is a human-readable label for this watch entry, used in logs and metrics.
 	Name string `yaml:"name" jsonschema:"minLength=1"`
-	// WatchedPath is the filesystem path to the directory to watch. Relative paths are resolved
-	// against the watcher's working directory.
-	WatchedPath string `yaml:"watchedPath" jsonschema:"minLength=1"`
+	// Input describes the directory the watcher scans for media files.
+	Input WatchEntryInput `yaml:"input"`
 	// MediaType indicates whether this directory contains movies or TV show episodes.
 	MediaType medialib.MediaType `yaml:"mediaType" validate:"mediatype"`
 	// IgnorePatterns is an optional list of Go regular expressions matched against the absolute

--- a/internal/watcherconfig/validate.go
+++ b/internal/watcherconfig/validate.go
@@ -21,7 +21,7 @@ func NewValidator() *validator.Validate {
 		panic("failed to register validation \"mediatype\": " + err.Error())
 	}
 
-	registerSchemaConstraints(v, Config{}, WatchEntry{}, WatchEntryOutput{})
+	registerSchemaConstraints(v, Config{}, WatchEntry{}, WatchEntryInput{}, WatchEntryOutput{})
 
 	return v
 }

--- a/internal/watcherconfig/validate_test.go
+++ b/internal/watcherconfig/validate_test.go
@@ -24,7 +24,7 @@ func TestNewValidator_MinLengthRulesEnforced(t *testing.T) {
 			cfg: Config{
 				ScanInterval: DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+					{Name: "movies", Input: WatchEntryInput{Path: "/watch"}, MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
 				},
 			},
 		},
@@ -33,17 +33,17 @@ func TestNewValidator_MinLengthRulesEnforced(t *testing.T) {
 			cfg: Config{
 				ScanInterval: DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+					{Name: "", Input: WatchEntryInput{Path: "/watch"}, MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
 				},
 			},
 			errFunc: require.Error,
 		},
 		{
-			name: "empty WatchedPath is rejected",
+			name: "empty Input.Path is rejected",
 			cfg: Config{
 				ScanInterval: DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "", MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
+					{Name: "movies", Input: WatchEntryInput{Path: ""}, MediaType: "movie", Output: WatchEntryOutput{Path: "/out"}},
 				},
 			},
 			errFunc: require.Error,
@@ -53,7 +53,7 @@ func TestNewValidator_MinLengthRulesEnforced(t *testing.T) {
 			cfg: Config{
 				ScanInterval: DefaultScanInterval,
 				Watches: []WatchEntry{
-					{Name: "movies", WatchedPath: "/watch", MediaType: "movie", Output: WatchEntryOutput{Path: ""}},
+					{Name: "movies", Input: WatchEntryInput{Path: "/watch"}, MediaType: "movie", Output: WatchEntryOutput{Path: ""}},
 				},
 			},
 			errFunc: require.Error,

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -45,10 +45,9 @@
           "minLength": 1,
           "description": "Name is a human-readable label for this watch entry, used in logs and metrics."
         },
-        "watchedPath": {
-          "type": "string",
-          "minLength": 1,
-          "description": "WatchedPath is the filesystem path to the directory to watch. Relative paths are resolved\nagainst the watcher's working directory."
+        "input": {
+          "$ref": "#/$defs/WatchEntryInput",
+          "description": "Input describes the directory the watcher scans for media files."
         },
         "mediaType": {
           "$ref": "#/$defs/MediaType",
@@ -78,11 +77,26 @@
       "type": "object",
       "required": [
         "name",
-        "watchedPath",
+        "input",
         "mediaType",
         "output"
       ],
       "description": "WatchEntry describes a watched location, mapping a filesystem path to a media type for dispatch and carrying a human-readable name for identification."
+    },
+    "WatchEntryInput": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path is the filesystem path to the directory the watcher scans. Relative paths are\nresolved against the watcher's working directory."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "description": "WatchEntryInput describes the input source for a watch entry."
     },
     "WatchEntryOutput": {
       "properties": {


### PR DESCRIPTION
## Summary

Replace the chart-level `config.inputVolume` + `watches[].watchedPath` surface with a per-watch `input` block (`{volumeName, mountPath, subPath}`) that mirrors the existing `output` block. Each watch entry is now a self-contained "I read from X, write to Y" declaration, and a single `config.watcher.volumes` map serves both directions.

Eliminates two long-standing limitations:

- The asymmetry where outputs could declare per-watch volumes but inputs shared a single chart-mounted `/media/input`. Operators with sources spread across multiple PVCs / NFS exports no longer need to merge or symlink them under one root.
- The hardcoded `/media/input` mount path. Each watch now declares its own in-container `input.mountPath`; the chart no longer knows about `/media/input`.

## Changes

**Binary (`internal/watcherconfig/`, `cmd/watcher/`)**
- `WatchEntry.WatchedPath` (yaml `watchedPath`) replaced with `WatchEntry.Input` (yaml `input`) carrying a single `Path` field. New `WatchEntryInput` struct mirrors the existing `WatchEntryOutput`.
- All five callsites in `cmd/watcher/watcher.go` updated from `w.WatchedPath` to `w.Input.Path`.
- Unit tests, integration tests, and the e2e fixture updated to the new shape.
- `schemas/watcher.schema.json` regenerated via `make generate-schema`.

**Chart (`deploy/charts/media-processor/`)**
- `config.inputVolume` and the `$inputMountPath` constant removed.
- Input + output volume mounts now built in a single pass over `config.watcher.watches`, then per-volume:
  - watcher advancedMounts: read-only mounts of input refs only (the watcher never sees outputs)
  - worker advancedMounts: read-write mounts of input + output refs, deduped by mount path with subPath conflict detection across the input/output split
- Watch-cleaning step strips Helm-only `volumeName` / `mountPath` / `subPath` from both `input` and `output` blocks before serializing the watcher YAML, so the binary sees only `{input.path, output.path, output.remotePath}`.
- Reserved persistence keys list no longer includes `input` (no longer chart-built).

**Docs**
- `docs/configuration.md`, `docs/helm.md`, and `README.md` updated with the new YAML shape and a worked example showing one NFS share serving both input and output mounts under different sub-paths.
- Removed `Input mount path: /media/input` from the helm.md hard-coded internals table.

## Migration

Operators must rewrite watch entries:

- Chart values: `watchedPath: <path>` -> `input: { volumeName, mountPath, subPath }` referencing a volume from `config.watcher.volumes`. `config.inputVolume` is no longer a recognized field.
- Direct binary YAML: `watchedPath: <path>` -> `input: { path: <path> }`.

## Test plan

- [x] `make vet` / `make test` / `make lint` clean.
- [x] `make generate-schema` produced a coherent `schemas/watcher.schema.json` with `input` and `WatchEntryInput` defs in place of `watchedPath`.
- [x] All seven prior chart spot-check scenarios (default, metrics on/off, multi-worker, scaledjob with and without metrics, KEDA TLS, full-config) render cleanly with the expected resource counts.
- [x] Render-tested against a production hr.yaml with two scaledjob workers (general + transcode) sharing one NFS export across four input subpaths and two output subpaths:
  - watcher gets four RO mounts (one per watch's `input.mountPath` with the right subPath), no stray `/media`, no output volumes
  - each ScaledJob pod template gets the full RW set (4 input mounts + 2 output mounts) all on the single shared volume
  - watcher YAML ConfigMap contains only the binary-relevant fields (`input.path`, `output.path`, `output.remotePath`)
- [x] Volumes referenced by both directions are correctly merged (single Kubernetes volume, multiple mount paths) and conflicting subPath at the same mount path fails render-time with a controller-named error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)