### PR TITLE
fix(ffmpeg): clamp non-monotonic DTS on the copy path

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -64,10 +64,14 @@ type copyStreamState struct {
 	outStream *astiav.Stream
 	frames    int64 // encoded frames written; used for progress reporting
 	// lastWrittenDts is the DTS of the most recent packet handed to the muxer
-	// for outStream, in outStream's timebase. Used by receiveAndWritePackets to
-	// repair non-monotonic DTS coming out of the encoder (notably hevc_qsv on
-	// VFR sources, where Intel's libmfx runtime computes DecodeTimeStamp
-	// assuming uniform input cadence). NoPtsValue before the first write.
+	// for outStream, in outStream's timebase. Used to clamp non-monotonic DTS
+	// before the muxer's strict monotonicity check sees it — both from
+	// encoders that emit out-of-order DTS (hevc_qsv on VFR sources, where
+	// Intel's libmfx runtime computes DecodeTimeStamp assuming uniform input
+	// cadence) and from copy-path sources whose authored timestamps regress
+	// (PGS subtitle streams from some BluRay-authoring tools, where Block
+	// timestamps go briefly backwards between adjacent display sets).
+	// NoPtsValue before the first write.
 	lastWrittenDts int64
 }
 
@@ -84,17 +88,23 @@ func (css *copyStreamState) encoderContext() *astiav.CodecContext               
 func (css *copyStreamState) processPacket(packet *astiav.Packet, outputFmt *astiav.FormatContext, progressCh chan<- Progress, totalDuration int64) error {
 	packet.RescaleTs(css.inStream.TimeBase(), css.outStream.TimeBase())
 	packet.SetStreamIndex(css.outStream.Index())
+	css.repairNonMonotonicDts(packet)
 
 	css.frames++
-	// sendProgress must read packet.Pts() before WriteInterleavedFrame, which
-	// takes ownership of the packet and zeroes its fields.
+	// sendProgress and the DTS snapshot must read packet fields before
+	// WriteInterleavedFrame, which takes ownership of the packet and zeroes
+	// them.
 	if progressCh != nil {
 		sendProgress(progressCh, css.frames, packet, css.outStream, totalDuration)
 	}
 
+	writtenDts := packet.Dts()
+
 	if err := outputFmt.WriteInterleavedFrame(packet); err != nil {
 		return fmt.Errorf("ffmpeg: writing remuxed packet for stream %d: %w", css.outStream.Index(), err)
 	}
+
+	css.lastWrittenDts = writtenDts
 
 	return nil
 }
