### PR TITLE
fix(medialib): recover Notify from arr-import races via size post-check

### DIFF
--- a/pkg/medialib/internal/arrcommand/arrcommand.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand.go
@@ -11,10 +11,19 @@ package arrcommand
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 )
+
+// ErrNoSuccessfulImports is returned (wrapped) when a command completes with
+// result="unsuccessful". This commonly means the file at the scan path is no
+// longer eligible for import — for example, the arr service's own
+// completed-download handler raced our explicit scan and already imported
+// the file. Callers can detect via errors.Is and post-check whether the
+// import actually happened before treating it as a hard failure.
+var ErrNoSuccessfulImports = errors.New("no successful imports")
 
 // DefaultPollInterval is used when the caller passes a non-positive interval.
 // Sonarr/Radarr command status updates are inexpensive (a single DB read on
@@ -76,7 +85,7 @@ func Wait(ctx context.Context, fetch Fetcher, id int64, interval time.Duration, 
 		switch strings.ToLower(status.Status) {
 		case "completed":
 			if strings.EqualFold(status.Result, "unsuccessful") {
-				return fmt.Errorf("%s command %d completed but reported no successful imports: %s", service, id, status.Message)
+				return fmt.Errorf("%s command %d completed but reported %w: %s", service, id, ErrNoSuccessfulImports, status.Message)
 			}
 
 			return nil

--- a/pkg/medialib/internal/arrcommand/arrcommand_test.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand_test.go
@@ -57,7 +57,9 @@ func TestWait(t *testing.T) {
 			statuses: []arrcommand.Status{
 				{Status: "completed", Result: "unsuccessful", Message: "no eligible files"},
 			},
-			errFunc:      require.Error,
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.ErrorIs(t, err, arrcommand.ErrNoSuccessfulImports, msgAndArgs...)
+			},
 			errSubstring: "no successful imports",
 			wantCalls:    1,
 		},

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -144,7 +144,13 @@ type ArrLibrary interface {
 	// ImportByFilePath translates path to the arr service's view and sends a
 	// DownloadedMoviesScan (Radarr) or DownloadedEpisodesScan (Sonarr) command,
 	// triggering the arr service's normal download-completion import pipeline.
-	ImportByFilePath(ctx context.Context, path string) error
+	// expectedSize is the size of the local source file in bytes. It is used
+	// as a post-check tiebreaker when the scan command finishes with no
+	// successful imports: if the library item's stored file matches
+	// expectedSize, the import is treated as having succeeded (typically
+	// because the arr service's own completed-download handler raced our
+	// scan). A non-positive expectedSize disables the post-check.
+	ImportByFilePath(ctx context.Context, path string, expectedSize int64) error
 	// GetInfo returns structured media metadata for the item at path.
 	// Returns ErrNotFound if no item is identified.
 	GetInfo(ctx context.Context, path string) (MediaInfo, error)

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -141,15 +141,6 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 	}
 
 	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "radarr"); err != nil {
-		// Radarr's own completed-download handler can race our scan and import
-		// the file before our command runs. In that case, the scan command
-		// finishes with result="unsuccessful" (nothing left at the path), but
-		// the movie is already imported. To distinguish that benign race
-		// from a real failure (e.g. transient Radarr error causing our file
-		// to be rejected while a pre-existing lower-quality file is kept),
-		// compare Radarr's stored MovieFile.Size to expectedSize. A match
-		// proves Radarr has our file; a mismatch (or unknown size) leaves
-		// the original error in place so Temporal can retry.
 		if expectedSize > 0 && errors.Is(err, arrcommand.ErrNoSuccessfulImports) {
 			if size, ok := c.movieFileSize(ctx, filePath); ok && size == expectedSize {
 				slog.InfoContext(ctx, "radarr scan reported no imports but movie file size matches local output; treating as success",

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -115,7 +117,11 @@ func (c *Client) GetInfo(ctx context.Context, filePath string) (medialib.MediaIn
 // until Radarr reports the command has reached a terminal status.
 // Blocking is required so the caller can safely operate on filePath (e.g. prune the
 // containing directory) once Radarr has finished moving the file into its library.
-func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
+// expectedSize, when positive, is the size of the local source file in bytes
+// and enables a post-check that distinguishes a benign race (Radarr's own
+// completed-download handler imported the file first) from a real failure
+// (Radarr kept a different pre-existing file) — see movieFileSize.
+func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expectedSize int64) error {
 	requestPayload := struct {
 		Name string `json:"name"`
 		Path string `json:"path"`
@@ -135,10 +141,47 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
 	}
 
 	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "radarr"); err != nil {
+		// Radarr's own completed-download handler can race our scan and import
+		// the file before our command runs. In that case, the scan command
+		// finishes with result="unsuccessful" (nothing left at the path), but
+		// the movie is already imported. To distinguish that benign race
+		// from a real failure (e.g. transient Radarr error causing our file
+		// to be rejected while a pre-existing lower-quality file is kept),
+		// compare Radarr's stored MovieFile.Size to expectedSize. A match
+		// proves Radarr has our file; a mismatch (or unknown size) leaves
+		// the original error in place so Temporal can retry.
+		if expectedSize > 0 && errors.Is(err, arrcommand.ErrNoSuccessfulImports) {
+			if size, ok := c.movieFileSize(ctx, filePath); ok && size == expectedSize {
+				slog.InfoContext(ctx, "radarr scan reported no imports but movie file size matches local output; treating as success",
+					"file_path", filePath, "size", size)
+
+				return nil
+			}
+		}
+
 		return fmt.Errorf("wait for command for %q: %w", filePath, err)
 	}
 
 	return nil
+}
+
+// movieFileSize returns the size in bytes of the file Radarr currently has
+// for the movie identified by filePath. The second return is false when
+// the movie cannot be parsed, has no file, or any lookup fails — callers
+// should treat that as "do not recover" so the original scan error remains
+// in force.
+func (c *Client) movieFileSize(ctx context.Context, filePath string) (int64, bool) {
+	parsed, err := c.parseFilePath(ctx, filePath)
+	if err != nil || parsed == nil {
+		return 0, false
+	}
+
+	full, err := c.radarr.GetMovieByIDContext(ctx, parsed.ID)
+	if err != nil || full == nil || !full.HasFile || full.MovieFile == nil {
+		return 0, false
+	}
+
+	return full.MovieFile.Size, true
 }
 
 // fetchCommandStatus implements arrcommand.Fetcher. It hits Radarr's

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -172,7 +172,7 @@ func TestImportByFilePath(t *testing.T) {
 
 			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), test.path)
+			err := client.ImportByFilePath(t.Context(), test.path, 0)
 
 			errFunc := test.errFunc
 			if errFunc == nil {
@@ -253,12 +253,98 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 
 			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv")
+			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv", 0)
 			test.errFunc(t, err)
 
 			if test.errSubstring != "" && err != nil {
 				assert.Contains(t, err.Error(), test.errSubstring)
 			}
+		})
+	}
+}
+
+// TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch verifies the
+// race-recovery post-check: when the scan command finishes with
+// result="unsuccessful" but Radarr's stored movie file size matches the
+// caller's expectedSize, ImportByFilePath treats the scan as having
+// succeeded (Radarr's own completed-download handler already imported the
+// file). When sizes disagree, the movie lacks a file, or the lookup fails,
+// the original "no successful imports" error must propagate so the
+// workflow retries.
+func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
+	const matchingSize int64 = 67890
+
+	knownMovie := &radarrlib.Movie{ID: 42, Title: "The Matrix", Year: 1999}
+
+	propagatesUnsuccessful := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.Contains(t, err.Error(), "no successful imports")
+	}
+
+	tests := []struct {
+		name         string
+		expectedSize int64
+		parseResp    *parseResponse
+		movieByID    *radarrlib.Movie
+		errFunc      require.ErrorAssertionFunc
+	}{
+		{
+			name:         "size matches: scan treated as success",
+			expectedSize: matchingSize,
+			parseResp:    &parseResponse{Movie: knownMovie},
+			movieByID:    &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: matchingSize}},
+		},
+		{
+			name:         "size mismatches: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    &parseResponse{Movie: knownMovie},
+			movieByID:    &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: matchingSize + 1}},
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "movie has no file: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    &parseResponse{Movie: knownMovie},
+			movieByID:    &radarrlib.Movie{ID: 42, HasFile: false},
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "movie unidentifiable by parse: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    &parseResponse{Movie: nil},
+			movieByID:    nil,
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "expectedSize zero disables post-check: original error propagates",
+			expectedSize: 0,
+			parseResp:    &parseResponse{Movie: knownMovie},
+			movieByID:    &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: matchingSize}},
+			errFunc:      propagatesUnsuccessful,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newTestServerWithConfig(t, testServerConfig{
+				parseResp:            test.parseResp,
+				movieByID:            test.movieByID,
+				commandStatuses:      []string{"completed"},
+				commandResult:        "unsuccessful",
+				commandStatusMessage: "no eligible files",
+			})
+			t.Cleanup(srv.Close)
+
+			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv", test.expectedSize)
+
+			errFunc := test.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, err)
 		})
 	}
 }
