### PR TITLE
fix(notify): skip import when arr rejects release as not an upgrade

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,18 +28,19 @@ For Kubernetes, ensure `terminationGracePeriodSeconds` on the worker pod is at l
 
 ### Worker — media workflow
 
-| Metric                                       | Type      | Unit    | Description                                                                                              |
-| -------------------------------------------- | --------- | ------- | -------------------------------------------------------------------------------------------------------- |
-| `media_workflow_source_duration_seconds`     | histogram | seconds | Distribution of source media file durations as reported by probe (workload characterization).                                  |
-| `media_workflow_source_file_size_bytes`      | histogram | bytes   | Distribution of source file sizes before transcoding.                                                                          |
-| `media_workflow_destination_file_size_bytes` | histogram | bytes   | Distribution of output file sizes after transcoding. Compare against source for compression ratio.                             |
-| `media_workflow_transcode_duration_seconds`  | histogram | seconds | Wall-clock time spent transcoding. Carries codec / hardware-acceleration / crop tags so runtime can be correlated with input characteristics. Not emitted when an existing output at the destination path is reused without re-encoding (the source/destination size histograms still fire so corpus shape stays accurate). |
-| `media_workflow_audio_track_count`           | gauge     | tracks  | Audio track count from the most recent probe per label combination.                                                            |
-| `media_workflow_subtitle_track_count`        | gauge     | tracks  | Subtitle track count from the most recent probe per label combination.                                                         |
-| `media_workflow_invalid_files_total`         | counter   | —       | Files skipped because they could not be probed or contained no video stream.                                                   |
-| `media_workflow_artwork_fetch_skipped_total` | counter   | —       | Transcode runs where artwork fetch was attempted but yielded no embeddable image.                                              |
-| `media_workflow_import_skipped_not_in_library_total` | counter | —    | Files whose Radarr/Sonarr import was skipped because the media item is no longer in the library (the movie/series was removed or is no longer monitored). The transcode still completed; the workflow removes the orphaned output and finishes successfully without firing the failure webhook. |
-| `media_workflow_metrics_errors_total`        | counter   | —       | Radarr/Sonarr `GetInfo` lookups that did not return a result while resolving high-cardinality tags — either a backend error (unreachable, auth failure, etc.) or the library could not parse the filename to a known item. |
+| Metric                                               | Type      | Unit    | Description                                                                                                                                                                                                                                                                                                                 |
+| ---------------------------------------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `media_workflow_source_duration_seconds`             | histogram | seconds | Distribution of source media file durations as reported by probe (workload characterization).                                                                                                                                                                                                                               |
+| `media_workflow_source_file_size_bytes`              | histogram | bytes   | Distribution of source file sizes before transcoding.                                                                                                                                                                                                                                                                       |
+| `media_workflow_destination_file_size_bytes`         | histogram | bytes   | Distribution of output file sizes after transcoding. Compare against source for compression ratio.                                                                                                                                                                                                                          |
+| `media_workflow_transcode_duration_seconds`          | histogram | seconds | Wall-clock time spent transcoding. Carries codec / hardware-acceleration / crop tags so runtime can be correlated with input characteristics. Not emitted when an existing output at the destination path is reused without re-encoding (the source/destination size histograms still fire so corpus shape stays accurate). |
+| `media_workflow_audio_track_count`                   | gauge     | tracks  | Audio track count from the most recent probe per label combination.                                                                                                                                                                                                                                                         |
+| `media_workflow_subtitle_track_count`                | gauge     | tracks  | Subtitle track count from the most recent probe per label combination.                                                                                                                                                                                                                                                      |
+| `media_workflow_invalid_files_total`                 | counter   | —       | Files skipped because they could not be probed or contained no video stream.                                                                                                                                                                                                                                                |
+| `media_workflow_artwork_fetch_skipped_total`         | counter   | —       | Transcode runs where artwork fetch was attempted but yielded no embeddable image.                                                                                                                                                                                                                                           |
+| `media_workflow_import_skipped_not_in_library_total` | counter   | —       | Files whose Radarr/Sonarr import was skipped because the media item is no longer in the library (the movie/series was removed or is no longer monitored). The transcode still completed; the workflow removes the orphaned output and finishes successfully without firing the failure webhook.                             |
+| `media_workflow_import_skipped_not_upgrade_total`    | counter   | —       | Files whose Radarr/Sonarr import was skipped because the library already holds an equal or better file, so the release was rejected as "not an upgrade" (quality or custom-format). The transcode still completed; the workflow removes the orphaned output and finishes successfully without firing the failure webhook.   |
+| `media_workflow_metrics_errors_total`                | counter   | —       | Radarr/Sonarr `GetInfo` lookups that did not return a result while resolving high-cardinality tags — either a backend error (unreachable, auth failure, etc.) or the library could not parse the filename to a known item.                                                                                                  |
 
 End-to-end workflow latency, schedule-to-start latency, retry counts, and worker poll metrics are emitted by the Temporal SDK — see the [Temporal SDK metrics section](#worker--temporal-sdk) below. Per-activity execution latency is also available there, but only with SDK tags; the application-side `media_workflow_transcode_duration_seconds` above carries the media-domain tags needed to slice runtime by codec, hardware acceleration, and crop.
 
@@ -47,36 +48,36 @@ End-to-end workflow latency, schedule-to-start latency, retry counts, and worker
 
 These metrics describe the GPU-aware Temporal slot supplier that gates transcode-activity admission. They are **only emitted on workers whose `WORKER_ACTIVITIES` set includes `transcode`**; pods that don't run the transcode activity register no `media_worker_transcode_*` series. See [configuration.md](configuration.md#transcode-admission-controller) for the operator-tunable inputs and [hardware-acceleration.md](hardware-acceleration.md#static-cap-fallback) for the fallback rules.
 
-| Metric                                                | Type    | Unit    | Labels  | Description                                                                                                                                                                                       |
-| ----------------------------------------------------- | ------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `media_worker_transcode_slots_in_flight`              | gauge   | slots   | —       | Number of transcodes currently holding a slot on this worker.                                                                                                                                      |
-| `media_worker_transcode_slots_blocked_seconds_total`  | counter | seconds | —       | Cumulative seconds reservations spent blocked on the admission controller before being admitted or cancelled.                                                                                       |
-| `media_worker_transcode_load_utilization`             | gauge   | ratio   | —       | EWMA-smoothed load probe reading, in `[0, 1]`. Source depends on the probe in use: i915 GPU video-engine busy ratio on hardware-accelerated workers, container CPU utilization in software mode. |
-| `media_worker_transcode_admission_mode`               | gauge   | —       | `mode`  | Active admission mode. `mode="probe"` is `1` when the load probe drives admission; `mode="static"` is `1` when the supplier has fallen back to static-cap-only mode. The two series are inverse.   |
+| Metric                                               | Type    | Unit    | Labels | Description                                                                                                                                                                                      |
+| ---------------------------------------------------- | ------- | ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `media_worker_transcode_slots_in_flight`             | gauge   | slots   | —      | Number of transcodes currently holding a slot on this worker.                                                                                                                                    |
+| `media_worker_transcode_slots_blocked_seconds_total` | counter | seconds | —      | Cumulative seconds reservations spent blocked on the admission controller before being admitted or cancelled.                                                                                    |
+| `media_worker_transcode_load_utilization`            | gauge   | ratio   | —      | EWMA-smoothed load probe reading, in `[0, 1]`. Source depends on the probe in use: i915 GPU video-engine busy ratio on hardware-accelerated workers, container CPU utilization in software mode. |
+| `media_worker_transcode_admission_mode`              | gauge   | —       | `mode` | Active admission mode. `mode="probe"` is `1` when the load probe drives admission; `mode="static"` is `1` when the supplier has fallen back to static-cap-only mode. The two series are inverse. |
 
 `media_worker_activity_enabled` is a complementary gauge emitted on **every** worker pod regardless of activity set:
 
-| Metric                          | Type  | Labels    | Description                                                                                                                                                                          |
-| ------------------------------- | ----- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `media_worker_activity_enabled` | gauge | `activity`| `1` if this pod has the named activity enabled, `0` otherwise. One series per known activity. Use `sum by (activity) (media_worker_activity_enabled == 1)` for per-activity pod counts. |
+| Metric                          | Type  | Labels     | Description                                                                                                                                                                             |
+| ------------------------------- | ----- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `media_worker_activity_enabled` | gauge | `activity` | `1` if this pod has the named activity enabled, `0` otherwise. One series per known activity. Use `sum by (activity) (media_worker_activity_enabled == 1)` for per-activity pod counts. |
 
 `media_worker_idle_exit_seconds_remaining` is emitted **only when `WORKER_IDLE_EXIT_AFTER` is set to a positive duration** (see [configuration.md](configuration.md#worker)). On workers where the feature is disabled, the gauge is not registered.
 
-| Metric                                     | Type  | Unit    | Labels | Description                                                                                                                                                                                                                       |
-| ------------------------------------------ | ----- | ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Metric                                     | Type  | Unit    | Labels | Description                                                                                                                                                                                                                             |
+| ------------------------------------------ | ----- | ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `media_worker_idle_exit_seconds_remaining` | gauge | seconds | —      | Seconds remaining before the worker initiates an idle-exit drain. Held at the configured `WORKER_IDLE_EXIT_AFTER` value while activity- or workflow-task work is in flight (the timer is paused). Reaches `0` immediately before drain. |
 
 ### Worker — Temporal SDK
 
 The Temporal Go SDK emits its own set of counters and histograms onto the same `/metrics` endpoint. A few that are especially useful operationally:
 
-| Metric                                                | Type      | Description                                                                  |
-| ----------------------------------------------------- | --------- | ---------------------------------------------------------------------------- |
-| `temporal_workflow_endtoend_latency_seconds`          | histogram | Wall-clock time from workflow start to close, tagged by `workflow_type`.     |
+| Metric                                                | Type      | Description                                                                                                                                |
+| ----------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `temporal_workflow_endtoend_latency_seconds`          | histogram | Wall-clock time from workflow start to close, tagged by `workflow_type`.                                                                   |
 | `temporal_activity_execution_latency_seconds`         | histogram | Wall-clock time inside an activity, tagged by `activity_type` and `workflow_type`. Use `activity_type="Transcode"` for transcode duration. |
-| `temporal_activity_schedule_to_start_latency_seconds` | histogram | Time between an activity being scheduled and a worker picking it up — a leading indicator of worker capacity. |
-| `temporal_request_total`                              | counter   | gRPC requests issued by the SDK to the Temporal frontend.                    |
-| `temporal_long_request_latency_seconds`               | histogram | Latency of long-poll RPCs.                                                   |
+| `temporal_activity_schedule_to_start_latency_seconds` | histogram | Time between an activity being scheduled and a worker picking it up — a leading indicator of worker capacity.                              |
+| `temporal_request_total`                              | counter   | gRPC requests issued by the SDK to the Temporal frontend.                                                                                  |
+| `temporal_long_request_latency_seconds`               | histogram | Latency of long-poll RPCs.                                                                                                                 |
 
 Refer to the [Temporal Go SDK metrics reference](https://docs.temporal.io/references/sdk-metrics) for the full catalogue, since the exact set of instruments depends on the SDK version in use.
 
@@ -97,40 +98,41 @@ Refer to the [Temporal Go SDK metrics reference](https://docs.temporal.io/refere
 
 Worker application metrics carry the tags listed below. Per-metric coverage varies because some tags are only knowable later in the run (codec/container after probe; hardware-acceleration and crop only after transcode).
 
-| Tag                     | Values                    | Description                                                                                                                                                                                                          |
-| ----------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `media_type`            | `movie`, `show`           | Type of media being processed.                                                                                                                                                                                       |
-| `mapping_name`          | _(configured watch name)_ | Name of the watch entry that triggered the job.                                                                                                                                                                      |
-| `source_codec`          | e.g. `h264`, `hevc`       | Video codec of the source file.                                                                                                                                                                                      |
-| `destination_codec`     | e.g. `hevc`, `copy`       | Video codec written to the output (`copy` when the source was remuxed without re-encode).                                                                                                                            |
-| `source_container`      | e.g. `matroska,webm`      | Container format of the source file as reported by libavformat (comma-joined list).                                                                                                                                  |
-| `destination_container` | `mkv`                     | Container format of the output file (always `mkv`).                                                                                                                                                                  |
-| `hardware_accelerated`  | `true`, `false`           | `true` when at least one video stream was encoded with a hardware encoder (QSV, VAAPI). `false` when the encoder fell back to software (e.g. libx265), even if `MEDIA_HARDWARE_DEVICE_PATH` is set.                   |
-| `crop_applied`          | `true`, `false`           | Whether a crop filter was applied during transcoding.                                                                                                                                                                |
+| Tag                     | Values                    | Description                                                                                                                                                                                         |
+| ----------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `media_type`            | `movie`, `show`           | Type of media being processed.                                                                                                                                                                      |
+| `mapping_name`          | _(configured watch name)_ | Name of the watch entry that triggered the job.                                                                                                                                                     |
+| `source_codec`          | e.g. `h264`, `hevc`       | Video codec of the source file.                                                                                                                                                                     |
+| `destination_codec`     | e.g. `hevc`, `copy`       | Video codec written to the output (`copy` when the source was remuxed without re-encode).                                                                                                           |
+| `source_container`      | e.g. `matroska,webm`      | Container format of the source file as reported by libavformat (comma-joined list).                                                                                                                 |
+| `destination_container` | `mkv`                     | Container format of the output file (always `mkv`).                                                                                                                                                 |
+| `hardware_accelerated`  | `true`, `false`           | `true` when at least one video stream was encoded with a hardware encoder (QSV, VAAPI). `false` when the encoder fell back to software (e.g. libx265), even if `MEDIA_HARDWARE_DEVICE_PATH` is set. |
+| `crop_applied`          | `true`, `false`           | Whether a crop filter was applied during transcoding.                                                                                                                                               |
 
-| Metric                                       | Application tags                                                                                                                                          |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `media_workflow_source_duration_seconds`     | `media_type`, `mapping_name`                                                                                                                              |
-| `media_workflow_audio_track_count`           | `media_type`, `mapping_name`                                                                                                                              |
-| `media_workflow_subtitle_track_count`        | `media_type`, `mapping_name`                                                                                                                              |
-| `media_workflow_invalid_files_total`         | `media_type`, `mapping_name`                                                                                                                              |
-| `media_workflow_source_file_size_bytes`      | `media_type`, `mapping_name`, `source_codec`, `destination_codec`, `source_container`, `destination_container`, `hardware_accelerated`, `crop_applied`    |
-| `media_workflow_destination_file_size_bytes` | same as `media_workflow_source_file_size_bytes`                                                                                                           |
-| `media_workflow_transcode_duration_seconds`  | same as `media_workflow_source_file_size_bytes`                                                                                                           |
-| `media_workflow_artwork_fetch_skipped_total` | _(none)_                                                                                                                                                  |
-| `media_workflow_import_skipped_not_in_library_total` | `media_type`, `mapping_name`                                                                                                                      |
-| `media_workflow_metrics_errors_total`        | _(none)_                                                                                                                                                  |
+| Metric                                               | Application tags                                                                                                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `media_workflow_source_duration_seconds`             | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_audio_track_count`                   | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_subtitle_track_count`                | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_invalid_files_total`                 | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_source_file_size_bytes`              | `media_type`, `mapping_name`, `source_codec`, `destination_codec`, `source_container`, `destination_container`, `hardware_accelerated`, `crop_applied` |
+| `media_workflow_destination_file_size_bytes`         | same as `media_workflow_source_file_size_bytes`                                                                                                        |
+| `media_workflow_transcode_duration_seconds`          | same as `media_workflow_source_file_size_bytes`                                                                                                        |
+| `media_workflow_artwork_fetch_skipped_total`         | _(none)_                                                                                                                                               |
+| `media_workflow_import_skipped_not_in_library_total` | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_import_skipped_not_upgrade_total`    | `media_type`, `mapping_name`                                                                                                                           |
+| `media_workflow_metrics_errors_total`                | _(none)_                                                                                                                                               |
 
 ### Worker — Temporal SDK tags
 
 Every metric the worker emits — including the application metrics above — additionally carries the SDK-injected tags below. Use them to filter per namespace, per task queue, or per workflow/activity type when you have multiple workers writing to the same Prometheus.
 
-| Tag             | Description                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| `namespace`     | The Temporal namespace the worker is connected to.                                           |
-| `task_queue`    | The Temporal task queue the worker polls.                                                    |
-| `activity_type` | Name of the activity that emitted the metric (present on activity-emitted metrics).          |
-| `workflow_type` | Name of the workflow type (present on workflow-emitted SDK metrics).                         |
+| Tag             | Description                                                                         |
+| --------------- | ----------------------------------------------------------------------------------- |
+| `namespace`     | The Temporal namespace the worker is connected to.                                  |
+| `task_queue`    | The Temporal task queue the worker polls.                                           |
+| `activity_type` | Name of the activity that emitted the metric (present on activity-emitted metrics). |
+| `workflow_type` | Name of the workflow type (present on workflow-emitted SDK metrics).                |
 
 ### Watcher tags
 
@@ -140,14 +142,14 @@ All watcher metrics carry `mapping_name`. `watcher_files_discovered_total`, `wat
 
 Set `METRICS_HIGH_CARDINALITY_LABELS=true` on the worker to attach per-item identification labels to the histograms that already carry the full transcode tag set (`media_workflow_source_file_size_bytes`, `media_workflow_destination_file_size_bytes`, `media_workflow_transcode_duration_seconds`):
 
-| Label            | Applies to                | Description                          |
-| ---------------- | ------------------------- | ------------------------------------ |
-| `id`             | all                       | Library item ID from Radarr/Sonarr.  |
-| `title`          | all                       | Title of the movie or episode.       |
-| `year`           | all                       | Release year.                        |
-| `series_title`   | shows (empty for movies)  | Series title.                        |
-| `season_number`  | shows (empty for movies)  | Season number.                       |
-| `episode_number` | shows (empty for movies)  | Episode number.                      |
+| Label            | Applies to               | Description                         |
+| ---------------- | ------------------------ | ----------------------------------- |
+| `id`             | all                      | Library item ID from Radarr/Sonarr. |
+| `title`          | all                      | Title of the movie or episode.      |
+| `year`           | all                      | Release year.                       |
+| `series_title`   | shows (empty for movies) | Series title.                       |
+| `season_number`  | shows (empty for movies) | Season number.                      |
+| `episode_number` | shows (empty for movies) | Episode number.                     |
 
 When enabled, those three histograms carry the full set of six labels on every observation. For movie observations, the show-only labels (`series_title`, `season_number`, `episode_number`) are present with empty-string values so the label set stays consistent across observations.
 

--- a/pkg/medialib/internal/arrcommand/arrcommand.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand.go
@@ -25,6 +25,31 @@ import (
 // import actually happened before treating it as a hard failure.
 var ErrNoSuccessfulImports = errors.New("no successful imports")
 
+// notUpgradeMarker is the case-insensitive substring Sonarr/Radarr put in a
+// queue item's status messages when they refuse to import a release because the
+// file already in the library is as good or better. Both the quality variant
+// ("Not an upgrade for existing episode/movie file(s)") and the custom-format
+// variant ("Not a Custom Format upgrade for existing episode/movie file(s)")
+// share "upgrade for existing", which is specific enough not to collide with
+// transient import errors.
+const notUpgradeMarker = "upgrade for existing"
+
+// IsNotUpgradeRejection reports whether any of the given queue status messages
+// indicates the release was rejected because the existing library file is
+// already as good or better (a "not an upgrade" / "not a Custom Format upgrade"
+// rejection). Such a rejection is permanent: re-running the import scan always
+// hits the same comparison, so callers should treat it as a benign skip rather
+// than a retryable failure.
+func IsNotUpgradeRejection(messages ...string) bool {
+	for _, message := range messages {
+		if strings.Contains(strings.ToLower(message), notUpgradeMarker) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // DefaultPollInterval is used when the caller passes a non-positive interval.
 // Sonarr/Radarr command status updates are inexpensive (a single DB read on
 // the server side), but importing a season pack can serialize many commands

--- a/pkg/medialib/internal/arrcommand/arrcommand_test.go
+++ b/pkg/medialib/internal/arrcommand/arrcommand_test.go
@@ -174,3 +174,54 @@ func TestWait_ZeroIntervalUsesDefault(t *testing.T) {
 	require.NoError(t, arrcommand.Wait(t.Context(), fetcher, 1, 0, "arrtest"))
 	require.NoError(t, arrcommand.Wait(t.Context(), fetcher, 1, -1, "arrtest"))
 }
+
+func TestIsNotUpgradeRejection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		messages []string
+		expected bool
+	}{
+		{
+			name: "custom format non-upgrade rejection",
+			messages: []string{
+				"Not a Custom Format upgrade for existing episode file(s). New: [Scene] (90000) do not improve on Existing: [DSNP] (101075)",
+			},
+			expected: true,
+		},
+		{
+			name:     "quality non-upgrade rejection",
+			messages: []string{"Not an upgrade for existing movie file(s)"},
+			expected: true,
+		},
+		{
+			name:     "match is case-insensitive",
+			messages: []string{"NOT AN UPGRADE FOR EXISTING EPISODE FILE(S)"},
+			expected: true,
+		},
+		{
+			name:     "rejection found among multiple messages",
+			messages: []string{"Sample file detected", "Not an upgrade for existing episode file(s)"},
+			expected: true,
+		},
+		{
+			name:     "unrelated import error",
+			messages: []string{"Unable to parse file", "No files found are eligible for import"},
+			expected: false,
+		},
+		{
+			name:     "no messages",
+			messages: nil,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, arrcommand.IsNotUpgradeRejection(test.messages...))
+		})
+	}
+}

--- a/pkg/medialib/medialib.go
+++ b/pkg/medialib/medialib.go
@@ -11,6 +11,13 @@ import (
 // ErrNotFound is returned when a media item is not found in the library.
 var ErrNotFound = errors.New("not found in library")
 
+// ErrNotUpgrade is returned when an import scan reports no successful imports
+// because the file already in the library is as good or better than the file
+// being imported (the arr service rejected the release as "not an upgrade" /
+// "not a Custom Format upgrade"). The import can never succeed, so callers
+// should treat this as a benign skip rather than a retryable failure.
+var ErrNotUpgrade = errors.New("existing library file is already an equal or better version")
+
 // MediaType identifies whether a media file is a movie or a TV show episode.
 type MediaType string
 
@@ -153,8 +160,10 @@ type ArrLibrary interface {
 	//
 	// Returns ErrNotFound when the scan reports no successful imports and the
 	// media item is no longer in the library (removed or no longer monitored),
-	// so the import can never succeed. Callers should treat this as a benign
-	// skip rather than a retryable failure.
+	// so the import can never succeed. Returns ErrNotUpgrade when the scan
+	// reports no successful imports because the library already holds an equal
+	// or better file (the release was rejected as "not an upgrade"). Callers
+	// should treat both as a benign skip rather than a retryable failure.
 	ImportByFilePath(ctx context.Context, path string, expectedSize int64) error
 	// GetInfo returns structured media metadata for the item at path.
 	// Returns ErrNotFound if no item is identified.

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -215,7 +215,7 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 			// because its existing file is already as good or better ("not an
 			// upgrade"), the scan can never succeed — surface ErrNotUpgrade so the
 			// caller treats it as a benign skip rather than burning the retry budget.
-			if c.rejectedAsNotUpgrade(ctx, filePath) {
+			if c.rejectedAsNotUpgrade(ctx, filePath, downloadClientID) {
 				slog.InfoContext(ctx, "radarr scan reported no imports because the existing movie file is already an equal or better version; skipping import",
 					"file_path", filePath)
 
@@ -269,7 +269,12 @@ func (c *Client) movieFileSize(ctx context.Context, filePath string) (int64, boo
 // "not a Custom Format upgrade"). An unidentifiable movie, API errors, and a
 // missing record all return false so the caller falls back to its normal
 // failure handling.
-func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool {
+//
+// downloadClientID is the tracked download the scan was attached to. When set,
+// only that download's record is inspected so a stale or unrelated record for
+// the same movie cannot turn a retryable failure into a permanent skip; when
+// empty (no tracked download was found), records are matched by movie alone.
+func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath, downloadClientID string) bool {
 	movie, err := c.getMovieByFilePath(ctx, filePath)
 	if err != nil {
 		return false
@@ -285,6 +290,17 @@ func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool
 
 		for _, record := range curr.Records {
 			if record.MovieID == 0 || record.MovieID != movie.GetID() {
+				continue
+			}
+
+			// Skip records that aren't the download the scan was attached to, and
+			// records Radarr already imported on its own — neither reflects the
+			// outcome of this import attempt.
+			if downloadClientID != "" && record.DownloadID != "" && record.DownloadID != downloadClientID {
+				continue
+			}
+
+			if strings.EqualFold(record.TrackedDownloadState, "imported") {
 				continue
 			}
 

--- a/pkg/medialib/radarr/client.go
+++ b/pkg/medialib/radarr/client.go
@@ -211,8 +211,19 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 				return fmt.Errorf("import %q: %w", filePath, medialib.ErrNotFound)
 			}
 
-			// The movie is still in the library, so fall through to the
-			// benign-race size post-check documented on expectedSize above.
+			// The movie is still in the library. If Radarr rejected the import
+			// because its existing file is already as good or better ("not an
+			// upgrade"), the scan can never succeed — surface ErrNotUpgrade so the
+			// caller treats it as a benign skip rather than burning the retry budget.
+			if c.rejectedAsNotUpgrade(ctx, filePath) {
+				slog.InfoContext(ctx, "radarr scan reported no imports because the existing movie file is already an equal or better version; skipping import",
+					"file_path", filePath)
+
+				return fmt.Errorf("import %q: %w", filePath, medialib.ErrNotUpgrade)
+			}
+
+			// Otherwise fall through to the benign-race size post-check
+			// documented on expectedSize above.
 			if expectedSize > 0 {
 				if size, ok := c.movieFileSize(ctx, filePath); ok && size == expectedSize {
 					slog.InfoContext(ctx, "radarr scan reported no imports but movie file size matches local output; treating as success",
@@ -250,6 +261,51 @@ func (c *Client) movieFileSize(ctx context.Context, filePath string) (int64, boo
 	}
 
 	return full.MovieFile.Size, true
+}
+
+// rejectedAsNotUpgrade reports whether the movie identified by filePath has a
+// queue record whose status messages indicate Radarr refused the import because
+// the existing library file is already as good or better ("not an upgrade" /
+// "not a Custom Format upgrade"). An unidentifiable movie, API errors, and a
+// missing record all return false so the caller falls back to its normal
+// failure handling.
+func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool {
+	movie, err := c.getMovieByFilePath(ctx, filePath)
+	if err != nil {
+		return false
+	}
+
+	const pageSize = 100
+
+	for page, fetched := 1, 0; ; page++ {
+		curr, err := c.radarr.GetQueuePageContext(ctx, &starr.PageReq{PageSize: pageSize, Page: page})
+		if err != nil {
+			return false
+		}
+
+		for _, record := range curr.Records {
+			if record.MovieID == 0 || record.MovieID != movie.GetID() {
+				continue
+			}
+
+			for _, statusMessage := range record.StatusMessages {
+				if statusMessage == nil {
+					continue
+				}
+
+				if arrcommand.IsNotUpgradeRejection(statusMessage.Messages...) {
+					return true
+				}
+			}
+		}
+
+		fetched += len(curr.Records)
+		if fetched >= curr.TotalRecords || len(curr.Records) == 0 {
+			break
+		}
+	}
+
+	return false
 }
 
 // fetchCommandStatus implements arrcommand.Fetcher. It hits Radarr's

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -35,6 +35,7 @@ type parseResponse struct {
 type testServerConfig struct {
 	parseResp *parseResponse
 	movieByID *radarrlib.Movie // response for /api/v3/movie/{id}
+	queueResp *radarrlib.Queue // single-page queue response; nil returns empty queue
 	imageBody []byte           // raw bytes served at image paths
 	imageType string           // Content-Type for image responses
 	// commandStatuses is the sequence of status values returned by GET
@@ -120,6 +121,16 @@ func newTestServerWithConfig(t *testing.T, cfg testServerConfig) *httptest.Serve
 
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(body))
+	})
+
+	mux.HandleFunc("/api/v3/queue", func(w http.ResponseWriter, r *http.Request) {
+		q := cfg.queueResp
+		if q == nil {
+			q = &radarrlib.Queue{Records: []*radarrlib.QueueRecord{}}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(q))
 	})
 
 	mux.HandleFunc("/api/v3/movie/", func(w http.ResponseWriter, r *http.Request) {
@@ -371,6 +382,87 @@ func TestImportByFilePath_NotInLibraryReturnsNotFound(t *testing.T) {
 
 	err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv", expectedSize)
 	require.ErrorIs(t, err, medialib.ErrNotFound)
+}
+
+// TestImportByFilePath_NotUpgradeReturnsNotUpgrade verifies that when a scan
+// finishes with no successful imports and the movie's queue record reports the
+// release was rejected because the existing library file is already as good or
+// better, ImportByFilePath returns medialib.ErrNotUpgrade rather than the
+// generic "no successful imports" error. The caller relies on this sentinel to
+// skip the import as a benign no-op instead of retrying for the full retry
+// budget. The rejection is checked before the size post-check, so a stored file
+// whose size differs from expectedSize must not mask it.
+func TestImportByFilePath_NotUpgradeReturnsNotUpgrade(t *testing.T) {
+	const expectedSize int64 = 67890
+
+	knownMovie := &radarrlib.Movie{ID: 42, Title: "The Matrix", Year: 1999}
+
+	tests := []struct {
+		name       string
+		statusMsgs []*starr.StatusMessage
+		movieByID  *radarrlib.Movie
+		errFunc    require.ErrorAssertionFunc
+	}{
+		{
+			name: "custom format non-upgrade rejection",
+			statusMsgs: []*starr.StatusMessage{{
+				Title: "The.Matrix.1999.mkv",
+				Messages: []string{
+					"Not a Custom Format upgrade for existing movie file(s). New: [Scene] (90000) do not improve on Existing: [BluRay] (101075)",
+				},
+			}},
+		},
+		{
+			name: "quality non-upgrade rejection",
+			statusMsgs: []*starr.StatusMessage{{
+				Title:    "The.Matrix.1999.mkv",
+				Messages: []string{"Not an upgrade for existing movie file(s)"},
+			}},
+		},
+		{
+			name: "unrelated status message falls through to size post-check",
+			statusMsgs: []*starr.StatusMessage{{
+				Title:    "The.Matrix.1999.mkv",
+				Messages: []string{"Unable to parse file"},
+			}},
+			// Movie has a stored file whose size differs from expectedSize, so the
+			// size post-check cannot recover and the generic error propagates.
+			movieByID: &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: expectedSize + 1}},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				assert.Contains(t, err.Error(), "no successful imports")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newTestServerWithConfig(t, testServerConfig{
+				parseResp: &parseResponse{Movie: knownMovie},
+				movieByID: test.movieByID,
+				queueResp: &radarrlib.Queue{Records: []*radarrlib.QueueRecord{
+					{MovieID: 42, StatusMessages: test.statusMsgs},
+				}},
+				commandStatuses:      []string{"completed"},
+				commandResult:        "unsuccessful",
+				commandStatusMessage: "Failed to import",
+			})
+			t.Cleanup(srv.Close)
+
+			client := radarr.New(radarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/movies/The.Matrix.1999.mkv", expectedSize)
+
+			if test.errFunc != nil {
+				test.errFunc(t, err)
+				assert.NotErrorIs(t, err, medialib.ErrNotUpgrade)
+
+				return
+			}
+
+			require.ErrorIs(t, err, medialib.ErrNotUpgrade)
+		})
+	}
 }
 
 func TestGetInfo_UsesFileStemAsTitleParam(t *testing.T) {

--- a/pkg/medialib/radarr/client_test.go
+++ b/pkg/medialib/radarr/client_test.go
@@ -397,52 +397,73 @@ func TestImportByFilePath_NotUpgradeReturnsNotUpgrade(t *testing.T) {
 
 	knownMovie := &radarrlib.Movie{ID: 42, Title: "The Matrix", Year: 1999}
 
+	notUpgradeMsgs := []*starr.StatusMessage{{
+		Title: "The.Matrix.1999.mkv",
+		Messages: []string{
+			"Not a Custom Format upgrade for existing movie file(s). New: [Scene] (90000) do not improve on Existing: [BluRay] (101075)",
+		},
+	}}
+
+	propagatesUnsuccessful := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.Contains(t, err.Error(), "no successful imports")
+	}
+
 	tests := []struct {
-		name       string
-		statusMsgs []*starr.StatusMessage
-		movieByID  *radarrlib.Movie
-		errFunc    require.ErrorAssertionFunc
+		name         string
+		queueRecords []*radarrlib.QueueRecord
+		movieByID    *radarrlib.Movie
+		errFunc      require.ErrorAssertionFunc
 	}{
 		{
-			name: "custom format non-upgrade rejection",
-			statusMsgs: []*starr.StatusMessage{{
-				Title: "The.Matrix.1999.mkv",
-				Messages: []string{
-					"Not a Custom Format upgrade for existing movie file(s). New: [Scene] (90000) do not improve on Existing: [BluRay] (101075)",
-				},
-			}},
+			name:         "custom format non-upgrade rejection",
+			queueRecords: []*radarrlib.QueueRecord{{MovieID: 42, StatusMessages: notUpgradeMsgs}},
 		},
 		{
 			name: "quality non-upgrade rejection",
-			statusMsgs: []*starr.StatusMessage{{
+			queueRecords: []*radarrlib.QueueRecord{{MovieID: 42, StatusMessages: []*starr.StatusMessage{{
 				Title:    "The.Matrix.1999.mkv",
 				Messages: []string{"Not an upgrade for existing movie file(s)"},
-			}},
+			}}}},
+		},
+		{
+			name: "rejection on the attached download",
+			queueRecords: []*radarrlib.QueueRecord{
+				{MovieID: 42, DownloadID: "current", StatusMessages: notUpgradeMsgs},
+			},
 		},
 		{
 			name: "unrelated status message falls through to size post-check",
-			statusMsgs: []*starr.StatusMessage{{
+			queueRecords: []*radarrlib.QueueRecord{{MovieID: 42, StatusMessages: []*starr.StatusMessage{{
 				Title:    "The.Matrix.1999.mkv",
 				Messages: []string{"Unable to parse file"},
-			}},
+			}}}},
 			// Movie has a stored file whose size differs from expectedSize, so the
 			// size post-check cannot recover and the generic error propagates.
 			movieByID: &radarrlib.Movie{ID: 42, HasFile: true, MovieFile: &radarrlib.MovieFile{Size: expectedSize + 1}},
-			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
-				require.Error(t, err, msgAndArgs...)
-				assert.Contains(t, err.Error(), "no successful imports")
+			errFunc:   propagatesUnsuccessful,
+		},
+		{
+			name: "rejection on a different download does not skip the current import",
+			queueRecords: []*radarrlib.QueueRecord{
+				// The pending download the scan attaches to (found first by
+				// findTrackedDownloadID) carries no rejection.
+				{MovieID: 42, DownloadID: "current", TrackedDownloadState: "importPending"},
+				// A stale record for the same movie carries an old not-upgrade
+				// rejection; it must not be mistaken for this import's outcome.
+				{MovieID: 42, DownloadID: "stale", StatusMessages: notUpgradeMsgs},
 			},
+			movieByID: &radarrlib.Movie{ID: 42, HasFile: false},
+			errFunc:   propagatesUnsuccessful,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			srv := newTestServerWithConfig(t, testServerConfig{
-				parseResp: &parseResponse{Movie: knownMovie},
-				movieByID: test.movieByID,
-				queueResp: &radarrlib.Queue{Records: []*radarrlib.QueueRecord{
-					{MovieID: 42, StatusMessages: test.statusMsgs},
-				}},
+				parseResp:            &parseResponse{Movie: knownMovie},
+				movieByID:            test.movieByID,
+				queueResp:            &radarrlib.Queue{Records: test.queueRecords},
 				commandStatuses:      []string{"completed"},
 				commandResult:        "unsuccessful",
 				commandStatusMessage: "Failed to import",

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -195,8 +195,19 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 				return fmt.Errorf("import %q: %w", filePath, medialib.ErrNotFound)
 			}
 
-			// The episode is still in the library, so fall through to the
-			// benign-race size post-check documented on expectedSize above.
+			// The episode is still in the library. If Sonarr rejected the import
+			// because its existing file is already as good or better ("not an
+			// upgrade"), the scan can never succeed — surface ErrNotUpgrade so the
+			// caller treats it as a benign skip rather than burning the retry budget.
+			if c.rejectedAsNotUpgrade(ctx, filePath) {
+				slog.InfoContext(ctx, "sonarr scan reported no imports because the existing episode file is already an equal or better version; skipping import",
+					"file_path", filePath)
+
+				return fmt.Errorf("import %q: %w", filePath, medialib.ErrNotUpgrade)
+			}
+
+			// Otherwise fall through to the benign-race size post-check
+			// documented on expectedSize above.
 			if expectedSize > 0 {
 				if size, ok := c.episodeFileSize(ctx, filePath); !ok {
 					slog.WarnContext(ctx, "sonarr scan reported no imports and episode file lookup failed; cannot recover",
@@ -241,6 +252,51 @@ func (c *Client) episodeFileSize(ctx context.Context, filePath string) (int64, b
 	}
 
 	return files[0].Size, true
+}
+
+// rejectedAsNotUpgrade reports whether the episode identified by filePath has a
+// queue record whose status messages indicate Sonarr refused the import because
+// the existing library file is already as good or better ("not an upgrade" /
+// "not a Custom Format upgrade"). An unidentifiable episode, API errors, and a
+// missing record all return false so the caller falls back to its normal
+// failure handling.
+func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool {
+	episode, err := c.getEpisodeByFilePath(ctx, filePath)
+	if err != nil {
+		return false
+	}
+
+	const pageSize = 100
+
+	for page, fetched := 1, 0; ; page++ {
+		curr, err := c.sonarr.GetQueuePageContext(ctx, &starr.PageReq{PageSize: pageSize, Page: page})
+		if err != nil {
+			return false
+		}
+
+		for _, record := range curr.Records {
+			if record.EpisodeID == 0 || record.EpisodeID != episode.GetID() {
+				continue
+			}
+
+			for _, statusMessage := range record.StatusMessages {
+				if statusMessage == nil {
+					continue
+				}
+
+				if arrcommand.IsNotUpgradeRejection(statusMessage.Messages...) {
+					return true
+				}
+			}
+		}
+
+		fetched += len(curr.Records)
+		if fetched >= curr.TotalRecords || len(curr.Records) == 0 {
+			break
+		}
+	}
+
+	return false
 }
 
 // fetchCommandStatus implements arrcommand.Fetcher. It hits Sonarr's

--- a/pkg/medialib/sonarr/client.go
+++ b/pkg/medialib/sonarr/client.go
@@ -199,7 +199,7 @@ func (c *Client) ImportByFilePath(ctx context.Context, filePath string, expected
 			// because its existing file is already as good or better ("not an
 			// upgrade"), the scan can never succeed — surface ErrNotUpgrade so the
 			// caller treats it as a benign skip rather than burning the retry budget.
-			if c.rejectedAsNotUpgrade(ctx, filePath) {
+			if c.rejectedAsNotUpgrade(ctx, filePath, downloadClientID) {
 				slog.InfoContext(ctx, "sonarr scan reported no imports because the existing episode file is already an equal or better version; skipping import",
 					"file_path", filePath)
 
@@ -260,7 +260,12 @@ func (c *Client) episodeFileSize(ctx context.Context, filePath string) (int64, b
 // "not a Custom Format upgrade"). An unidentifiable episode, API errors, and a
 // missing record all return false so the caller falls back to its normal
 // failure handling.
-func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool {
+//
+// downloadClientID is the tracked download the scan was attached to. When set,
+// only that download's record is inspected so a stale or unrelated record for
+// the same episode cannot turn a retryable failure into a permanent skip; when
+// empty (no tracked download was found), records are matched by episode alone.
+func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath, downloadClientID string) bool {
 	episode, err := c.getEpisodeByFilePath(ctx, filePath)
 	if err != nil {
 		return false
@@ -276,6 +281,17 @@ func (c *Client) rejectedAsNotUpgrade(ctx context.Context, filePath string) bool
 
 		for _, record := range curr.Records {
 			if record.EpisodeID == 0 || record.EpisodeID != episode.GetID() {
+				continue
+			}
+
+			// Skip records that aren't the download the scan was attached to, and
+			// records Sonarr already imported on its own — neither reflects the
+			// outcome of this import attempt.
+			if downloadClientID != "" && record.DownloadID != "" && record.DownloadID != downloadClientID {
+				continue
+			}
+
+			if strings.EqualFold(record.TrackedDownloadState, "imported") {
 				continue
 			}
 

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -609,55 +609,76 @@ func TestImportByFilePath_NotUpgradeReturnsNotUpgrade(t *testing.T) {
 		},
 	}
 
+	notUpgradeMsgs := []*starr.StatusMessage{{
+		Title: "king.of.the.hill.s14e09.mkv",
+		Messages: []string{
+			"Not a Custom Format upgrade for existing episode file(s). New: [Scene] (90000) do not improve on Existing: [DSNP] (101075)",
+		},
+	}}
+
+	propagatesUnsuccessful := func(t require.TestingT, err error, msgAndArgs ...any) {
+		require.Error(t, err, msgAndArgs...)
+		assert.Contains(t, err.Error(), "no successful imports")
+	}
+
 	tests := []struct {
-		name        string
-		statusMsgs  []*starr.StatusMessage
-		episodeByID *sonarrlib.Episode
-		episodeFile *sonarrlib.EpisodeFile
-		errFunc     require.ErrorAssertionFunc
+		name         string
+		queueRecords []*sonarrlib.QueueRecord
+		episodeByID  *sonarrlib.Episode
+		episodeFile  *sonarrlib.EpisodeFile
+		errFunc      require.ErrorAssertionFunc
 	}{
 		{
-			name: "custom format non-upgrade rejection",
-			statusMsgs: []*starr.StatusMessage{{
-				Title: "king.of.the.hill.s14e09.mkv",
-				Messages: []string{
-					"Not a Custom Format upgrade for existing episode file(s). New: [Scene] (90000) do not improve on Existing: [DSNP] (101075)",
-				},
-			}},
+			name:         "custom format non-upgrade rejection",
+			queueRecords: []*sonarrlib.QueueRecord{{EpisodeID: 200, StatusMessages: notUpgradeMsgs}},
 		},
 		{
 			name: "quality non-upgrade rejection",
-			statusMsgs: []*starr.StatusMessage{{
+			queueRecords: []*sonarrlib.QueueRecord{{EpisodeID: 200, StatusMessages: []*starr.StatusMessage{{
 				Title:    "king.of.the.hill.s14e09.mkv",
 				Messages: []string{"Not an upgrade for existing episode file(s)"},
-			}},
+			}}}},
+		},
+		{
+			name: "rejection on the attached download",
+			queueRecords: []*sonarrlib.QueueRecord{
+				{EpisodeID: 200, DownloadID: "current", StatusMessages: notUpgradeMsgs},
+			},
 		},
 		{
 			name: "unrelated status message falls through to size post-check",
-			statusMsgs: []*starr.StatusMessage{{
+			queueRecords: []*sonarrlib.QueueRecord{{EpisodeID: 200, StatusMessages: []*starr.StatusMessage{{
 				Title:    "king.of.the.hill.s14e09.mkv",
 				Messages: []string{"Unable to parse file"},
-			}},
+			}}}},
 			// Episode has a stored file whose size differs from expectedSize, so
 			// the size post-check cannot recover and the generic error propagates.
 			episodeByID: &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
 			episodeFile: &sonarrlib.EpisodeFile{ID: 7, Size: expectedSize + 1},
-			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
-				require.Error(t, err, msgAndArgs...)
-				assert.Contains(t, err.Error(), "no successful imports")
+			errFunc:     propagatesUnsuccessful,
+		},
+		{
+			name: "rejection on a different download does not skip the current import",
+			queueRecords: []*sonarrlib.QueueRecord{
+				// The pending download the scan attaches to (found first by
+				// findTrackedDownloadID) carries no rejection.
+				{EpisodeID: 200, DownloadID: "current", TrackedDownloadState: "importPending"},
+				// A stale record for the same episode carries an old not-upgrade
+				// rejection; it must not be mistaken for this import's outcome.
+				{EpisodeID: 200, DownloadID: "stale", StatusMessages: notUpgradeMsgs},
 			},
+			episodeByID: &sonarrlib.Episode{ID: 200, HasFile: false},
+			errFunc:     propagatesUnsuccessful,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
-				parseResp:   parseResp,
-				episodeByID: test.episodeByID,
-				episodeFile: test.episodeFile,
-				queueResp: &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{
-					{EpisodeID: 200, StatusMessages: test.statusMsgs},
-				}},
+				parseResp:            parseResp,
+				episodeByID:          test.episodeByID,
+				episodeFile:          test.episodeFile,
+				queueResp:            &sonarrlib.Queue{Records: test.queueRecords},
 				commandStatuses:      []string{"completed"},
 				commandResult:        "unsuccessful",
 				commandStatusMessage: "Failed to import",

--- a/pkg/medialib/sonarr/client_test.go
+++ b/pkg/medialib/sonarr/client_test.go
@@ -586,6 +586,100 @@ func TestImportByFilePath_NotInLibraryReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, medialib.ErrNotFound)
 }
 
+// TestImportByFilePath_NotUpgradeReturnsNotUpgrade verifies that when a scan
+// finishes with no successful imports and the episode's queue record reports
+// the release was rejected because the existing library file is already as good
+// or better, ImportByFilePath returns medialib.ErrNotUpgrade rather than the
+// generic "no successful imports" error. The caller relies on this sentinel to
+// skip the import as a benign no-op instead of retrying for the full retry
+// budget. The rejection is checked before the size post-check, so a stored
+// file whose size differs from expectedSize must not mask it.
+func TestImportByFilePath_NotUpgradeReturnsNotUpgrade(t *testing.T) {
+	const expectedSize int64 = 12345
+
+	parseResp := &sonarrlib.ParseOutput{
+		Title: "Breaking Bad",
+		ParsedEpisodeInfo: &sonarrlib.ParsedEpisodeInfo{
+			SeriesTitle:    "Breaking Bad",
+			SeasonNumber:   1,
+			EpisodeNumbers: []int{1},
+		},
+		Episodes: []*sonarrlib.Episode{
+			{ID: 200, SeriesID: 10, SeasonNumber: 1, EpisodeNumber: 1},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		statusMsgs  []*starr.StatusMessage
+		episodeByID *sonarrlib.Episode
+		episodeFile *sonarrlib.EpisodeFile
+		errFunc     require.ErrorAssertionFunc
+	}{
+		{
+			name: "custom format non-upgrade rejection",
+			statusMsgs: []*starr.StatusMessage{{
+				Title: "king.of.the.hill.s14e09.mkv",
+				Messages: []string{
+					"Not a Custom Format upgrade for existing episode file(s). New: [Scene] (90000) do not improve on Existing: [DSNP] (101075)",
+				},
+			}},
+		},
+		{
+			name: "quality non-upgrade rejection",
+			statusMsgs: []*starr.StatusMessage{{
+				Title:    "king.of.the.hill.s14e09.mkv",
+				Messages: []string{"Not an upgrade for existing episode file(s)"},
+			}},
+		},
+		{
+			name: "unrelated status message falls through to size post-check",
+			statusMsgs: []*starr.StatusMessage{{
+				Title:    "king.of.the.hill.s14e09.mkv",
+				Messages: []string{"Unable to parse file"},
+			}},
+			// Episode has a stored file whose size differs from expectedSize, so
+			// the size post-check cannot recover and the generic error propagates.
+			episodeByID: &sonarrlib.Episode{ID: 200, HasFile: true, EpisodeFileID: 7},
+			episodeFile: &sonarrlib.EpisodeFile{ID: 7, Size: expectedSize + 1},
+			errFunc: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				assert.Contains(t, err.Error(), "no successful imports")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := newSonarrTestServerWithConfig(t, sonarrTestServerConfig{
+				parseResp:   parseResp,
+				episodeByID: test.episodeByID,
+				episodeFile: test.episodeFile,
+				queueResp: &sonarrlib.Queue{Records: []*sonarrlib.QueueRecord{
+					{EpisodeID: 200, StatusMessages: test.statusMsgs},
+				}},
+				commandStatuses:      []string{"completed"},
+				commandResult:        "unsuccessful",
+				commandStatusMessage: "Failed to import",
+			})
+			t.Cleanup(srv.Close)
+
+			client := sonarr.New(sonarr.Config{URL: srv.URL, APIKey: "test-key", CommandPollInterval: fastPollInterval})
+
+			err := client.ImportByFilePath(t.Context(), "/tv/Breaking.Bad.S01E01.mkv", expectedSize)
+
+			if test.errFunc != nil {
+				test.errFunc(t, err)
+				assert.NotErrorIs(t, err, medialib.ErrNotUpgrade)
+
+				return
+			}
+
+			require.ErrorIs(t, err, medialib.ErrNotUpgrade)
+		})
+	}
+}
+
 func TestGetInfo(t *testing.T) {
 	knownParseOutput := &sonarrlib.ParseOutput{
 		Title: "Breaking Bad",

--- a/workflows/media/activities.go
+++ b/workflows/media/activities.go
@@ -359,11 +359,13 @@ func emitTranscodeMetrics(ctx context.Context, input MediaInput, probe ProbeOutp
 }
 
 // NotifyOutput is the result of the Notify activity. ImportSkipped is true when
-// the library import was deliberately skipped because the media item is no
-// longer present in the arr library (the movie/series was removed or is no
-// longer monitored). The workflow forwards it to Cleanup so the orphaned
-// transcoded output file — which a successful arr import would normally consume
-// by moving it into the library — is removed.
+// the library import was deliberately skipped because the import can never
+// succeed: either the media item is no longer present in the arr library (the
+// movie/series was removed or is no longer monitored), or the library already
+// holds an equal or better file so the release was rejected as "not an upgrade".
+// The workflow forwards it to Cleanup so the orphaned transcoded output file —
+// which a successful arr import would normally consume by moving it into the
+// library — is removed.
 type NotifyOutput struct {
 	ImportSkipped bool `json:"import_skipped,omitempty"`
 }
@@ -375,11 +377,12 @@ type NotifyOutput struct {
 // the output tree) are returned as non-retryable so Temporal does not burn the
 // retry budget on inputs that cannot recover.
 //
-// When the arr service reports the media item is no longer in its library, the
-// import can never succeed. That is an expected, benign outcome rather than a
-// failure: Notify records it, returns NotifyOutput{ImportSkipped: true} with a
-// nil error so the workflow proceeds to Cleanup (which removes the orphaned
-// output file), and avoids both the retry budget and the failure webhook.
+// When the arr service reports the media item is no longer in its library, or
+// rejects the release because its existing file is already an equal or better
+// version, the import can never succeed. That is an expected, benign outcome
+// rather than a failure: Notify records it, returns NotifyOutput{ImportSkipped:
+// true} with a nil error so the workflow proceeds to Cleanup (which removes the
+// orphaned output file), and avoids both the retry budget and the failure webhook.
 func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode TranscodeOutput) (NotifyOutput, error) {
 	start := time.Now()
 
@@ -426,6 +429,18 @@ func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode Tra
 			return NotifyOutput{ImportSkipped: true}, nil
 		}
 
+		// The arr service rejected the import because its existing file is already
+		// an equal or better version. Like the not-in-library case, the import can
+		// never succeed, so skip it rather than retrying or firing the webhook.
+		if errors.Is(err, medialib.ErrNotUpgrade) {
+			activity.GetLogger(ctx).Info("library already has an equal or better file; skipping import",
+				"file", input.FilePath, "import_path", importPath)
+			activity.GetMetricsHandler(ctx).WithTags(baseTags(input)).Counter(metricImportSkippedNotUpgrade).Inc(1)
+			logStepResult(ctx, "notify", input.FilePath, start, nil)
+
+			return NotifyOutput{ImportSkipped: true}, nil
+		}
+
 		wrappedErr := fmt.Errorf("notify library: %w", err)
 		logStepResult(ctx, "notify", input.FilePath, start, wrappedErr)
 
@@ -447,8 +462,9 @@ func (a *Activities) Notify(ctx context.Context, input MediaInput, transcode Tra
 // source has already been removed by Probe (RunCleanup is a near-no-op),
 // transcode.DestFilePath is empty, and output pruning is skipped.
 // When notify.ImportSkipped is set (the media item is no longer in the arr
-// library), the arr service will not move the transcoded file into its
-// library, so the orphaned output file is removed here before pruning.
+// library, or the library already holds an equal or better file), the arr
+// service will not move the transcoded file into its library, so the orphaned
+// output file is removed here before pruning.
 func (a *Activities) Cleanup(ctx context.Context, input MediaInput, transcode TranscodeOutput, notify NotifyOutput) error {
 	start := time.Now()
 

--- a/workflows/media/activities_test.go
+++ b/workflows/media/activities_test.go
@@ -112,6 +112,26 @@ func TestNotify_NotInLibrarySkipsWithoutError(t *testing.T) {
 	assert.True(t, got.ImportSkipped, "Notify should signal the import was skipped")
 }
 
+// TestNotify_NotUpgradeSkipsWithoutError verifies that when the library rejects
+// the import because its existing file is already an equal or better version
+// (medialib.ErrNotUpgrade), Notify treats it as a benign skip: it returns no
+// error (so the workflow does not retry or fire the failure webhook) and signals
+// ImportSkipped so Cleanup removes the orphaned output file.
+func TestNotify_NotUpgradeSkipsWithoutError(t *testing.T) {
+	radarr := &stubLibraryClient{err: fmt.Errorf("notify: %w", medialib.ErrNotUpgrade)}
+	a, env := newActivityEnv(t, MediaWorkflowConfig{}, radarr, &stubLibraryClient{}, &webhook.Client{}, nil)
+
+	val, err := env.ExecuteActivity(a.Notify,
+		MediaInput{FilePath: "/in/movie.mkv", MediaType: medialib.MovieType, OutputPath: "/out"},
+		TranscodeOutput{DestFilePath: "/out/movie.mkv"},
+	)
+	require.NoError(t, err, "an existing equal-or-better library file is a benign skip, not a failure")
+
+	var got NotifyOutput
+	require.NoError(t, val.Get(&got))
+	assert.True(t, got.ImportSkipped, "Notify should signal the import was skipped")
+}
+
 func TestCleanup_DeletesSource(t *testing.T) {
 	srcDir := t.TempDir()
 	srcPath := filepath.Join(srcDir, "movie.mkv")

--- a/workflows/media/metrics.go
+++ b/workflows/media/metrics.go
@@ -35,13 +35,17 @@ const (
 	// metricImportSkippedNotInLibrary counts files whose library import was
 	// skipped because the media item is no longer in the arr library.
 	metricImportSkippedNotInLibrary = "media_workflow_import_skipped_not_in_library"
-	metricMetricsErrors             = "media_workflow_metrics_errors"
-	metricAudioTrackCount           = "media_workflow_audio_track_count"
-	metricSubtitleTrackCount        = "media_workflow_subtitle_track_count"
-	metricSourceDurationSeconds     = "media_workflow_source_duration_seconds"
-	metricSourceFileSizeBytes       = "media_workflow_source_file_size_bytes"
-	metricDestFileSizeBytes         = "media_workflow_destination_file_size_bytes"
-	metricTranscodeDurationSecs     = "media_workflow_transcode_duration_seconds"
+	// metricImportSkippedNotUpgrade counts files whose library import was skipped
+	// because the arr library already holds an equal or better file (the release
+	// was rejected as "not an upgrade").
+	metricImportSkippedNotUpgrade = "media_workflow_import_skipped_not_upgrade"
+	metricMetricsErrors           = "media_workflow_metrics_errors"
+	metricAudioTrackCount         = "media_workflow_audio_track_count"
+	metricSubtitleTrackCount      = "media_workflow_subtitle_track_count"
+	metricSourceDurationSeconds   = "media_workflow_source_duration_seconds"
+	metricSourceFileSizeBytes     = "media_workflow_source_file_size_bytes"
+	metricDestFileSizeBytes       = "media_workflow_destination_file_size_bytes"
+	metricTranscodeDurationSecs   = "media_workflow_transcode_duration_seconds"
 )
 
 // baseTags returns the tag map carried by every media-workflow metric


### PR DESCRIPTION
## Problem

The `Notify` activity fails the entire media workflow — burning the full retry budget and firing the failure webhook — when Sonarr/Radarr permanently refuse an import because the library already holds an equal or better file (the "not an upgrade" / "not a Custom Format upgrade" rejection). This is the same class of bug as #239, but with a different, also-permanent trigger.

Observed in production on a Sonarr show import: the transcode completed, the file existed, and the Sonarr queue showed `Release rejected: Not a Custom Format upgrade for existing episode file(s). New: [...Scene] (90000) do not improve on Existing: [...DSNP...] (101075)`, yet the workflow failed with `completed but reported no successful imports: Failed to import`.

## Root cause

In `ImportByFilePath` (both clients), an unsuccessful scan whose item is still in the library falls through to the size post-check. The arr service's stored file is the pre-existing better copy, so its size differs from the local transcode, the check cannot recover, and the error is returned as retryable. The actual rejection reason lives only in the queue record's `statusMessages`, which the code never inspected.

## Fix

Detect the rejection and treat it as a benign skip, mirroring the not-in-library handling from #239:

- `arrcommand.IsNotUpgradeRejection` — shared, case-insensitive matcher on `"upgrade for existing"`, covering both the quality and custom-format rejection variants without colliding with transient errors.
- `medialib.ErrNotUpgrade` — new sentinel.
- Sonarr + Radarr clients — on `ErrNoSuccessfulImports`, after the existing not-in-library check, scan the item's queue record status messages and return `ErrNotUpgrade` when it is a non-upgrade rejection. Checked **before** the size post-check so a differing stored-file size cannot mask it.
- `Notify` activity — new branch on `ErrNotUpgrade` returns `ImportSkipped: true` with a nil error (no retry, no failure webhook); Cleanup removes the orphaned transcode and source.
- New metric `media_workflow_import_skipped_not_upgrade_total`, documented in `docs/metrics.md`.

## Tests

- `arrcommand.IsNotUpgradeRejection`: quality / custom-format / case-insensitive / multi-message / negative / empty cases.
- Sonarr + Radarr `ImportByFilePath`: non-upgrade rejection returns `ErrNotUpgrade` and is detected ahead of the size post-check; unrelated status messages still propagate the generic error.
- `Notify`: `ErrNotUpgrade` yields a nil error and `ImportSkipped`.

`make fmt vet lint` clean (0 issues); full `go test ./...` green.

## Acceptance criteria

- [x] An unsuccessful scan with a not-an-upgrade queue rejection returns a distinct sentinel rather than the generic "no successful imports" error.
- [x] `Notify` treats that sentinel as a benign skip: no error, `ImportSkipped` set, no retry, no failure webhook.
- [x] The rejection is detected before the size post-check, so a differing stored-file size does not mask it.
- [x] An unsuccessful scan with an unrelated status message keeps the existing size post-check / retry behavior.

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
