### PR TITLE
fix(medialib): remove DownloadClientId from Sonarr scan; return ErrLibraryFileMismatch on size mismatch

### DIFF
--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -11,6 +11,14 @@ import (
 // ErrNotFound is returned when a media item is not found in the library.
 var ErrNotFound = errors.New("not found in library")
 
+// ErrLibraryFileMismatch is returned by ImportByFilePath when the arr service
+// already has a file for the requested media item but that file's size differs
+// from expectedSize. This indicates the arr service's existing file is from a
+// different import (not the file we just produced) and the service declined to
+// replace it. Retrying will not help; the operator must resolve the conflict in
+// the arr service before the workflow can succeed.
+var ErrLibraryFileMismatch = errors.New("library already has a different file for this media item")
+
 // MediaType identifies whether a media file is a movie or a TV show episode.
 type MediaType string
 
@@ -150,6 +158,9 @@ type ArrLibrary interface {
 	// expectedSize, the import is treated as having succeeded (typically
 	// because the arr service's own completed-download handler raced our
 	// scan). A non-positive expectedSize disables the post-check.
+	// Returns ErrLibraryFileMismatch (wrapped) when the arr service already
+	// has a file of a different size and declined to replace it — this
+	// condition will not resolve on retry.
 	ImportByFilePath(ctx context.Context, path string, expectedSize int64) error
 	// GetInfo returns structured media metadata for the item at path.
 	// Returns ErrNotFound if no item is identified.

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -142,7 +142,13 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 
 	if err := arrcommand.Wait(ctx, c.fetchCommandStatus, resp.ID, c.cfg.CommandPollInterval, "radarr"); err != nil {
 		if expectedSize > 0 && errors.Is(err, arrcommand.ErrNoSuccessfulImports) {
-			if size, ok := c.movieFileSize(ctx, filePath); ok && size == expectedSize {
+			if size, ok := c.movieFileSize(ctx, filePath); !ok {
+				slog.WarnContext(ctx, "radarr scan reported no imports and movie file lookup failed; cannot recover",
+					"file_path", filePath, "expected_size", expectedSize)
+			} else if size != expectedSize {
+				return fmt.Errorf("radarr already has a file of size %d for %q but expected %d: %w",
+					size, filePath, expectedSize, medialib.ErrLibraryFileMismatch)
+			} else {
 				slog.InfoContext(ctx, "radarr scan reported no imports but movie file size matches local output; treating as success",
 					"file_path", filePath, "size", size)
 

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -281,6 +281,11 @@ func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
 		assert.Contains(t, err.Error(), "no successful imports")
 	}
 
+	propagatesFileMismatch := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.True(t, errors.Is(err, medialib.ErrLibraryFileMismatch), "expected ErrLibraryFileMismatch, got: %v", err)
+	}
+
 	tests := []struct {
 		name         string
 		expectedSize int64
@@ -295,11 +300,11 @@ func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
 			movieByID:    &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: matchingSize}},
 		},
 		{
-			name:         "size mismatches: original error propagates",
+			name:         "size mismatches: ErrLibraryFileMismatch returned",
 			expectedSize: matchingSize,
 			parseResp:    &parseResponse{Movie: knownMovie},
 			movieByID:    &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: matchingSize + 1}},
-			errFunc:      propagatesUnsuccessful,
+			errFunc:      propagatesFileMismatch,
 		},
 		{
 			name:         "movie has no file: original error propagates",

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -99,14 +99,13 @@ func (c *Client) GetInfo(ctx context.Context, filePath string) (medialib.MediaIn
 	return c.getEpisodeByFilePath(ctx, filePath)
 }
 
-// findTrackedDownloadID returns the download client's native ID for the pending
-// tracked download that corresponds to the episode at path, or "" if none is
-// found. API errors are treated as "no match" so callers always get a safe
-// fallback.
-func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) string {
+// findQueueRecordID returns the Sonarr queue record ID for the pending tracked
+// download that corresponds to the episode at filePath, or 0 if none is found.
+// API errors are treated as "no match" so callers always get a safe fallback.
+func (c *Client) findQueueRecordID(ctx context.Context, filePath string) int64 {
 	episode, err := c.getEpisodeByFilePath(ctx, filePath)
 	if err != nil {
-		return ""
+		return 0
 	}
 
 	const pageSize = 100
@@ -114,7 +113,7 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) str
 	for page, fetched := 1, 0; ; page++ {
 		curr, err := c.sonarr.GetQueuePageContext(ctx, &starr.PageReq{PageSize: pageSize, Page: page})
 		if err != nil {
-			return ""
+			return 0
 		}
 
 		for _, record := range curr.Records {
@@ -127,11 +126,11 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) str
 				continue
 			}
 
-			if record.DownloadID == "" {
+			if record.ID == 0 {
 				continue
 			}
 
-			return record.DownloadID
+			return record.ID
 		}
 
 		fetched += len(curr.Records)
@@ -140,7 +139,7 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) str
 		}
 	}
 