@@ -296,7 +382,7 @@ func TestGetInfo_UnreachableURL(t *testing.T) {
 func TestImportByFilePath_UnreachableURL(t *testing.T) {
 	client := radarr.New(radarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
-	err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv")
+	err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv", 0)
 	require.Error(t, err)
 }
 

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -149,7 +151,11 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) str
 // When a pending tracked download for the episode is found in the queue, its
 // download client ID is included so Sonarr calls VerifyImport and removes the
 // item from the downloads queue.
-func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
+// expectedSize, when positive, is the size of the local source file in bytes
+// and enables a post-check that distinguishes a benign race (Sonarr's own
+// completed-download handler imported the file first) from a real failure
+// (Sonarr kept a different pre-existing file) — see episodeFileSize.
+func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expectedSize int64) error {
 	downloadClientID := c.findTrackedDownloadID(ctx, filePath)
 
 	requestPayload := struct {
@@ -174,10 +180,52 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string) error {
 	}
 
 	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "sonarr"); err != nil {
+		// Sonarr's own completed-download handler can race our scan and import
+		// the file before our command runs. In that case, the scan command
+		// finishes with result="unsuccessful" (nothing left at the path), but
+		// the episode is already imported. To distinguish that benign race
+		// from a real failure (e.g. transient Sonarr error causing our file
+		// to be rejected while a pre-existing lower-quality file is kept),
+		// compare Sonarr's stored EpisodeFile.Size to expectedSize. A match
+		// proves Sonarr has our file; a mismatch (or unknown size) leaves
+		// the original error in place so Temporal can retry.
+		if expectedSize > 0 && errors.Is(err, arrcommand.ErrNoSuccessfulImports) {
+			if size, ok := c.episodeFileSize(ctx, filePath); ok && size == expectedSize {
+				slog.InfoContext(ctx, "sonarr scan reported no imports but episode file size matches local output; treating as success",
+					"file_path", filePath, "size", size)
+
+				return nil
+			}
+		}
+
 		return fmt.Errorf("wait for command for %q: %w", filePath, err)
 	}
 
 	return nil
