### PR TITLE
fix(ffmpeg): deduplicate non-monotonic DTS clamp logs

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -73,6 +73,10 @@ type copyStreamState struct {
 	// timestamps go briefly backwards between adjacent display sets).
 	// NoPtsValue before the first write.
 	lastWrittenDts int64
+	// clampedCount caps log volume from repairNonMonotonicDts: only the first
+	// clamp on a stream logs a detailed warn line, and logClampSummary later
+	// emits the total. Pathological sources can regress on thousands of packets.
+	clampedCount int64
 }
 
 func (css *copyStreamState) inputStream() *astiav.Stream  { return css.inStream }
@@ -80,6 +84,7 @@ func (css *copyStreamState) outputStream() *astiav.Stream { return css.outStream
 func (css *copyStreamState) setOutputStream(out *astiav.Stream) {
 	css.outStream = out
 	css.lastWrittenDts = astiav.NoPtsValue
+	css.clampedCount = 0
 }
 
 func (css *copyStreamState) setupEncoder(_ HWAccel, _ *astiav.FormatContext) error { return nil }
@@ -115,7 +120,12 @@ func (css *copyStreamState) flush(_ *astiav.FormatContext, _ chan<- Progress, _ 
 
 func (css *copyStreamState) applyOutputOverrides(_ *astiav.Stream) error { return nil }
 
-func (css *copyStreamState) free() {}
+// free must be invoked by every embedding type's free() — Go does not promote
+// the embedded method once the outer type defines its own — so the DTS-clamp
+// summary is emitted exactly once per stream.
+func (css *copyStreamState) free() {
+	css.logClampSummary()
+}
 
 // receiveAndWritePackets drains encoded packets from the encoder context and
 // writes each to the output. css.frames is incremented per written packet.
@@ -167,18 +177,36 @@ func (css *copyStreamState) repairNonMonotonicDts(pkt *astiav.Packet) {
 		return
 	}
 
-	slog.Warn("ffmpeg: clamping non-monotonic DTS",
-		slog.Int("stream", css.outStream.Index()),
-		slog.Int64("packet_dts", pkt.Dts()),
-		slog.Int64("previous_dts", css.lastWrittenDts),
-		slog.Int64("corrected_dts", newDts),
-	)
+	if css.clampedCount == 0 {
+		slog.Warn("ffmpeg: clamping non-monotonic DTS",
+			slog.Int("stream", css.outStream.Index()),
+			slog.Int64("packet_dts", pkt.Dts()),
+			slog.Int64("previous_dts", css.lastWrittenDts),
+			slog.Int64("corrected_dts", newDts),
+		)
+	}
+
+	css.clampedCount++
 
 	pkt.SetDts(newDts)
 
 	if newPts != pkt.Pts() {
 		pkt.SetPts(newPts)
 	}
+}
+
+// logClampSummary skips the single-clamp case because repairNonMonotonicDts
+// already logged that packet in detail — a summary saying "1 clamp" would
+// just duplicate the existing line.
+func (css *copyStreamState) logClampSummary() {
+	if css.clampedCount <= 1 || css.outStream == nil {
+		return
+	}
+
+	slog.Warn("ffmpeg: clamped non-monotonic DTS on stream",
+		slog.Int("stream", css.outStream.Index()),
+		slog.Int64("total_clamps", css.clampedCount),
+	)
 }
 
 // monotonicDtsClamp computes the DTS and PTS for an outgoing packet so that

--- a/pkg/ffmpeg/stream_audio.go
+++ b/pkg/ffmpeg/stream_audio.go
@@ -59,6 +59,8 @@ func (ass *audioStreamState) free() {
 	if ass.encoder.fifoFrame != nil {
 		ass.encoder.fifoFrame.Free()
 	}
+
+	ass.copyStreamState.free()
 }
 
 // setupDecoder initialises the software decoder codec context for the audio stream.

--- a/pkg/ffmpeg/stream_subtitle.go
+++ b/pkg/ffmpeg/stream_subtitle.go
@@ -127,4 +127,5 @@ func (sss *subtitleStreamState) processPacket(packet *astiav.Packet, outputFmt *
 
 func (sss *subtitleStreamState) free() {
 	sss.converter.free()
+	sss.copyStreamState.free()
 }

--- a/pkg/ffmpeg/stream_test.go
+++ b/pkg/ffmpeg/stream_test.go
@@ -259,8 +259,22 @@ func TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts(t *testing.T
 
 	pkt.Unref()
 
+	assert.Equal(t, int64(1), css.clampedCount,
+		"clampedCount must increment on the first repaired packet")
+
+	readAudioPacket()
+	pkt.SetDts(60)
+	pkt.SetPts(60)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"second non-monotonic packet must also be repaired and accepted")
+
+	pkt.Unref()
+
 	require.NoError(t, outputFmt.WriteTrailer())
 
 	assert.Greater(t, css.lastWrittenDts, int64(100),
 		"copyStreamState.lastWrittenDts must advance strictly past the previous packet's DTS after the repair")
+	assert.Equal(t, int64(2), css.clampedCount,
+		"clampedCount must accumulate across every repaired packet so the summary log reflects the true total")
 }

--- a/pkg/ffmpeg/stream_video.go
+++ b/pkg/ffmpeg/stream_video.go
@@ -122,6 +122,8 @@ func (vss *videoStreamState) free() {
 			vss.plan.cropFilter.frame.Free()
 		}
 	}
+
+	vss.copyStreamState.free()
 }
 
 // setupDecoder selects and configures the decoder codec context for the video


### PR DESCRIPTION
## Summary
- Pathological sources (notably hevc_qsv on VFR inputs, and PGS subtitle streams whose authored timestamps regress between display sets) could emit thousands of `ffmpeg: clamping non-monotonic DTS` warn lines for a single transcode, drowning out everything else in the log.
- `repairNonMonotonicDts` now logs the detailed warn only on the first clamp per stream; subsequent clamps bump a counter, and a single summary line `ffmpeg: clamped non-monotonic DTS on stream` with the total is emitted when the stream is finalized.
- The summary is wired through `copyStreamState.free()` and delegated to from each embedding type's `free()`, so it fires exactly once per stream — including the downmix stream, which finalizes outside `freeStreams`.

## Test plan
- [x] `make test` — `pkg/ffmpeg` unit tests pass, including an extended `TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts` that now sends two regressing packets and asserts `clampedCount == 2`.
- [x] `make lint` — clean.
- [ ] Confirm on a known-noisy source (e.g. an hevc_qsv VFR re-encode) that the log shows one detailed warn + one summary line per affected stream instead of per-packet flooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)