### PR TITLE
fix(ffmpeg): repair pts < dts on the copy path

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -180,11 +180,13 @@ func (css *copyStreamState) repairNonMonotonicDts(pkt *astiav.Packet) {
 	}
 
 	if css.clampedCount == 0 {
-		slog.Warn("ffmpeg: clamping non-monotonic DTS",
+		slog.Warn("ffmpeg: clamping packet timestamps",
 			slog.Int("stream", css.outStream.Index()),
 			slog.Int64("packet_dts", pkt.Dts()),
 			slog.Int64("previous_dts", css.lastWrittenDts),
 			slog.Int64("corrected_dts", newDts),
+			slog.Int64("packet_pts", pkt.Pts()),
+			slog.Int64("corrected_pts", newPts),
 		)
 	}
 
@@ -205,7 +207,7 @@ func (css *copyStreamState) logClampSummary() {
 		return
 	}
 
-	slog.Warn("ffmpeg: clamped non-monotonic DTS on stream",
+	slog.Warn("ffmpeg: clamped packet timestamps on stream",
 		slog.Int("stream", css.outStream.Index()),
 		slog.Int64("total_clamps", css.clampedCount),
 	)

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -163,14 +163,16 @@ func (css *copyStreamState) receiveAndWritePackets(encCtx *astiav.CodecContext, 
 	}
 }
 
-// repairNonMonotonicDts rewrites pkt's DTS (and PTS, if needed to keep
-// DTS <= PTS) so that it is strictly greater than the last DTS written to the
-// output stream. Mirrors the clamp in fftools/ffmpeg_mux.c::mux_fixup_ts that
-// lets the FFmpeg CLI tolerate non-monotonic DTS — both from encoders that
-// emit out-of-order DTS (notably hevc_qsv on VFR sources) and from copy-path
-// sources whose authored timestamps regress. No-op on the first packet, on
-// packets without a DTS value, or when the incoming DTS is already
-// monotonic — so well-formed sources produce bit-identical output.
+// repairNonMonotonicDts rewrites pkt's DTS so that it is strictly greater than
+// the last DTS written to the output stream, and rewrites pkt's PTS so that it
+// is never behind its own DTS. Mirrors the clamp in
+// fftools/ffmpeg_mux.c::mux_fixup_ts that lets the FFmpeg CLI tolerate both
+// non-monotonic DTS — from encoders that emit out-of-order DTS (notably
+// hevc_qsv on VFR sources) and from copy-path sources whose authored timestamps
+// regress — and packets whose authored PTS sits behind their DTS, which
+// libavformat otherwise rejects with EINVAL ("Invalid argument"). No-op when
+// the incoming DTS is already monotonic and its PTS is not behind it — so
+// well-formed sources produce bit-identical output.
 func (css *copyStreamState) repairNonMonotonicDts(pkt *astiav.Packet) {
 	newDts, newPts, clamped := monotonicDtsClamp(css.lastWrittenDts, pkt.Dts(), pkt.Pts())
 	if !clamped {
@@ -210,25 +212,37 @@ func (css *copyStreamState) logClampSummary() {
 }
 
 // monotonicDtsClamp computes the DTS and PTS for an outgoing packet so that
-// its DTS is strictly greater than the previous packet's DTS on the same
-// stream. clamped is true when the encoder's DTS was non-monotonic and had to
-// be rewritten. Pure function — no I/O, no logging — so it can be unit-tested
-// without a hardware encoder or a live FormatContext. Inputs and outputs are
-// in the muxer's stream timebase. AV_NOPTS_VALUE sentinels short-circuit the
-// clamp (first-packet case and packets without DTS pass through unchanged).
+// (1) its DTS is strictly greater than the previous packet's DTS on the same
+// stream and (2) its PTS is not behind its own DTS. clamped is true when either
+// invariant had to be repaired. Pure function — no I/O, no logging — so it can
+// be unit-tested without a hardware encoder or a live FormatContext. Inputs and
+// outputs are in the muxer's stream timebase. AV_NOPTS_VALUE sentinels
+// short-circuit each repair (first-packet case and packets without DTS pass the
+// monotonicity check unchanged; packets without PTS skip the pts >= dts check).
+//
+// The pts >= dts repair matters independently of the DTS clamp: libavformat
+// rejects any packet with pts < dts (EINVAL, surfaced as "Invalid argument"),
+// and a source stream can carry such packets with an already-monotonic DTS — in
+// which case the monotonicity branch leaves the packet untouched and only this
+// second repair keeps the muxer happy. The ffmpeg CLI performs the same clamp
+// at its stream-output layer, which is why the CLI tolerates these sources.
+// Well-formed sources (pts >= dts, monotonic DTS) are returned unchanged, so
+// they still produce bit-identical output.
 func monotonicDtsClamp(lastWrittenDts, encDts, encPts int64) (newDts, newPts int64, clamped bool) {
-	if lastWrittenDts == astiav.NoPtsValue || encDts == astiav.NoPtsValue || encDts > lastWrittenDts {
-		return encDts, encPts, false
-	}
-
-	newDts = lastWrittenDts + 1
+	newDts = encDts
 	newPts = encPts
 
-	if encPts != astiav.NoPtsValue && encPts < newDts {
-		newPts = newDts
+	if lastWrittenDts != astiav.NoPtsValue && encDts != astiav.NoPtsValue && encDts <= lastWrittenDts {
+		newDts = lastWrittenDts + 1
+		clamped = true
 	}
 
-	return newDts, newPts, true
+	if newDts != astiav.NoPtsValue && newPts != astiav.NoPtsValue && newPts < newDts {
+		newPts = newDts
+		clamped = true
+	}
+
+	return newDts, newPts, clamped
 }
 
 // sendProgress emits a non-blocking progress update on ch.

--- a/pkg/ffmpeg/stream_test.go
+++ b/pkg/ffmpeg/stream_test.go
@@ -99,6 +99,33 @@ func TestMonotonicDtsClamp(t *testing.T) {
 			wantPts:        astiav.NoPtsValue,
 			wantClamped:    true,
 		},
+		{
+			name:           "monotonic DTS but PTS behind DTS — PTS clamped up to DTS",
+			lastWrittenDts: 100,
+			encDts:         150,
+			encPts:         120,
+			wantDts:        150,
+			wantPts:        150,
+			wantClamped:    true,
+		},
+		{
+			name:           "first packet with PTS behind DTS — PTS clamped up to DTS",
+			lastWrittenDts: astiav.NoPtsValue,
+			encDts:         150,
+			encPts:         120,
+			wantDts:        150,
+			wantPts:        150,
+			wantClamped:    true,
+		},
+		{
+			name:           "monotonic DTS and PTS ahead — pass through unchanged",
+			lastWrittenDts: 100,
+			encDts:         150,
+			encPts:         300,
+			wantDts:        150,
+			wantPts:        300,
+			wantClamped:    false,
+		},
 	}
 
 	for _, test := range tests {
@@ -150,7 +177,10 @@ func TestMonotonicDtsClamp_FMABFailureSequence(t *testing.T) {
 		lastWritten = newDts
 	}
 
-	assert.Equal(t, 3, clampedCount, "clamp must fire on every regressing packet")
+	// Three packets regress the DTS, and one earlier packet ({dts: 400113,
+	// pts: 400071}) carries a PTS behind its own (already-monotonic) DTS — the
+	// clamp repairs that too so the muxer does not reject it with EINVAL.
+	assert.Equal(t, 4, clampedCount, "clamp must fire on every regressing or pts-behind-dts packet")
 
 	for i := 1; i < len(muxedDts); i++ {
 		assert.Greater(t, muxedDts[i], muxedDts[i-1],
@@ -277,4 +307,111 @@ func TestCopyStreamState_processPacket_RepairsNonMonotonicSourceDts(t *testing.T
 		"copyStreamState.lastWrittenDts must advance strictly past the previous packet's DTS after the repair")
 	assert.Equal(t, int64(2), css.clampedCount,
 		"clampedCount must accumulate across every repaired packet so the summary log reflects the true total")
+}
+
+// TestCopyStreamState_processPacket_RepairsPtsBehindDts verifies that the
+// pure-copy packet path repairs a packet whose PTS is behind its own DTS
+// before submitting it to the muxer, even when the DTS is monotonic (so the
+// non-monotonic-DTS clamp does not fire). libavformat rejects a packet with
+// pts < dts with EINVAL ("Invalid argument") in av_interleaved_write_frame.
+//
+// The motivating production failure is a copied HEVC video stream (stream 0)
+// of a 2160p WEB-DL whose authored packet timestamps include pts < dts. The
+// ffmpeg CLI tolerates this by clamping pts up to dts at its stream-output
+// layer; our in-process transcoder reaches the muxer directly, so the activity
+// failed with "ffmpeg: writing remuxed packet for stream 0: Invalid argument".
+// The DTS here is strictly increasing, so the existing non-monotonic-DTS clamp
+// leaves the packet untouched — only the dedicated pts >= dts repair prevents
+// the rejection.
+func TestCopyStreamState_processPacket_RepairsPtsBehindDts(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "out.mkv")
+
+	inputFmt := astiav.AllocFormatContext()
+	require.NotNil(t, inputFmt)
+
+	defer inputFmt.Free()
+
+	require.NoError(t, inputFmt.OpenInput("testdata/video_with_subrip_subtitle.mkv", nil, nil))
+	defer inputFmt.CloseInput()
+
+	require.NoError(t, inputFmt.FindStreamInfo(nil))
+
+	var inAudioStream *astiav.Stream
+
+	for _, stream := range inputFmt.Streams() {
+		if stream.CodecParameters().MediaType() == astiav.MediaTypeAudio {
+			inAudioStream = stream
+			break
+		}
+	}
+
+	require.NotNil(t, inAudioStream, "test fixture must carry an audio stream")
+
+	outputFmt, err := astiav.AllocOutputFormatContext(nil, "matroska", outputPath)
+	require.NoError(t, err)
+
+	defer outputFmt.Free()
+
+	outStream := outputFmt.NewStream(nil)
+	require.NotNil(t, outStream)
+	require.NoError(t, inAudioStream.CodecParameters().Copy(outStream.CodecParameters()))
+	outStream.CodecParameters().SetCodecTag(0)
+	outStream.SetTimeBase(inAudioStream.TimeBase())
+
+	ioCtx, err := astiav.OpenIOContext(outputPath, astiav.NewIOContextFlags(astiav.IOContextFlagWrite), nil, nil)
+	require.NoError(t, err)
+
+	defer func() { _ = ioCtx.Close() }()
+
+	outputFmt.SetPb(ioCtx)
+
+	require.NoError(t, outputFmt.WriteHeader(nil))
+
+	css := &copyStreamState{inStream: inAudioStream}
+	css.setOutputStream(outStream)
+
+	pkt := astiav.AllocPacket()
+	defer pkt.Free()
+
+	readAudioPacket := func() {
+		t.Helper()
+
+		for {
+			err := inputFmt.ReadFrame(pkt)
+			require.NoError(t, err, "input must supply enough audio packets for the test")
+
+			if pkt.StreamIndex() == inAudioStream.Index() {
+				return
+			}
+
+			pkt.Unref()
+		}
+	}
+
+	// First packet: well-formed (pts == dts), establishes the baseline DTS.
+	readAudioPacket()
+	pkt.SetDts(100)
+	pkt.SetPts(100)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"first packet (pts == dts) must be accepted by the muxer")
+
+	pkt.Unref()
+
+	// Second packet: DTS is strictly monotonic (150 > 100) so the
+	// non-monotonic-DTS clamp does not fire, but PTS (120) is behind DTS (150).
+	// Without the pts >= dts repair the matroska muxer rejects this with EINVAL.
+	readAudioPacket()
+	pkt.SetDts(150)
+	pkt.SetPts(120)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"a packet whose PTS is behind its monotonic DTS must be repaired so the matroska muxer accepts it")
+
+	pkt.Unref()
+
+	assert.Equal(t, int64(1), css.clampedCount,
+		"the pts < dts repair must be recorded as a clamp")
+
+	require.NoError(t, outputFmt.WriteTrailer())
 }


### PR DESCRIPTION
## Problem

A production transcode of a 2160p HEVC WEB-DL failed during remux with:

```
transcode: ffmpeg: writing remuxed packet for stream 0: Invalid argument
```

The source is HEVC in matroska, so `SelectVideoCodec` returns `CodecCopy` and the video (stream 0) is copied straight to the matroska muxer via `WriteInterleavedFrame`. libavformat rejects any packet with `pts < dts` with `AVERROR(EINVAL)`, which go-astiav surfaces as the bare errno string `Invalid argument`. FFmpeg's own stderr for the repro shows the precise cause:

```
pts (120) < dts (150) in stream 0
```

## Root cause

The copy path already clamped non-monotonic DTS (`monotonicDtsClamp`, added across #214/#232/#234), but it only corrected `pts < dts` as a side effect of bumping a regressing DTS. When the DTS was already monotonic — the common case, including the first packet — the function early-returned and passed the packet through untouched. A source packet authored with `pts < dts` (and a fine, increasing DTS) therefore reached the muxer and was rejected.

The ffmpeg CLI tolerates these sources because it clamps `pts` up to `dts` at its stream-output layer; our in-process transcoder reaches the muxer directly.

## Fix

`monotonicDtsClamp` now enforces two invariants on every copy/encode packet — strictly-monotonic DTS **and** `pts >= dts` — the second independent of whether the DTS needed bumping. Well-formed sources (monotonic DTS, `pts >= dts`) are returned unchanged, so output stays bit-identical.

## Tests

- `TestCopyStreamState_processPacket_RepairsPtsBehindDts` — drives the real matroska muxer through the copy path with a monotonic-DTS / `pts < dts` packet. Fails with the verbatim production error on the old code; passes now.
- Three new cases in `TestMonotonicDtsClamp` for the pure-function behavior (monotonic DTS with PTS behind, first-packet PTS behind, and the unchanged pass-through).
- `TestMonotonicDtsClamp_FMABFailureSequence`: its data already contained a latent `pts < dts` packet (`{dts: 400113, pts: 400071}`) that the old code would have leaked to the muxer — the expected clamp count goes 3 to 4 now that it is correctly repaired.

`pkg/ffmpeg` suite, `go vet`, and `golangci-lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