+}
+
+// episodeFileSize returns the size in bytes of the file Sonarr currently has
+// for the episode identified by filePath. The second return is false when
+// the episode cannot be parsed, has no file, or any lookup fails — callers
+// should treat that as "do not recover" so the original scan error remains
+// in force.
+func (c *Client) episodeFileSize(ctx context.Context, filePath string) (int64, bool) {
+	ep, err := c.getEpisodeByFilePath(ctx, filePath)
+	if err != nil {
+		return 0, false
+	}
+
+	full, err := c.sonarr.GetEpisodeByIDContext(ctx, ep.GetID())
+	if err != nil || full == nil || !full.HasFile || full.EpisodeFileID == 0 {
+		return 0, false
+	}
+
+	files, err := c.sonarr.GetEpisodeFilesContext(ctx, full.EpisodeFileID)
+	if err != nil || len(files) == 0 || files[0] == nil {
+		return 0, false
+	}
+
+	return files[0].Size, true
 }
 
 // fetchCommandStatus implements arrcommand.Fetcher. It hits Sonarr's

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -180,15 +180,6 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 	}
 
 	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "sonarr"); err != nil {
-		// Sonarr's own completed-download handler can race our scan and import
-		// the file before our command runs. In that case, the scan command
-		// finishes with result="unsuccessful" (nothing left at the path), but
-		// the episode is already imported. To distinguish that benign race
-		// from a real failure (e.g. transient Sonarr error causing our file
-		// to be rejected while a pre-existing lower-quality file is kept),
-		// compare Sonarr's stored EpisodeFile.Size to expectedSize. A match
-		// proves Sonarr has our file; a mismatch (or unknown size) leaves
-		// the original error in place so Temporal can retry.
 		if expectedSize > 0 && errors.Is(err, arrcommand.ErrNoSuccessfulImports) {
 			if size, ok := c.episodeFileSize(ctx, filePath); ok && size == expectedSize {
 				slog.InfoContext(ctx, "sonarr scan reported no imports but episode file size matches local output; treating as success",

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -29,10 +29,12 @@ const fastPollInterval = time.Millisecond
 // sonarrTestServerConfig holds configuration for test HTTP servers.
 type sonarrTestServerConfig struct {
 	parseResp       *sonarrlib.ParseOutput
-	seriesByID      *sonarrlib.Series  // response for /api/v3/series/{id}
-	queueResp       *sonarrlib.Queue   // single-page queue response; nil returns empty queue
-	queuePages      []*sonarrlib.Queue // multi-page queue responses; index 0 = page 1; takes priority over queueResp
-	queueHTTPStatus int                // override HTTP status for /api/v3/queue; 0 means 200
+	seriesByID      *sonarrlib.Series      // response for /api/v3/series/{id}
+	episodeByID     *sonarrlib.Episode     // response for /api/v3/episode/{id}; nil → 404
+	episodeFile     *sonarrlib.EpisodeFile // single file returned by /api/v3/episodeFile; nil → empty array
+	queueResp       *sonarrlib.Queue       // single-page queue response; nil returns empty queue
+	queuePages      []*sonarrlib.Queue     // multi-page queue responses; index 0 = page 1; takes priority over queueResp
+	queueHTTPStatus int                    // override HTTP status for /api/v3/queue; 0 means 200
 	imageBody       []byte
 	imageType       string
 	// commandStatuses is the sequence of status values returned by GET
@@ -161,6 +163,26 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 	mux.HandleFunc("/api/v3/series/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(cfg.seriesByID))
+	})
+
+	mux.HandleFunc("/api/v3/episode/", func(w http.ResponseWriter, r *http.Request) {
+		if cfg.episodeByID == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(cfg.episodeByID))
+	})
+
+	mux.HandleFunc("/api/v3/episodeFile", func(w http.ResponseWriter, r *http.Request) {
+		var files []*sonarrlib.EpisodeFile
+		if cfg.episodeFile != nil {
+			files = []*sonarrlib.EpisodeFile{cfg.episodeFile}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(files))
 	})
 
 	mux.HandleFunc("/MediaCover/", func(w http.ResponseWriter, r *http.Request) {
@@ -297,7 +319,7 @@ func TestImportByFilePath(t *testing.T) {
 
 			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), test.path)
+			err := client.ImportByFilePath(t.Context(), test.path, 0)
 
 			errFunc := test.errFunc
 			if errFunc == nil {
@@ -358,7 +380,7 @@ func TestGetInfo_UnreachableURL(t *testing.T) {
 func TestImportByFilePath_UnreachableURL(t *testing.T) {
 	client := sonarr.New(sonarr.Config{URL: unreachableURL, APIKey: "test-key"})
 
-	err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
+	err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv", 0)
 	require.Error(t, err)
 }
 
@@ -427,12 +449,113 @@ func TestImportByFilePath_BlocksUntilTerminalStatus(t *testing.T) {
 
 			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
 
-			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv")
+			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv", 0)
 			test.errFunc(t, err)
 
 			if test.errSubstring != "" && err != nil {
 				assert.Contains(t, err.Error(), test.errSubstring)
 			}
+		})
+	}
+}
+
+// TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch verifies the
+// race-recovery post-check: when the scan command finishes with
+// result="unsuccessful" but Sonarr's stored episode file size matches the
+// caller's expectedSize, ImportByFilePath treats the scan as having
+// succeeded (Sonarr's own completed-download handler already imported the
+// file). When sizes disagree, the episode lacks a file, or the lookup
+// fails, the original "no successful imports" error must propagate so the
+// workflow retries.
+func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
+	const matchingSize int64 = 12345
+
+	episodeParseOutput := &sonarrlib.ParseOutput{
+		Title: "Breaking Bad",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Breaking Bad",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
+		},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+		},
+	}
+
+	propagatesUnsuccessful := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.Contains(t, err.Error(), "no successful imports")
+	}
+
+	tests := []struct {
+		name         string
+		expectedSize int64
+		parseResp    *sonarrlib.ParseOutput
+		episodeByID  *sonarrlib.Episode
+		episodeFile  *sonarrlib.EpisodeFile
+		errFunc      require.ErrorAssertionFunc
+	}{
+		{
+			name:         "size matches: scan treated as success",
+			expectedSize: matchingSize,
+			parseResp:    episodeParseOutput,
+			episodeByID:  &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
+			episodeFile:  &sonarrlib.EpisodeFile{ID: 7, Size: matchingSize},
+		},
+		{
+			name:         "size mismatches: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    episodeParseOutput,
+			episodeByID:  &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
+			episodeFile:  &sonarrlib.EpisodeFile{ID: 7, Size: matchingSize + 1},
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "episode has no file: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    episodeParseOutput,
+			episodeByID:  &sonarrlib.Episode{ID: 200, HasFile: false},
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "episode unidentifiable by parse: original error propagates",
+			expectedSize: matchingSize,
+			parseResp:    &sonarrlib.ParseOutput{},
+			episodeByID:  nil,
+			errFunc:      propagatesUnsuccessful,
+		},
+		{
+			name:         "expectedSize zero disables post-check: original error propagates",
+			expectedSize: 0,
+			parseResp:    episodeParseOutput,
+			episodeByID:  &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
+			episodeFile:  &sonarrlib.EpisodeFile{ID: 7, Size: matchingSize},
+			errFunc:      propagatesUnsuccessful,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+				parseResp:            test.parseResp,
+				episodeByID:          test.episodeByID,
+				episodeFile:          test.episodeFile,
+				commandStatuses:      []string{"completed"},
+				commandResult:        "unsuccessful",
+				commandStatusMessage: "no eligible files",
+			})
+			t.Cleanup(srv.Close)
+
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv", test.expectedSize)
+
+			errFunc := test.errFunc
+			if errFunc == nil {
+				errFunc = require.NoError
+			}
+
+			errFunc(t, err)
 		})
 	}
 }

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -394,7 +395,18 @@ func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode Tra
 		importPath = filepath.Join(remotePath, rel)
 	}
 