-	return ""
+	return 0
 }
 
 // ImportByFilePath implements medialib.ArrLibrary. It sends a DownloadedEpisodesScan command
@@ -148,24 +147,25 @@ func (c *Client) findTrackedDownloadID(ctx context.Context, filePath string) str
 // until Sonarr reports the command has reached a terminal status.
 // Blocking is required so the caller can safely operate on filePath (e.g. prune the
 // containing directory) once Sonarr has finished moving the file into its library.
-// When a pending tracked download for the episode is found in the queue, its
-// download client ID is included so Sonarr calls VerifyImport and removes the
-// item from the downloads queue.
+// The Sonarr queue record for the episode is deleted after a successful import so
+// the download no longer shows as ImportPending. DownloadClientId is intentionally
+// omitted from the scan command: including it causes Sonarr to scan the download
+// client's content directory (rather than filePath), which for series packs imports
+// all episodes from the original download location and can produce unexpected
+// batch-episode records.
 // expectedSize, when positive, is the size of the local source file in bytes
 // and enables a post-check that distinguishes a benign race (Sonarr's own
 // completed-download handler imported the file first) from a real failure
 // (Sonarr kept a different pre-existing file) — see episodeFileSize.
 func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expectedSize int64) error {
-	downloadClientID := c.findTrackedDownloadID(ctx, filePath)
+	queueRecordID := c.findQueueRecordID(ctx, filePath)
 
 	requestPayload := struct {
-		Name             string `json:"name"`
-		Path             string `json:"path"`
-		DownloadClientId string `json:"downloadClientId,omitempty"`
+		Name string `json:"name"`
+		Path string `json:"path"`
 	}{
-		Name:             "DownloadedEpisodesScan",
-		Path:             filePath,
-		DownloadClientId: downloadClientID,
+		Name: "DownloadedEpisodesScan",
+		Path: filePath,
 	}
 
 	var body bytes.Buffer
@@ -185,11 +185,13 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 				slog.WarnContext(ctx, "sonarr scan reported no imports and episode file lookup failed; cannot recover",
 					"file_path", filePath, "expected_size", expectedSize)
 			} else if size != expectedSize {
-				slog.WarnContext(ctx, "sonarr scan reported no imports and episode file size does not match expected; cannot recover",
-					"file_path", filePath, "sonarr_size", size, "expected_size", expectedSize)
+				return fmt.Errorf("sonarr already has a file of size %d for %q but expected %d: %w",
+					size, filePath, expectedSize, medialib.ErrLibraryFileMismatch)
 			} else {
 				slog.InfoContext(ctx, "sonarr scan reported no imports but episode file size matches local output; treating as success",
 					"file_path", filePath, "size", size)
+
+				c.deleteQueueRecord(ctx, filePath, queueRecordID)
 
 				return nil
 			}
@@ -198,7 +200,25 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 		return fmt.Errorf("wait for command for %q: %w", filePath, err)
 	}
 
+	c.deleteQueueRecord(ctx, filePath, queueRecordID)
+
 	return nil
