### PR TITLE
feat(watcher): add per-watch skipCropDetection option

### DIFF
--- a/cmd/watcher/watcher.go
+++ b/cmd/watcher/watcher.go
@@ -483,6 +483,7 @@ func scan(ctx context.Context, cfg *Config, instruments *scanInstruments, dispat
 				PreserveSource:         w.PreserveSource,
 				WatchRoot:              absWatchRoot,
 				RetainEmptyDirectories: w.RetainEmptyDirectories,
+				SkipCropDetection:      w.SkipCropDetection,
 				OutputPath:             absOutputPath,
 				OutputRemotePath:       outputRemotePath,
 			})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ watches:
       path: /processed/archive
     preserveSource: true           # keep the original file
     retainEmptyDirectories: true   # leave empty directories in place
+    skipCropDetection: true        # transcode the full frame, no crop detection
 ```
 
 ### Fields
@@ -64,6 +65,7 @@ watches:
 | `watches[].ignorePatterns`         | []string | `[]`    | Regular expressions in [RE2 syntax](https://github.com/google/re2/wiki/Syntax). A file whose path matches any pattern is silently skipped; a directory match skips the entire subtree.                                  |
 | `watches[].preserveSource`         | bool     | `false` | When `true`, the source file is kept after successful transcoding.                                                                                                                                                      |
 | `watches[].retainEmptyDirectories` | bool     | `false` | When `true`, parent directories that become empty after source deletion are left in place rather than being deleted up to the watch root.                                                                               |
+| `watches[].skipCropDetection`      | bool     | `false` | When `true`, crop detection is skipped for files from this watch and the full frame is transcoded without a crop filter. Useful for sources known to have no black bars, avoiding the detect-crop step entirely.        |
 
 ## Temporal client configuration file
 

--- a/internal/watcherconfig/config.go
+++ b/internal/watcherconfig/config.go
@@ -138,6 +138,10 @@ type WatchEntry struct {
 	// become empty as a result of source-file deletion are pruned bottom-up, stopping at the
 	// watch root. When true, no directory removal is performed.
 	RetainEmptyDirectories bool `yaml:"retainEmptyDirectories,omitempty"`
+	// SkipCropDetection disables the crop-detection step for files from this watch. When true,
+	// the workflow does not run the detect-crop activity and transcodes the full frame without
+	// a crop filter. When false or omitted (the default), crop detection runs as normal.
+	SkipCropDetection bool `yaml:"skipCropDetection,omitempty"`
 	// Output describes where processed files are written and how the output path is translated
 	// for the arr service.
 	Output WatchEntryOutput `yaml:"output"`

--- a/schemas/watcher.schema.json
+++ b/schemas/watcher.schema.json
@@ -68,6 +68,10 @@
           "type": "boolean",
           "description": "RetainEmptyDirectories controls whether empty parent directories are removed after the\nsource file is deleted. When false or omitted (the default), parent directories that\nbecome empty as a result of source-file deletion are pruned bottom-up, stopping at the\nwatch root. When true, no directory removal is performed."
         },
+        "skipCropDetection": {
+          "type": "boolean",
+          "description": "SkipCropDetection disables the crop-detection step for files from this watch. When true,\nthe workflow does not run the detect-crop activity and transcodes the full frame without\na crop filter. When false or omitted (the default), crop detection runs as normal."
+        },
         "output": {
           "$ref": "#/$defs/WatchEntryOutput",
           "description": "Output describes where processed files are written and how the output path is translated\nfor the arr service."

--- a/workflows/media/media_test.go
+++ b/workflows/media/media_test.go
@@ -53,6 +53,35 @@ func TestMediaWorkflow_ValidPath_RunsAllActivitiesInOrder(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
+func TestMediaWorkflow_SkipCropDetection_SkipsDetectCropAndTranscodesWithoutCrop(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	newWorkflowActivities(t).Register(env)
+
+	probeOut := ProbeOutput{IsValidMedia: true, VideoCodec: "h264", Format: "mp4", VideoWidth: 1920, VideoHeight: 1080}
+	transOut := TranscodeOutput{DestCodec: "hevc", DestContainer: "mkv", DestFilePath: "/out/file.mkv"}
+
+	env.OnActivity(ProbeActivityName, mock.Anything, mock.Anything).Return(probeOut, nil).Once()
+	// DetectCrop must NOT be invoked: no .Return is registered for it, so the
+	// mock fails the test if it is called. Transcode must receive a zero-value
+	// DetectCropOutput (nil crop) so the full frame is transcoded.
+	env.OnActivity(TranscodeActivityName, mock.Anything, mock.Anything, mock.Anything, expectCrop(DetectCropOutput{})).
+		Return(transOut, nil).Once()
+	env.OnActivity(NotifyActivityName, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	env.OnActivity(CleanupActivityName, mock.Anything, mock.Anything, expectTranscode(transOut)).Return(nil).Once()
+
+	env.ExecuteWorkflow(MediaWorkflowName, MediaInput{
+		FilePath:          "/in/file.mp4",
+		MediaType:         medialib.MovieType,
+		OutputPath:        "/out",
+		SkipCropDetection: true,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
 func TestMediaWorkflow_InvalidPath_SkipsTranscodeAndCallsCleanup(t *testing.T) {
 	suite := &testsuite.WorkflowTestSuite{}
 	env := suite.NewTestWorkflowEnvironment()
@@ -429,4 +458,11 @@ var _ medialib.ArrLibrary = (*stubLibraryClient)(nil)
 // Using mock.Anything would let either regression slip through.
 func expectTranscode(want TranscodeOutput) any {
 	return mock.MatchedBy(func(got TranscodeOutput) bool { return got == want })
+}
+
+// expectCrop matches the DetectCropOutput argument passed to the transcode
+// activity. A zero-value DetectCropOutput (nil Crop) means no crop filter is
+// applied, which is what the skip-crop-detection path must forward.
+func expectCrop(want DetectCropOutput) any {
+	return mock.MatchedBy(func(got DetectCropOutput) bool { return got == want })
 }

--- a/workflows/media/types/types.go
+++ b/workflows/media/types/types.go
@@ -22,6 +22,7 @@ type MediaInput struct {
 	PreserveSource         bool               `json:"preserve_source,omitempty"`
 	WatchRoot              string             `json:"watch_root,omitempty"`
 	RetainEmptyDirectories bool               `json:"retain_empty_directories,omitempty"`
+	SkipCropDetection      bool               `json:"skip_crop_detection,omitempty"`
 	OutputPath             string             `json:"output_path"`
 	OutputRemotePath       string             `json:"output_remote_path,omitempty"`
 }

--- a/workflows/media/workflow.go
+++ b/workflows/media/workflow.go
@@ -110,11 +110,19 @@ func (a *Activities) MediaWorkflow(ctx workflow.Context, input MediaInput) (err 
 		return nil
 	}
 
-	cropCtx := workflow.WithActivityOptions(ctx, a.activityOptions(DetectCropActivityName, a.cfg.DetectCropTimeout, defaultMaxAttempts))
-
 	var crop DetectCropOutput
-	if err := workflow.ExecuteActivity(cropCtx, DetectCropActivityName, input, probe).Get(cropCtx, &crop); err != nil {
-		return err
+
+	// When crop detection is disabled for this watch, skip the detect-crop
+	// activity entirely. A nil crop means no crop filter is applied (the full
+	// frame is transcoded), so no detect-crop worker is needed for these files.
+	if input.SkipCropDetection {
+		log.Info("crop detection skipped (disabled for watch)", "file", input.FilePath)
+	} else {
+		cropCtx := workflow.WithActivityOptions(ctx, a.activityOptions(DetectCropActivityName, a.cfg.DetectCropTimeout, defaultMaxAttempts))
+
+		if err := workflow.ExecuteActivity(cropCtx, DetectCropActivityName, input, probe).Get(cropCtx, &crop); err != nil {
+			return err
+		}
 	}
 
 	transcodeOpts := a.activityOptions(TranscodeActivityName, a.cfg.TranscodeTimeout, defaultMaxAttempts)


### PR DESCRIPTION
## Summary

- Adds a per-watch `skipCropDetection` boolean to `WatchEntry`. When enabled, files from that watch skip crop detection.
- The media workflow now branches on `MediaInput.SkipCropDetection`: when set, it does **not** schedule the detect-crop activity and passes a nil crop to transcode, so the full frame is transcoded without a crop filter (`crop_applied=false`). No detect-crop worker is needed for those files.
- Flag is plumbed watcher config -> `MediaInput` payload -> workflow. Regenerated `schemas/watcher.schema.json` and documented the option in `docs/configuration.md`.

## Why skip the activity instead of short-circuiting inside it

A nil crop already means "no crop filter" everywhere downstream, so skipping the activity at the workflow level avoids the detect-crop queue, worker poll, and 30m timeout for files that don't need it — cleaner than scheduling an activity that returns immediately.

## Temporal determinism

The new field defaults to `false`, so workflows started before this change deserialize to the prior behavior and take the same (run-the-activity) branch on replay. Branching on immutable workflow input is deterministic, and because the default preserves old behavior there is no replay break and no `workflow.GetVersion` versioning required.

## Test plan

- [x] `make fmt` / `make vet` / `make lint` clean
- [x] `make build` succeeds
- [x] `make test` (race) passes, including a new workflow test asserting detect-crop is never invoked and transcode receives a nil crop when `SkipCropDetection` is true

Note: no linked GitHub issue exists for this work, so no `Fixes #` reference is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)