-	if err := library.ImportByFilePath(ctx, importPath); err != nil {
+	// Stat the local output before invoking the scan so the client can
+	// post-check the imported file size when the arr service races our scan
+	// and reports "no successful imports". The stat is on the worker's view
+	// (transcode.DestFilePath), which is the same bytes the arr service will
+	// see once it imports. Stat failures degrade gracefully: a zero size
+	// disables the post-check.
+	var expectedSize int64
+	if info, statErr := os.Stat(transcode.DestFilePath); statErr == nil {
+		expectedSize = info.Size()
+	}
+
+	if err := library.ImportByFilePath(ctx, importPath, expectedSize); err != nil {
 		wrappedErr := fmt.Errorf("notify library: %w", err)
 		logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
 

--- a/workflows/media/testhelpers_test.go
+++ b/workflows/media/testhelpers_test.go
@@ -49,17 +49,20 @@ func copyTwoAudioTestVideo(t *testing.T) string {
 
 // stubLibraryClient implements medialib.ArrLibrary for testing.
 type stubLibraryClient struct {
-	err         error
-	importCalls []string
-	infoResult  medialib.MediaInfo
-	infoErr     error
-	posterBytes []byte
-	posterMime  string
-	posterErr   error
+	err             error
+	importCalls     []string
+	importCallSizes []int64
+	infoResult      medialib.MediaInfo
+	infoErr         error
+	posterBytes     []byte
+	posterMime      string
+	posterErr       error
 }
 
-func (s *stubLibraryClient) ImportByFilePath(_ context.Context, path string) error {
+func (s *stubLibraryClient) ImportByFilePath(_ context.Context, path string, expectedSize int64) error {
 	s.importCalls = append(s.importCalls, path)
+	s.importCallSizes = append(s.importCallSizes, expectedSize)
+
 	return s.err
 }
 


### PR DESCRIPTION
## Summary

- Adds a size-based post-check to `Sonarr`/`Radarr` `ImportByFilePath` so a benign race (the arr service's own completed-download handler imported our file before our scan ran) doesn't surface as a notify failure.
- Strict guard against the dangerous false-positive: if the library item's stored file size doesn't match the local output's size, the original `no successful imports` error propagates so Temporal retries. This specifically protects the case where a transient arr error rejects our (e.g. higher-quality) file while a pre-existing lower-quality copy is kept.
- Widens the `medialib.ArrLibrary.ImportByFilePath` signature to take `expectedSize int64` (zero disables the post-check). `Notify` stats `transcode.DestFilePath` before invoking the scan; stat failures degrade to size=0.

## Why

The original failure mode: Sonarr's completed-download handler imports a file before our explicit `DownloadedEpisodesScan` runs, so the command finishes with `result=\"unsuccessful\"` (nothing left at the scan path) and the notify activity retries until exhausted, even though the import already succeeded.

A naive fix (treat `HasFile=true` as success) has a dangerous false-positive: if a pre-existing lower-quality file is in place and a transient arr error blocks our upgrade, `HasFile=true` would silently consume our higher-quality source via `Cleanup`. Comparing the stored file size to the local output's size answers the precise question — \"did the arr service end up with my file?\" — without depending on clock skew, timestamps, or hashing.

## Implementation notes

- `arrcommand.ErrNoSuccessfulImports` is exported and wrapped so callers can `errors.Is` against it.
- Sonarr path: parse → `GetEpisodeByID` → `GetEpisodeFiles[id]` → `EpisodeFile.Size`. Two extra round trips on the rare unsuccessful-result path.
- Radarr path: parse → `GetMovieByID` (returns embedded `MovieFile`) → `MovieFile.Size`. One extra round trip.

No linked issue — the bug was diagnosed in conversation while debugging a real notify race.

## Test plan

- [x] `make fmt`
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] `make test` (all packages pass)
- [ ] Live verification against an actual Sonarr instance under load — look for the new `\"sonarr scan reported no imports but episode file size matches local output; treating as success\"` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)