@@ -146,19 +156,20 @@ func (css *copyStreamState) receiveAndWritePackets(encCtx *astiav.CodecContext, 
 // repairNonMonotonicDts rewrites pkt's DTS (and PTS, if needed to keep
 // DTS <= PTS) so that it is strictly greater than the last DTS written to the
 // output stream. Mirrors the clamp in fftools/ffmpeg_mux.c::mux_fixup_ts that
-// lets the FFmpeg CLI tolerate the non-monotonic DTS the hevc_qsv encoder
-// emits on variable-frame-rate sources. No-op on the first packet, on packets
-// without a DTS value, or when the encoder DTS is already monotonic — so
-// well-formed encodes produce bit-identical output.
+// lets the FFmpeg CLI tolerate non-monotonic DTS — both from encoders that
+// emit out-of-order DTS (notably hevc_qsv on VFR sources) and from copy-path
+// sources whose authored timestamps regress. No-op on the first packet, on
+// packets without a DTS value, or when the incoming DTS is already
+// monotonic — so well-formed sources produce bit-identical output.
 func (css *copyStreamState) repairNonMonotonicDts(pkt *astiav.Packet) {
 	newDts, newPts, clamped := monotonicDtsClamp(css.lastWrittenDts, pkt.Dts(), pkt.Pts())
 	if !clamped {
 		return
 	}
 
-	slog.Warn("ffmpeg: clamping non-monotonic encoder DTS",
+	slog.Warn("ffmpeg: clamping non-monotonic DTS",
 		slog.Int("stream", css.outStream.Index()),
-		slog.Int64("encoder_dts", pkt.Dts()),
+		slog.Int64("packet_dts", pkt.Dts()),
 		slog.Int64("previous_dts", css.lastWrittenDts),
 		slog.Int64("corrected_dts", newDts),
 	)

--- a/pkg/ffmpeg/stream_test.go
+++ b/pkg/ffmpeg/stream_test.go
@@ -1,10 +1,12 @@
 package ffmpeg
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/asticode/go-astiav"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMonotonicDtsClamp covers the pure timestamp-clamp logic used by
@@ -155,4 +157,110 @@ func TestMonotonicDtsClamp_FMABFailureSequence(t *testing.T) {
 			"muxed DTS must be strictly monotonic at packet %d (got %d after %d)",
 			i, muxedDts[i], muxedDts[i-1])
 	}
+}
+
+// TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts verifies that
+// the pure-copy packet path repairs non-monotonic DTS coming from the input
+// source before submitting packets to the muxer. Without the repair,
+// libavformat's strict DTS monotonicity check rejects the second submission
+// with EINVAL ("Application provided invalid, non monotonically increasing
+// dts to muxer").
+//
+// The motivating production failure is a PGS subtitle stream whose authored
+// Block timestamps go briefly backwards between adjacent display sets. The
+// ffmpeg CLI silently clamps these at its stream-output layer (sost); our
+// in-process transcoder reached the muxer directly, so the activity failed
+// on the first regression. The same clamp logic already exists for encoded
+// streams (receiveAndWritePackets, monotonicDtsClamp) — this test exercises
+// the parallel path on copy streams.
+func TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "out.mkv")
+
+	inputFmt := astiav.AllocFormatContext()
+	require.NotNil(t, inputFmt)
+
+	defer inputFmt.Free()
+
+	require.NoError(t, inputFmt.OpenInput("testdata/video_with_subrip_subtitle.mkv", nil, nil))
+	defer inputFmt.CloseInput()
+
+	require.NoError(t, inputFmt.FindStreamInfo(nil))
+
+	var inAudioStream *astiav.Stream
+
+	for _, stream := range inputFmt.Streams() {
+		if stream.CodecParameters().MediaType() == astiav.MediaTypeAudio {
+			inAudioStream = stream
+			break
+		}
+	}
+
+	require.NotNil(t, inAudioStream, "test fixture must carry an audio stream")
+
+	outputFmt, err := astiav.AllocOutputFormatContext(nil, "matroska", outputPath)
+	require.NoError(t, err)
+
+	defer outputFmt.Free()
+
+	outStream := outputFmt.NewStream(nil)
+	require.NotNil(t, outStream)
+	require.NoError(t, inAudioStream.CodecParameters().Copy(outStream.CodecParameters()))
+	outStream.CodecParameters().SetCodecTag(0)
+	outStream.SetTimeBase(inAudioStream.TimeBase())
+
+	ioCtx, err := astiav.OpenIOContext(outputPath, astiav.NewIOContextFlags(astiav.IOContextFlagWrite), nil, nil)
+	require.NoError(t, err)
+
+	defer func() { _ = ioCtx.Close() }()
+
+	outputFmt.SetPb(ioCtx)
+
+	require.NoError(t, outputFmt.WriteHeader(nil))
+
+	css := &copyStreamState{inStream: inAudioStream}
+	css.setOutputStream(outStream)
+
+	pkt := astiav.AllocPacket()
+	defer pkt.Free()
+
+	readAudioPacket := func() {
+		t.Helper()
+
+		for {
+			err := inputFmt.ReadFrame(pkt)
+			require.NoError(t, err, "input must supply enough audio packets for the test")
+
+			if pkt.StreamIndex() == inAudioStream.Index() {
+				return
+			}
+
+			pkt.Unref()
+		}
+	}
+
+	// Override the natural DTS on both packets so the regression on the second
+	// is precisely controlled rather than dependent on whatever the demuxer
+	// happens to emit.
+	readAudioPacket()
+	pkt.SetDts(100)
+	pkt.SetPts(100)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"first packet (monotonic DTS) must be accepted by the muxer")
+
+	pkt.Unref()
+
+	readAudioPacket()
+	pkt.SetDts(50)
+	pkt.SetPts(50)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"non-monotonic source DTS must be repaired on the copy path so the matroska muxer accepts the packet")
+
+	pkt.Unref()
+
+	require.NoError(t, outputFmt.WriteTrailer())
+
+	assert.Greater(t, css.lastWrittenDts, int64(100),
+		"copyStreamState.lastWrittenDts must advance strictly past the previous packet's DTS after the repair")
 }


### PR DESCRIPTION
## Summary

- The matroska muxer rejects packets whose DTS regresses against the previously written DTS on the same stream with EINVAL (`Application provided invalid, non monotonically increasing dts to muxer`). The encoded-stream path already calls the existing monotonic-DTS clamp in `receiveAndWritePackets`; the copy-stream path did not, so source-side DTS regressions reached the muxer directly.
- Apply the same `repairNonMonotonicDts` clamp on `copyStreamState.processPacket`, snapshot DTS before `WriteInterleavedFrame` (which takes ownership), and advance `lastWrittenDts` after a successful write — matching the pattern in `receiveAndWritePackets`.
- Update the field/function doc comments and warning-log field name to be source-agnostic now that the clamp serves both encoder VFR and copy-path regressions.

## Production trigger

A PGS subtitle stream from a DVDFab-produced BluRay rip had six packets whose authored Block timestamps went backwards by up to ~4 s in matroska's 1/1000 timebase, causing the transcode activity to abort on the first regression with `ffmpeg: writing remuxed packet for stream 3: Invalid argument`. The ffmpeg CLI does not fail on the same file because its stream-output layer (`sost`) silently clamps non-monotonic DTS before they reach the muxer; our in-process transcoder reached the muxer directly.

## Test plan

- [x] Added `TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts` which drives the copy path with two packets whose DTS regresses (100, 50) against a real matroska output. Verified the test fails pre-fix with the exact production error and passes post-fix.
- [x] `go test ./...` (full workspace) green.
- [x] `make lint` green.
- [x] `make vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)