### PR TITLE
fix(ffmpeg): synthesize a monotonic DTS for copy packets with no DTS

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -214,27 +214,54 @@ func (css *copyStreamState) logClampSummary() {
 }
 
 // monotonicDtsClamp computes the DTS and PTS for an outgoing packet so that
-// (1) its DTS is strictly greater than the previous packet's DTS on the same
-// stream and (2) its PTS is not behind its own DTS. clamped is true when either
-// invariant had to be repaired. Pure function — no I/O, no logging — so it can
-// be unit-tested without a hardware encoder or a live FormatContext. Inputs and
-// outputs are in the muxer's stream timebase. AV_NOPTS_VALUE sentinels
-// short-circuit each repair (first-packet case and packets without DTS pass the
-// monotonicity check unchanged; packets without PTS skip the pts >= dts check).
+// (1) it carries a DTS at all, (2) that DTS is strictly greater than the
+// previous packet's DTS on the same stream, and (3) its PTS is not behind its
+// own DTS. clamped is true when any invariant had to be repaired. Pure
+// function — no I/O, no logging — so it can be unit-tested without a hardware
+// encoder or a live FormatContext. Inputs and outputs are in the muxer's stream
+// timebase.
 //
-// The pts >= dts repair matters independently of the DTS clamp: libavformat
-// rejects any packet with pts < dts (EINVAL, surfaced as "Invalid argument"),
-// and a source stream can carry such packets with an already-monotonic DTS — in
-// which case the monotonicity branch leaves the packet untouched and only this
-// second repair keeps the muxer happy. The ffmpeg CLI performs the same clamp
-// at its stream-output layer, which is why the CLI tolerates these sources.
-// Well-formed sources (pts >= dts, monotonic DTS) are returned unchanged, so
+// Three repairs, each independently necessary for the copy path to survive
+// real-world sources, all mirroring clamps the FFmpeg CLI performs at its
+// stream-output layer (which is why the CLI tolerates these sources):
+//
+//   - Missing DTS: a source packet can carry no DTS at all — seen on the leading
+//     reordered frames of some WEB-DL HEVC streams, where the demuxer cannot yet
+//     compute a decode time. Forwarding AV_NOPTS_VALUE to the muxer makes
+//     libavformat derive a DTS from the PTS, which on reordered B-frames runs
+//     backwards and is rejected ("non monotonically increasing dts"). We instead
+//     synthesize a monotonic DTS just past the previous one — mirroring the CLI's
+//     stream-copy path (of_streamcopy), which fills a running DTS estimate when
+//     the source DTS is absent. The first packet, having no prior anchor, falls
+//     back to its own PTS.
+//   - Non-monotonic DTS: an encoder (notably hevc_qsv on VFR sources) or a
+//     copy-path source can emit a DTS that regresses below the previous one;
+//     bump it just past.
+//   - PTS behind DTS: libavformat rejects any packet with pts < dts (EINVAL,
+//     surfaced as "Invalid argument"); a source can carry such packets with an
+//     already-monotonic DTS, so this repair stands on its own.
+//
+// matroska stores PTS as the block timecode and does not persist DTS, so the
+// synthesized/bumped DTS values are invisible in the output. Well-formed sources
+// (every packet has a DTS, DTS monotonic, pts >= dts) are returned unchanged, so
 // they still produce bit-identical output.
 func monotonicDtsClamp(lastWrittenDts, encDts, encPts int64) (newDts, newPts int64, clamped bool) {
 	newDts = encDts
 	newPts = encPts
 
-	if lastWrittenDts != astiav.NoPtsValue && encDts != astiav.NoPtsValue && encDts <= lastWrittenDts {
+	switch {
+	case encDts == astiav.NoPtsValue:
+		// Synthesize a DTS so the muxer never sees AV_NOPTS_VALUE. Advance past
+		// the previous packet when there is one; otherwise anchor to the PTS.
+		switch {
+		case lastWrittenDts != astiav.NoPtsValue:
+			newDts = lastWrittenDts + 1
+			clamped = true
+		case encPts != astiav.NoPtsValue:
+			newDts = encPts
+			clamped = true
+		}
+	case lastWrittenDts != astiav.NoPtsValue && encDts <= lastWrittenDts:
 		newDts = lastWrittenDts + 1
 		clamped = true
 	}

--- a/pkg/ffmpeg/stream_test.go
+++ b/pkg/ffmpeg/stream_test.go
@@ -82,12 +82,39 @@ func TestMonotonicDtsClamp(t *testing.T) {
 			wantClamped:    true,
 		},
 		{
-			name:           "packet has no DTS — pass through unchanged",
+			name:           "packet has no DTS with a previous DTS — synthesize one past the previous",
 			lastWrittenDts: 100,
 			encDts:         astiav.NoPtsValue,
 			encPts:         200,
-			wantDts:        astiav.NoPtsValue,
+			wantDts:        101,
 			wantPts:        200,
+			wantClamped:    true,
+		},
+		{
+			name:           "first packet has no DTS — anchor synthesized DTS to its PTS",
+			lastWrittenDts: astiav.NoPtsValue,
+			encDts:         astiav.NoPtsValue,
+			encPts:         200,
+			wantDts:        200,
+			wantPts:        200,
+			wantClamped:    true,
+		},
+		{
+			name:           "synthesized DTS past previous lands ahead of an earlier PTS — PTS clamped up",
+			lastWrittenDts: 100,
+			encDts:         astiav.NoPtsValue,
+			encPts:         83,
+			wantDts:        101,
+			wantPts:        101,
+			wantClamped:    true,
+		},
+		{
+			name:           "first packet has neither DTS nor PTS — nothing to synthesize from",
+			lastWrittenDts: astiav.NoPtsValue,
+			encDts:         astiav.NoPtsValue,
+			encPts:         astiav.NoPtsValue,
+			wantDts:        astiav.NoPtsValue,
+			wantPts:        astiav.NoPtsValue,
 			wantClamped:    false,
 		},
 		{
@@ -181,6 +208,52 @@ func TestMonotonicDtsClamp_FMABFailureSequence(t *testing.T) {
 	// pts: 400071}) carries a PTS behind its own (already-monotonic) DTS — the
 	// clamp repairs that too so the muxer does not reject it with EINVAL.
 	assert.Equal(t, 4, clampedCount, "clamp must fire on every regressing or pts-behind-dts packet")
+
+	for i := 1; i < len(muxedDts); i++ {
+		assert.Greater(t, muxedDts[i], muxedDts[i-1],
+			"muxed DTS must be strictly monotonic at packet %d (got %d after %d)",
+			i, muxedDts[i], muxedDts[i-1])
+	}
+}
+
+// TestMonotonicDtsClamp_MissingDtsSequence replays the leading packets of a
+// production NF 2160p HEVC WEB-DL (The Haunting S01E06) copied into matroska.
+// The first reordered B-frames carry no DTS at all (AV_NOPTS_VALUE) while their
+// PTS is set. Forwarding the missing DTS to the muxer made libavformat derive
+// one from the PTS, which ran backwards across the reordered frames and was
+// rejected ("non monotonically increasing dts to muxer in stream 0: 85 >= 83").
+// Verifies the clamp synthesizes a strictly monotonic DTS for the whole run.
+func TestMonotonicDtsClamp_MissingDtsSequence(t *testing.T) {
+	const noDts = astiav.NoPtsValue
+
+	type srcPkt struct{ dts, pts int64 }
+	// Source packet timestamps as demuxed (matroska 1/1000 timebase), in file
+	// order. Packets 1 and 2 have no DTS; their PTS (167, 83) is the value the
+	// muxer would otherwise derive a regressing DTS from.
+	sourcePackets := []srcPkt{
+		{dts: 0, pts: 0},
+		{dts: noDts, pts: 167},
+		{dts: noDts, pts: 83},
+		{dts: 42, pts: 42},
+		{dts: 83, pts: 125},
+		{dts: 125, pts: 334},
+		{dts: 167, pts: 250},
+		{dts: 209, pts: 209},
+	}
+
+	lastWritten := int64(astiav.NoPtsValue)
+	muxedDts := make([]int64, 0, len(sourcePackets))
+
+	for _, sourcePacket := range sourcePackets {
+		newDts, newPts, _ := monotonicDtsClamp(lastWritten, sourcePacket.dts, sourcePacket.pts)
+
+		require.NotEqual(t, int64(astiav.NoPtsValue), newDts,
+			"every muxed packet must carry a DTS — the muxer rejects unset timestamps")
+		assert.GreaterOrEqual(t, newPts, newDts, "PTS must never sit behind its own DTS")
+
+		muxedDts = append(muxedDts, newDts)
+		lastWritten = newDts
+	}
 
 	for i := 1; i < len(muxedDts); i++ {
 		assert.Greater(t, muxedDts[i], muxedDts[i-1],
@@ -414,4 +487,114 @@ func TestCopyStreamState_processPacket_RepairsPtsBehindDts(t *testing.T) {
 		"the pts < dts repair must be recorded as a clamp")
 
 	require.NoError(t, outputFmt.WriteTrailer())
+}
+
+// TestCopyStreamState_processPacket_SynthesizesMissingDts verifies that the
+// pure-copy packet path synthesizes a monotonic DTS for packets that arrive
+// with no DTS at all (AV_NOPTS_VALUE) before submitting them to the muxer.
+//
+// The motivating production failure is a copied HEVC video stream (stream 0)
+// of a 2160p NF WEB-DL whose leading reordered B-frames carry no DTS while
+// their PTS is set. Forwarding the unset DTS made libavformat derive one from
+// the PTS, which ran backwards across the reordered frames — the matroska muxer
+// rejected the third packet with "Application provided invalid, non
+// monotonically increasing dts to muxer in stream 0: 85 >= 83" (EINVAL,
+// surfaced as "writing remuxed packet for stream 0: Invalid argument"). The
+// ffmpeg CLI fills a running DTS estimate on its stream-copy path; our
+// in-process transcoder reaches the muxer directly, so the synthesis must
+// happen here.
+func TestCopyStreamState_processPacket_SynthesizesMissingDts(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "out.mkv")
+
+	inputFmt := astiav.AllocFormatContext()
+	require.NotNil(t, inputFmt)
+
+	defer inputFmt.Free()
+
+	require.NoError(t, inputFmt.OpenInput("testdata/video_with_subrip_subtitle.mkv", nil, nil))
+	defer inputFmt.CloseInput()
+
+	require.NoError(t, inputFmt.FindStreamInfo(nil))
+
+	var inAudioStream *astiav.Stream
+
+	for _, stream := range inputFmt.Streams() {
+		if stream.CodecParameters().MediaType() == astiav.MediaTypeAudio {
+			inAudioStream = stream
+			break
+		}
+	}
+
+	require.NotNil(t, inAudioStream, "test fixture must carry an audio stream")
+
+	outputFmt, err := astiav.AllocOutputFormatContext(nil, "matroska", outputPath)
+	require.NoError(t, err)
+
+	defer outputFmt.Free()
+
+	outStream := outputFmt.NewStream(nil)
+	require.NotNil(t, outStream)
+	require.NoError(t, inAudioStream.CodecParameters().Copy(outStream.CodecParameters()))
+	outStream.CodecParameters().SetCodecTag(0)
+	outStream.SetTimeBase(inAudioStream.TimeBase())
+
+	ioCtx, err := astiav.OpenIOContext(outputPath, astiav.NewIOContextFlags(astiav.IOContextFlagWrite), nil, nil)
+	require.NoError(t, err)
+
+	defer func() { _ = ioCtx.Close() }()
+
+	outputFmt.SetPb(ioCtx)
+
+	require.NoError(t, outputFmt.WriteHeader(nil))
+
+	css := &copyStreamState{inStream: inAudioStream}
+	css.setOutputStream(outStream)
+
+	pkt := astiav.AllocPacket()
+	defer pkt.Free()
+
+	readAudioPacket := func() {
+		t.Helper()
+
+		for {
+			err := inputFmt.ReadFrame(pkt)
+			require.NoError(t, err, "input must supply enough audio packets for the test")
+
+			if pkt.StreamIndex() == inAudioStream.Index() {
+				return
+			}
+
+			pkt.Unref()
+		}
+	}
+
+	// First packet: well-formed, establishes the baseline DTS.
+	readAudioPacket()
+	pkt.SetDts(0)
+	pkt.SetPts(0)
+
+	require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+		"first packet (monotonic DTS) must be accepted by the muxer")
+
+	pkt.Unref()
+
+	// Next two packets carry no DTS, with PTS that would derive a regressing DTS
+	// (167 then 83) if forwarded unset. The synthesis must keep them monotonic.
+	for _, pts := range []int64{167, 83} {
+		readAudioPacket()
+		pkt.SetDts(astiav.NoPtsValue)
+		pkt.SetPts(pts)
+
+		require.NoError(t, css.processPacket(pkt, outputFmt, nil, 0),
+			"a packet with no DTS must get a synthesized monotonic DTS so the matroska muxer accepts it")
+
+		pkt.Unref()
+	}
+
+	require.NoError(t, outputFmt.WriteTrailer())
+
+	assert.Equal(t, int64(2), css.clampedCount,
+		"each missing-DTS packet must be recorded as a clamp")
+	assert.Greater(t, css.lastWrittenDts, int64(0),
+		"the synthesized DTS must advance strictly past the baseline packet's DTS")
 }


### PR DESCRIPTION
## Summary

Follow-up to #242. The copy/remux path still failed on a 2160p HEVC NF WEB-DL (`The Haunting S01E06`) with:

```
ffmpeg: writing remuxed packet for stream 0: Invalid argument
```

with these worker logs:

```
WARN  Timestamps are unset in a packet for stream 0. ...
ERROR Application provided invalid, non monotonically increasing dts to muxer in stream 0: 85 >= 83
```

#242 repaired `pts < dts`, but this is a different variant: the leading reordered B-frames of the source carry **no DTS at all** (`AV_NOPTS_VALUE`) while their PTS is set. `ffprobe` on stream 0 confirms it:

```
pts  dts   flags
0    0     K__
167  N/A   ___   <- DTS unset
83   N/A   ___   <- DTS unset
42   42    ___
```

`monotonicDtsClamp` was a no-op whenever the source DTS was unset, so we forwarded `AV_NOPTS_VALUE` to the muxer. libavformat then derives a DTS from the PTS, which on these reordered frames runs backwards (`167` then `83`) and is rejected with `AVERROR(EINVAL)`.

The FFmpeg CLI tolerates these sources because its stream-copy path (`of_streamcopy` in `ffmpeg_mux.c`) fills a running DTS estimate whenever the source DTS is absent; our in-process transcoder reaches the muxer directly.

## Fix

`monotonicDtsClamp` now synthesizes a DTS when the source DTS is unset — it advances just past the previous packet's DTS, falling back to the packet's own PTS for the first packet. matroska stores PTS as the block timecode and does not persist DTS, so the synthesized values are invisible in the output, and well-formed sources (every packet has a DTS) are returned unchanged, keeping output bit-identical. As a bonus this also silences the `Timestamps are unset in a packet` deprecation warning.

## Verification

- New `TestCopyStreamState_processPacket_SynthesizesMissingDts` drives the real matroska muxer and **reproduces the exact production error when the fix is reverted** (`non monotonically increasing dts to muxer in stream 0: 167 >= 83`), and passes with it.
- New `TestMonotonicDtsClamp_MissingDtsSequence` replays the leading packets of the failing file and asserts a strictly monotonic, always-present DTS.
- Extended `TestMonotonicDtsClamp` table coverage for the new synthesis branches (previous-DTS anchor, first-packet PTS anchor, neither-set degenerate case).
- `go build ./...`, `go vet`, `golangci-lint`, and `go test ./pkg/ffmpeg/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