+}
+
+// deleteQueueRecord removes the Sonarr queue record for this import.
+// RemoveFromClient is false so the torrent stays in the download client —
+// series packs share one torrent across all episodes, and removing it when
+// the first episode completes would disrupt episodes still being processed.
+// Errors are logged but not propagated; queue cleanup is best-effort.
+func (c *Client) deleteQueueRecord(ctx context.Context, filePath string, queueRecordID int64) {
+	if queueRecordID == 0 {
+		return
+	}
+
+	if err := c.sonarr.DeleteQueueContext(ctx, queueRecordID, &starr.QueueDeleteOpts{RemoveFromClient: starr.False()}); err != nil {
+		slog.WarnContext(ctx, "failed to delete sonarr queue record after import; item may remain as ImportPending",
+			"file_path", filePath, "queue_record_id", queueRecordID, "error", err)
+	}
 }
 
 // episodeFileSize returns the size in bytes of the file Sonarr currently has

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -56,6 +57,8 @@ type sonarrTestServerConfig struct {
 	onCommand func(t *testing.T, r *http.Request)
 	// onParse is called with the raw parse request when /api/v3/parse is hit.
 	onParse func(t *testing.T, r *http.Request)
+	// onQueueDelete is called with the queue record ID when DELETE /api/v3/queue/{id} is hit.
+	onQueueDelete func(t *testing.T, id int64)
 }
 
 func newSonarrTestServer(t *testing.T, parseResp *sonarrlib.ParseOutput) *httptest.Server {
@@ -111,6 +114,23 @@ func newSonarrTestServerWithConfig(t *testing.T, cfg sonarrTestServerConfig) *ht
 		}
 
 		require.NoError(t, json.NewEncoder(w).Encode(q))
+	})
+
+	mux.HandleFunc("/api/v3/queue/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		idStr := strings.TrimPrefix(r.URL.Path, "/api/v3/queue/")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		require.NoError(t, err)
+
+		if cfg.onQueueDelete != nil {
+			cfg.onQueueDelete(t, id)
+		}
+
+		w.WriteHeader(http.StatusOK)
 	})
 
 	mux.HandleFunc("/api/v3/command", func(w http.ResponseWriter, r *http.Request) {
@@ -219,28 +239,30 @@ func TestImportByFilePath(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                 string
-		path                 string
-		parseResp            *sonarrlib.ParseOutput
-		queueResp            *sonarrlib.Queue
-		queuePages           []*sonarrlib.Queue
-		queueHTTPStatus      int
-		wantCmdName          string
-		wantCmdPath          string
-		wantDownloadClientID string
-		errFunc              require.ErrorAssertionFunc
+		name               string
+		path               string
+		parseResp          *sonarrlib.ParseOutput
+		queueResp          *sonarrlib.Queue
+		queuePages         []*sonarrlib.Queue
+		queueHTTPStatus    int
+		wantCmdName        string
+		wantCmdPath        string
+		wantQueueDeletedID int64 // 0 = no DELETE expected
+		errFunc            require.ErrorAssertionFunc
 	}{
 		{
-			name:                 "pending queue record found: downloadClientId included in command",
-			path:                 "/tv/Breaking.Bad.S01E01.mkv",
-			parseResp:            episodeParseOutput,
-			queueResp:            &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{pendingRecord}},
-			wantCmdName:          "DownloadedEpisodesScan",
-			wantCmdPath:          "/tv/Breaking.Bad.S01E01.mkv",
-			wantDownloadClientID: "nzb-abc123",
+			// Queue record found: command uses only Path (no DownloadClientId),
+			// and the queue record is deleted after successful import.
+			name:               "pending queue record found: queue record deleted after import",
+			path:               "/tv/Breaking.Bad.S01E01.mkv",
+			parseResp:          episodeParseOutput,
+			queueResp:          &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{pendingRecord}},
+			wantCmdName:        "DownloadedEpisodesScan",
+			wantCmdPath:        "/tv/Breaking.Bad.S01E01.mkv",
+			wantQueueDeletedID: 1,
 		},
 		{
-			name:        "episode unrecognized: command sent without downloadClientId",
+			name:        "episode unrecognized: command sent without queue delete",
 			path:        "/tv/Breaking.Bad.S01E01.mkv",
 			parseResp:   &sonarrlib.ParseOutput{},
 			queueResp:   &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{pendingRecord}},
@@ -248,7 +270,7 @@ func TestImportByFilePath(t *testing.T) {
 			wantCmdPath: "/tv/Breaking.Bad.S01E01.mkv",
 		},
 		{
-			name:        "no matching queue record: command sent without downloadClientId",
+			name:        "no matching queue record: command sent without queue delete",
 			path:        "/tv/Breaking.Bad.S01E01.mkv",
 			parseResp:   episodeParseOutput,
 			queueResp:   &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{}},
@@ -257,7 +279,7 @@ func TestImportByFilePath(t *testing.T) {
 		},
 		{
 			// Sonarr already imported the episode on its own before we scanned.
-			name:      "queue record already imported: command sent without downloadClientId",
+			name:      "queue record already imported: command sent without queue delete",
 			path:      "/tv/Breaking.Bad.S01E01.mkv",
 			parseResp: episodeParseOutput,
 			queueResp: &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{
@@ -268,7 +290,7 @@ func TestImportByFilePath(t *testing.T) {
 		},
 		{
 			// Queue API unreachable: fall back gracefully rather than blocking the import.
-			name:            "queue API error: command sent without downloadClientId",
+			name:            "queue API error: command sent without queue delete",
 			path:            "/tv/Breaking.Bad.S01E01.mkv",
 			parseResp:       episodeParseOutput,
 			queueHTTPStatus: http.StatusInternalServerError,
@@ -276,8 +298,8 @@ func TestImportByFilePath(t *testing.T) {
 			wantCmdPath:     "/tv/Breaking.Bad.S01E01.mkv",
 		},
 		{
-			// Match found on second page: verifies pagination terminates early on hit.
-			name:      "match on second queue page: downloadClientId from second page included",
+			// Match found on second page: queue record from second page is deleted after import.
+			name:      "match on second queue page: queue record from second page deleted after import",
 			path:      "/tv/Breaking.Bad.S01E01.mkv",
 			parseResp: episodeParseOutput,
 			queuePages: []*sonarrlib.Queue{
@@ -292,9 +314,9 @@ func TestImportByFilePath(t *testing.T) {
 					Records:      []*sonarrlib.QueueRecord{pendingRecord},
 				},
 			},
-			wantCmdName:          "DownloadedEpisodesScan",
-			wantCmdPath:          "/tv/Breaking.Bad.S01E01.mkv",
-			wantDownloadClientID: "nzb-abc123",
+			wantCmdName:        "DownloadedEpisodesScan",
+			wantCmdPath:        "/tv/Breaking.Bad.S01E01.mkv",
+			wantQueueDeletedID: 1,
 		},
 	}
 
@@ -306,6 +328,8 @@ func TestImportByFilePath(t *testing.T) {
 				DownloadClientId string `json:"downloadClientId"`
 			}
 
+			var deletedQueueID int64
+
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
 				parseResp:       test.parseResp,
 				queueResp:       test.queueResp,
@@ -313,6 +337,9 @@ func TestImportByFilePath(t *testing.T) {
 				queueHTTPStatus: test.queueHTTPStatus,
 				onCommand: func(t *testing.T, r *http.Request) {
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&gotCmd))
+				},
+				onQueueDelete: func(_ *testing.T, id int64) {
+					deletedQueueID = id
 				},
 			})
 			t.Cleanup(srv.Close)
@@ -331,8 +358,10 @@ func TestImportByFilePath(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, test.wantCmdName, gotCmd.Name)
 				assert.Equal(t, test.wantCmdPath, gotCmd.Path)
-				assert.Equal(t, test.wantDownloadClientID, gotCmd.DownloadClientId)
+				assert.Empty(t, gotCmd.DownloadClientId, "DownloadClientId must never be included in the scan command")
 			}
+
+			assert.Equal(t, test.wantQueueDeletedID, deletedQueueID, "queue record deletion")
 		})
 	}
 }
@@ -487,6 +516,11 @@ func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
 		assert.Contains(t, err.Error(), "no successful imports")
 	}
 
+	propagatesFileMismatch := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.True(t, errors.Is(err, medialib.ErrLibraryFileMismatch), "expected ErrLibraryFileMismatch, got: %v", err)
+	}
+
 	tests := []struct {
 		name         string
 		expectedSize int64
@@ -503,12 +537,12 @@ func TestImportByFilePath_UnsuccessfulRecoversOnSizeMatch(t *testing.T) {
 			episodeFile:  &sonarrlib.EpisodeFile{ID: 7, Size: matchingSize},
 		},
 		{
-			name:         "size mismatches: original error propagates",
+			name:         "size mismatches: ErrLibraryFileMismatch returned",
 			expectedSize: matchingSize,
 			parseResp:    episodeParseOutput,
 			episodeByID:  &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
 			episodeFile:  &sonarrlib.EpisodeFile{ID: 7, Size: matchingSize + 1},
-			errFunc:      propagatesUnsuccessful,
+			errFunc:      propagatesFileMismatch,
 		},
 		{
 			name:         "episode has no file: original error propagates",

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -398,10 +399,16 @@ func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode Tra
 	// which may no longer be present if the arr service has already moved it
 	// during a directory-level import (e.g. a series pack).
 	if err := library.ImportByFilePath(ctx, importPath, transcode.DestFileSizeBytes); err != nil {
-		wrappedErr := fmt.Errorf("notify library: %w", err)
-		logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
+		var finalErr error
+		if errors.Is(err, medialib.ErrLibraryFileMismatch) {
+			finalErr = temporal.NewNonRetryableApplicationError(err.Error(), errTypeNonRetryable, err)
+		} else {
+			finalErr = fmt.Errorf("notify library: %w", err)
+		}
 
-		return wrappedErr
+		logStepResult(ctx, "notify", input.FilePath, start, finalErr)
+
+		return finalErr
 	}
 
 	logStepResult(ctx, "notify", input.FilePath, start, nil)

--- a/workflows/media/activities_test.go
+++ b/workflows/media/activities_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally/v4"
 	contribtally "go.temporal.io/sdk/contrib/tally"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
 	"github.com/solidDoWant/media-processor/pkg/medialib"
@@ -89,6 +91,21 @@ func TestNotify_LibraryImportFailurePropagates(t *testing.T) {
 		TranscodeOutput{DestFilePath: "/out/movie.mkv"},
 	)
 	require.Error(t, err, "library import failure should propagate")
+}
+
+func TestNotify_LibraryFileMismatchIsNonRetryable(t *testing.T) {
+	radarr := &stubLibraryClient{err: fmt.Errorf("existing file: %w", medialib.ErrLibraryFileMismatch)}
+	a, env := newActivityEnv(t, MediaWorkflowConfig{}, radarr, &stubLibraryClient{}, &webhook.Client{}, nil)
+
+	_, err := env.ExecuteActivity(a.Notify,
+		MediaInput{FilePath: "/in/movie.mkv", MediaType: medialib.MovieType, OutputPath: "/out"},
+		TranscodeOutput{DestFilePath: "/out/movie.mkv", DestFileSizeBytes: 100},
+	)
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	assert.True(t, appErr.NonRetryable(), "ErrLibraryFileMismatch must produce a non-retryable application error")
 }
 
 func TestCleanup_DeletesSource(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fix 1 – Remove `DownloadClientId` from `DownloadedEpisodesScan`**: Including `DownloadClientId` caused Sonarr to scan the download client's content directory instead of the specified `Path`. For series packs this triggered a batch-import that produced a single `S01E01-E20` record overwriting all individual episode files. The fix drops `DownloadClientId` from the command entirely, then explicitly deletes the queue record via `DeleteQueueContext(RemoveFromClient: false)` after a successful scan — clearing `ImportPending` without disturbing the download client or affecting other in-progress episodes.
- **Fix 2 – Return `ErrLibraryFileMismatch` on post-check size mismatch (Sonarr + Radarr)**: When the race-recovery post-check finds that the arr service holds a file of a different size than expected, the previous code only logged a warning and fell through to retry. Since the arr service will never replace its existing file without operator intervention, retrying is futile. The fix returns `ErrLibraryFileMismatch` (wrapped), which the `Notify` activity surfaces as a `NonRetryableApplicationError` so Temporal stops burning retry budget.

## Test plan

- [x] `go test ./pkg/medialib/sonarr/...` — all `TestImportByFilePath*` cases pass, including new `wantQueueDeletedID` assertions and the renamed `ErrLibraryFileMismatch` case
- [x] `go test ./pkg/medialib/radarr/...` — `propagatesFileMismatch` check passes for size-mismatch case
- [x] `go test ./workflows/media/...` — new `TestNotify_LibraryFileMismatchIsNonRetryable` passes
- [x] `go test ./...` — full suite green
- [x] `make lint` — no issues

## Operator action required for existing failures

Workflows currently stuck on `ErrLibraryFileMismatch` (the `<Series Name>` `S01E01-E20` batch record):

1. In Sonarr, delete the file `<Series Name> - S01E01-E20- <First episode name>...<Second episode name> Bluray-1080p.mkv` from the library to unlink all 20 episodes.
2. Re-trigger the 26 failed workflow runs — they will now each import their correctly-named individual file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)